### PR TITLE
AB#328 : Add /recover API endpoint

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -25,7 +25,7 @@ type ClientCore interface {
 	GetCertQuote(ctx context.Context) (cert string, certQuote []byte, err error)
 	GetManifestSignature(ctx context.Context) (manifestSignature []byte)
 	GetStatus(ctx context.Context) (statusCode int, status string, err error)
-	SetEncryptionKey(ctx context.Context, encryptionKey []byte) error
+	Recover(ctx context.Context, encryptionKey []byte) error
 }
 
 // SetManifest sets the manifest, once and for all
@@ -116,8 +116,8 @@ func (c *Core) GetManifestSignature(ctx context.Context) []byte {
 	return hash[:]
 }
 
-// SetEncryptionKey sets an encryption key (ideally decrypted from the recovery data) and tries to unseal and load a saved state again.
-func (c *Core) SetEncryptionKey(ctx context.Context, encryptionKey []byte) error {
+// Recover sets an encryption key (ideally decrypted from the recovery data) and tries to unseal and load a saved state again.
+func (c *Core) Recover(ctx context.Context, encryptionKey []byte) error {
 	defer c.mux.Unlock()
 	if err := c.requireState(stateRecovery); err != nil {
 		return err

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -137,17 +137,7 @@ func (c *Core) Recover(ctx context.Context, encryptionKey []byte) error {
 	c.cert = cert
 	c.privk = privk
 
-	c.zaplogger.Info("regenerating quote")
-	quote, err := c.qi.Issue(cert.Raw)
-	if err != nil {
-		c.zaplogger.Warn("Failed to get quote. Proceeding in simulation mode.")
-		// If we run in SimulationMode we get an error here
-		// For testing purpose we do not want to just fail here
-		// Instead we store an empty quote that will make it transparent to the client that the integrity of the mesh can not be guaranteed.
-		c.quote = []byte{}
-	} else {
-		c.quote = quote
-	}
+	c.quote, err = c.generateQuote()
 
 	return nil
 }

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -137,6 +137,18 @@ func (c *Core) Recover(ctx context.Context, encryptionKey []byte) error {
 	c.cert = cert
 	c.privk = privk
 
+	c.zaplogger.Info("regenerating quote")
+	quote, err := c.qi.Issue(cert.Raw)
+	if err != nil {
+		c.zaplogger.Warn("Failed to get quote. Proceeding in simulation mode.")
+		// If we run in SimulationMode we get an error here
+		// For testing purpose we do not want to just fail here
+		// Instead we store an empty quote that will make it transparent to the client that the integrity of the mesh can not be guaranteed.
+		c.quote = []byte{}
+	} else {
+		c.quote = quote
+	}
+
 	return nil
 }
 

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -69,6 +69,10 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) ([]byte, err
 
 	c.manifest = manifest
 	c.rawManifest = rawManifest
+
+	// Generate a new encryption key for a new manifest, as the old one might be broken
+	c.sealer.GenerateNewEncryptionKey()
+
 	c.advanceState()
 	encryptionKey, err := c.sealState()
 	if err != nil {

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -137,16 +137,12 @@ func (c *Core) Recover(ctx context.Context, encryptionKey []byte) error {
 	c.cert = cert
 	c.privk = privk
 
-	c.quote, err = c.generateQuote()
+	c.quote = c.generateQuote()
 
 	return nil
 }
 
 // GetStatus returns status information about the state of the mesh.
 func (c *Core) GetStatus(ctx context.Context) (statusCode int, status string, err error) {
-	if err != nil {
-		return -1000, "Cannot determine server status", err
-	}
-
 	return c.getStatus(ctx)
 }

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -24,7 +24,7 @@ type ClientCore interface {
 	SetManifest(ctx context.Context, rawManifest []byte) (recoveryDataBytes []byte, err error)
 	GetCertQuote(ctx context.Context) (cert string, certQuote []byte, err error)
 	GetManifestSignature(ctx context.Context) (manifestSignature []byte)
-	GetStatus(ctx context.Context) (status string, err error)
+	GetStatus(ctx context.Context) (statusCode int, status string, err error)
 	SetEncryptionKey(ctx context.Context, encryptionKey []byte) error
 }
 
@@ -139,11 +139,11 @@ func (c *Core) SetEncryptionKey(ctx context.Context, encryptionKey []byte) error
 }
 
 // GetStatus is not implemented. It will return status information about the state of the mesh in the future.
-func (c *Core) GetStatus(ctx context.Context) (status string, err error) {
-	status, err = c.getStatus(ctx)
+func (c *Core) GetStatus(ctx context.Context) (statusCode int, status string, err error) {
+	statusCode, status, err = c.getStatus(ctx)
 	if err != nil {
-		return "", err
+		return -1000, "Cannot determine server status", err
 	}
 
-	return status, nil
+	return statusCode, status, nil
 }

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -92,3 +92,21 @@ func TestGetCertQuote(t *testing.T) {
 	assert.NoError(err, "GetCertQuote should not fail (with manifest)")
 	//todo check quote
 }
+
+func TestGetStatus(t *testing.T) {
+	assert := assert.New(t)
+	c, _ := mustSetup()
+
+	// Server should be ready to accept a manifest after initializing a mock core
+	statusCode, status, err := c.GetStatus(context.TODO())
+	assert.NoError(err, "GetStatus failed")
+	assert.EqualValues(stateAcceptingManifest, statusCode, "We should be ready to accept a manifest now, but GetStatus does tell us we don't.")
+	assert.NotEmpty(status, "Status string was empty, but should not.")
+
+	// Set a manifest, state should change
+	_, err = c.SetManifest(context.TODO(), []byte(test.ManifestJSON))
+	statusCode, status, err = c.GetStatus(context.TODO())
+	assert.NoError(err, "GetStatus failed")
+	assert.EqualValues(stateAcceptingMarbles, statusCode, "We should be ready to accept Marbles now, but GetStatus does tell us we don't.")
+	assert.NotEmpty(status, "Status string was empty, but should not.")
+}

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -160,17 +160,13 @@ func (c *Core) inSimulationMode() bool {
 
 // GetTLSConfig gets the core's TLS configuration
 func (c *Core) GetTLSConfig() (*tls.Config, error) {
-	cert, err := c.GetTLSCertificate()
-	if err != nil {
-		return nil, err
-	}
 	return &tls.Config{
-		Certificates: []tls.Certificate{*cert},
+		GetCertificate: c.GetTLSCertificate,
 	}, nil
 }
 
 // GetTLSCertificate creates a TLS certificate for the Coordinators self-signed x509 certificate
-func (c *Core) GetTLSCertificate() (*tls.Certificate, error) {
+func (c *Core) GetTLSCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	if c.state == stateUninitialized {
 		return nil, errors.New("don't have a cert yet")
 	}

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -121,7 +121,7 @@ func NewCore(dnsNames []string, qv quote.Validator, qi quote.Issuer, sealer Seal
 
 	c.cert = cert
 	c.privk = privk
-	c.quote, err = c.generateQuote()
+	c.quote = c.generateQuote()
 
 	return c, nil
 }
@@ -269,7 +269,7 @@ func (c *Core) generateCert(dnsNames []string) (*x509.Certificate, *ecdsa.Privat
 	return cert, privk, nil
 }
 
-func (c *Core) generateQuote() ([]byte, error) {
+func (c *Core) generateQuote() []byte {
 	c.zaplogger.Info("generating quote")
 	quote, err := c.qi.Issue(c.cert.Raw)
 	if err != nil {
@@ -277,9 +277,9 @@ func (c *Core) generateQuote() ([]byte, error) {
 		// If we run in SimulationMode we get an error here
 		// For testing purpose we do not want to just fail here
 		// Instead we store an empty quote that will make it transparent to the client that the integrity of the mesh can not be guaranteed.
-		return []byte{}, err
+		return []byte{}
 	}
-	return quote, nil
+	return quote
 }
 
 func getClientTLSCert(ctx context.Context) *x509.Certificate {

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -297,7 +297,6 @@ func getClientTLSCert(ctx context.Context) *x509.Certificate {
 }
 
 func (c *Core) getStatus(ctx context.Context) (int, string, error) {
-	statusCode := int(c.state)
 	var status string
 
 	switch c.state {
@@ -308,8 +307,8 @@ func (c *Core) getStatus(ctx context.Context) (int, string, error) {
 	case stateAcceptingMarbles:
 		status = "Coordinator is running correctly and ready to accept marbles."
 	default:
-		return -1000, "Cannot determine coordinator status.", errors.New("cannot determine coordinator status")
+		return -1, "Cannot determine coordinator status.", errors.New("cannot determine coordinator status")
 	}
 
-	return statusCode, status, nil
+	return int(c.state), status, nil
 }

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -288,6 +288,22 @@ func getClientTLSCert(ctx context.Context) *x509.Certificate {
 	return tlsInfo.State.PeerCertificates[0]
 }
 
-func (c *Core) getStatus(ctx context.Context) (string, error) {
-	return "this is a test status", nil
+func (c *Core) getStatus(ctx context.Context) (int, string, error) {
+	statusCode := int(c.state)
+	var status string
+
+	switch c.state {
+	case -1:
+		status = "Coordinator is in recovery mode. Either upload a key to unseal the saved state, or set a new manifest. For more information on how to proceed, consult the documentation."
+	case 0:
+		status = "Coordinator is uninitialized."
+	case 1:
+		status = "Coordinator is ready to accept a manifest."
+	case 2:
+		status = "Coordinator is running correctly and ready to accept marbles."
+	default:
+		return -1000, "Cannot determine coordinator status.", errors.New("cannot determine coordinator status")
+	}
+
+	return statusCode, status, nil
 }

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -84,3 +84,42 @@ func TestSeal(t *testing.T) {
 	signature2 := c2.GetManifestSignature(context.TODO())
 	assert.Equal(signature, signature2, "manifest signature differs after restart")
 }
+
+func TestRecover(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// setup mock zaplogger which can be passed to Core
+	zapLogger, err := zap.NewDevelopment()
+	require.NoError(err)
+	defer zapLogger.Sync()
+
+	validator := quote.NewMockValidator()
+	issuer := quote.NewMockIssuer()
+	sealer := &MockSealer{}
+
+	c, err := NewCore([]string{"localhost"}, validator, issuer, sealer, zapLogger)
+	require.NoError(err)
+
+	// new core does not allow recover
+	key := make([]byte, 16)
+	assert.Error(c.Recover(context.TODO(), key))
+
+	// Set manifest. This will seal the state.
+	_, err = c.SetManifest(context.TODO(), []byte(test.ManifestJSON))
+	require.NoError(err)
+
+	// core does not allow recover after manifest has been set
+	assert.Error(c.Recover(context.TODO(), key))
+
+	// Initialize new core and let unseal fail
+	sealer.unsealError = ErrEncryptionKey
+	c2, err := NewCore([]string{"localhost"}, validator, issuer, sealer, zapLogger)
+	sealer.unsealError = nil
+	require.NoError(err)
+	require.Equal(stateRecovery, c2.state)
+
+	// recover
+	assert.NoError(c2.Recover(context.TODO(), key))
+	assert.Equal(stateAcceptingMarbles, c2.state)
+}

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -24,7 +24,7 @@ func TestCore(t *testing.T) {
 	assert.Equal(stateAcceptingManifest, c.state)
 	assert.Equal(CoordinatorName, c.cert.Subject.CommonName)
 
-	cert, err := c.GetTLSCertificate()
+	cert, err := c.GetTLSCertificate(nil)
 	assert.NoError(err)
 	assert.NotNil(cert)
 
@@ -65,7 +65,7 @@ func TestSeal(t *testing.T) {
 	require.NoError(err)
 
 	// Get certificate and signature.
-	cert, err := c.GetTLSCertificate()
+	cert, err := c.GetTLSCertificate(nil)
 	assert.NoError(err)
 	signature := c.GetManifestSignature(context.TODO())
 
@@ -74,7 +74,7 @@ func TestSeal(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(stateAcceptingMarbles, c2.state)
 
-	cert2, err := c2.GetTLSCertificate()
+	cert2, err := c2.GetTLSCertificate(nil)
 	assert.NoError(err)
 	assert.Equal(cert, cert2)
 

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -204,12 +204,13 @@ func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 
 // MockSealer is a mockup sealer
 type MockSealer struct {
-	data []byte
+	data        []byte
+	unsealError error
 }
 
 // Unseal implements the Sealer interface
 func (s *MockSealer) Unseal() ([]byte, error) {
-	return s.data, nil
+	return s.data, s.unsealError
 }
 
 // Seal implements the Sealer interface

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -10,6 +10,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -21,6 +22,9 @@ const SealedDataFname string = "sealed_data"
 
 // SealedKeyFname contains the file name in which the key is sealed with the seal key on disk in seal_dir
 const SealedKeyFname string = "sealed_key"
+
+// ErrEncryptionKey occurs if unsealing the encryption key failed.
+var ErrEncryptionKey = errors.New("cannot unseal encryption key")
 
 // Sealer is an interface for the Core object to seal information to the filesystem for persistence
 type Sealer interface {
@@ -55,7 +59,7 @@ func (s *AESGCMSealer) Unseal() ([]byte, error) {
 
 	// Decrypt generated encryption key with seal key, if needed
 	if err = s.unsealEncryptionKey(); err != nil {
-		return nil, err
+		return nil, ErrEncryptionKey
 	}
 
 	// Decrypt data with the unsealed encryption key and return it

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -16,8 +16,11 @@ import (
 	"time"
 )
 
-const sealedDataFname string = "sealed_data"
-const sealedKeyFname string = "sealed_key"
+// SealedDataFname contains the file name in which the state is sealed on disk in seal_dir
+const SealedDataFname string = "sealed_data"
+
+// SealedKeyFname contains the file name in which the key is sealed with the seal key on disk in seal_dir
+const SealedKeyFname string = "sealed_key"
 
 // Sealer is an interface for the Core object to seal information to the filesystem for persistence
 type Sealer interface {
@@ -42,7 +45,7 @@ func NewAESGCMSealer(sealDir string, sealKey []byte) *AESGCMSealer {
 // Unseal reads and decrypts stored information from the fs
 func (s *AESGCMSealer) Unseal() ([]byte, error) {
 	// load from fs
-	sealedData, err := ioutil.ReadFile(s.getFname(sealedDataFname))
+	sealedData, err := ioutil.ReadFile(s.getFname(SealedDataFname))
 
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -78,7 +81,7 @@ func (s *AESGCMSealer) Seal(data []byte) ([]byte, error) {
 	}
 
 	// store to fs
-	if err := ioutil.WriteFile(s.getFname(sealedDataFname), encryptedData, 0600); err != nil {
+	if err := ioutil.WriteFile(s.getFname(SealedDataFname), encryptedData, 0600); err != nil {
 		return nil, err
 	}
 
@@ -95,7 +98,7 @@ func (s *AESGCMSealer) unsealEncryptionKey() error {
 	}
 
 	// Read from fs
-	sealedKeyData, err := ioutil.ReadFile(s.getFname(sealedKeyFname))
+	sealedKeyData, err := ioutil.ReadFile(s.getFname(SealedKeyFname))
 	if err != nil {
 		return err
 	}
@@ -127,9 +130,9 @@ func (s *AESGCMSealer) GenerateNewEncryptionKey() error {
 // SetEncryptionKey sets or restores an encryption key
 func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
 	// If there already is an existing key file stored on disk, save it
-	if sealedKeyData, err := ioutil.ReadFile(s.getFname(sealedKeyFname)); err == nil {
+	if sealedKeyData, err := ioutil.ReadFile(s.getFname(SealedKeyFname)); err == nil {
 		t := time.Now()
-		newFileName := s.getFname(sealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
+		newFileName := s.getFname(SealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
 		ioutil.WriteFile(newFileName, sealedKeyData, 0600)
 	}
 
@@ -140,7 +143,7 @@ func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
 	}
 
 	// Write the sealed encryption key to disk
-	if err = ioutil.WriteFile(s.getFname(sealedKeyFname), encryptedKeyData, 0600); err != nil {
+	if err = ioutil.WriteFile(s.getFname(SealedKeyFname), encryptedKeyData, 0600); err != nil {
 		return err
 	}
 

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const sealedDataFname string = "sealed_data"
@@ -122,7 +123,15 @@ func (s *AESGCMSealer) generateEncryptionKey() error {
 	return s.SetEncryptionKey(encryptionKey)
 }
 
+// SetEncryptionKey sets or restores an encryption key
 func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
+	// If there already is an existing key file stored on disk, save it
+	if sealedKeyData, err := ioutil.ReadFile(s.getFname(sealedKeyFname)); err == nil {
+		t := time.Now()
+		newFileName := s.getFname(sealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
+		ioutil.WriteFile(newFileName, sealedKeyData, 0600)
+	}
+
 	// Encrypt encryption key with seal key
 	encryptedKeyData, err := encrypt(encryptionKey, s.sealKey)
 	if err != nil {

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -22,6 +22,7 @@ const sealedKeyFname string = "sealed_key"
 type Sealer interface {
 	Seal(data []byte) ([]byte, error)
 	Unseal() ([]byte, error)
+	SetEncryptionKey(key []byte) error
 }
 
 // AESGCMSealer implements the Sealer interface using AES-GCM for confidentiallity and authentication
@@ -118,7 +119,11 @@ func (s *AESGCMSealer) generateEncryptionKey() error {
 		return err
 	}
 
-	// Encrypt randomly generated encryption key with seal key
+	return s.SetEncryptionKey(encryptionKey)
+}
+
+func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
+	// Encrypt encryption key with seal key
 	encryptedKeyData, err := encrypt(encryptionKey, s.sealKey)
 	if err != nil {
 		return err
@@ -194,4 +199,9 @@ func (s *MockSealer) Unseal() ([]byte, error) {
 func (s *MockSealer) Seal(data []byte) ([]byte, error) {
 	s.data = data
 	return []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, nil
+}
+
+// SetEncryptionKey implements the Sealer interface
+func (s *MockSealer) SetEncryptionKey(key []byte) error {
+	return nil
 }

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -23,6 +23,7 @@ const sealedKeyFname string = "sealed_key"
 type Sealer interface {
 	Seal(data []byte) ([]byte, error)
 	Unseal() ([]byte, error)
+	GenerateNewEncryptionKey() error
 	SetEncryptionKey(key []byte) error
 }
 
@@ -65,7 +66,7 @@ func (s *AESGCMSealer) Seal(data []byte) ([]byte, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		if err := s.generateEncryptionKey(); err != nil {
+		if err := s.GenerateNewEncryptionKey(); err != nil {
 			return nil, err
 		}
 	}
@@ -111,8 +112,8 @@ func (s *AESGCMSealer) unsealEncryptionKey() error {
 	return nil
 }
 
-// Generate random 128 Bit (16 Byte) key to encrypt the state
-func (s *AESGCMSealer) generateEncryptionKey() error {
+// GenerateNewEncryptionKey generates a random 128 Bit (16 Byte) key to encrypt the state
+func (s *AESGCMSealer) GenerateNewEncryptionKey() error {
 	encryptionKey := make([]byte, 16)
 
 	_, err := rand.Read(encryptionKey)
@@ -212,5 +213,10 @@ func (s *MockSealer) Seal(data []byte) ([]byte, error) {
 
 // SetEncryptionKey implements the Sealer interface
 func (s *MockSealer) SetEncryptionKey(key []byte) error {
+	return nil
+}
+
+// GenerateNewEncryptionKey implements the Sealer interface
+func (s *MockSealer) GenerateNewEncryptionKey() error {
 	return nil
 }

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -146,6 +146,23 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 		}
 	})
 
+	mux.HandleFunc("/recover", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			key, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if err = cc.SetEncryptionKey(r.Context(), key); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		default:
+			http.Error(w, "", http.StatusMethodNotAllowed)
+		}
+	})
+
 	return mux
 }
 

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -41,7 +41,7 @@ type manifestSignatureResp struct {
 }
 
 // Contains RSA-encrypted AES state sealing key with public key specified by user in manifest
-type recoveryData struct {
+type RecoveryDataResp struct {
 	EncryptionKey string
 }
 
@@ -126,7 +126,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 			// If a recovery key has been set, include recovery data as response. If not, leave response empty.
 			if recoveryDataBytes != nil {
 				encodedRecoveryData := base64.StdEncoding.EncodeToString(recoveryDataBytes)
-				writeJSON(w, recoveryData{encodedRecoveryData})
+				writeJSON(w, RecoveryDataResp{encodedRecoveryData})
 			}
 		default:
 			http.Error(w, "", http.StatusMethodNotAllowed)

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -33,6 +33,7 @@ type certQuoteResp struct {
 	Quote []byte
 }
 type statusResp struct {
+	Code   int
 	Status string
 }
 type manifestSignatureResp struct {
@@ -95,12 +96,12 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			status, err := cc.GetStatus(r.Context())
+			statusCode, status, err := cc.GetStatus(r.Context())
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			writeJSON(w, statusResp{status})
+			writeJSON(w, statusResp{statusCode, status})
 		default:
 			http.Error(w, "", http.StatusMethodNotAllowed)
 		}

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -155,7 +155,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			if err = cc.SetEncryptionKey(r.Context(), key); err != nil {
+			if err = cc.Recover(r.Context(), key); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -49,13 +49,8 @@ type recoveryDataResp struct {
 // `address` is the desired TCP address like "localhost:0".
 // The effective TCP address is returned via `addrChan`.
 func RunMarbleServer(core *core.Core, addr string, addrChan chan string, errChan chan error, zapLogger *zap.Logger) {
-	cert, err := core.GetTLSCertificate()
-	if err != nil {
-		errChan <- err
-		return
-	}
 	tlsConfig := tls.Config{
-		Certificates: []tls.Certificate{*cert},
+		GetCertificate: core.GetTLSCertificate,
 		// NOTE: we'll verify the cert later using the given quote
 		ClientAuth: tls.RequireAnyClientCert,
 	}

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -41,7 +41,7 @@ type manifestSignatureResp struct {
 }
 
 // Contains RSA-encrypted AES state sealing key with public key specified by user in manifest
-type RecoveryDataResp struct {
+type recoveryDataResp struct {
 	EncryptionKey string
 }
 
@@ -126,7 +126,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 			// If a recovery key has been set, include recovery data as response. If not, leave response empty.
 			if recoveryDataBytes != nil {
 				encodedRecoveryData := base64.StdEncoding.EncodeToString(recoveryDataBytes)
-				writeJSON(w, RecoveryDataResp{encodedRecoveryData})
+				writeJSON(w, recoveryDataResp{encodedRecoveryData})
 			}
 		default:
 			http.Error(w, "", http.StatusMethodNotAllowed)

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -79,7 +79,7 @@ func TestManifestWithRecoveryKey(t *testing.T) {
 	require.Equal(http.StatusOK, resp.Code)
 
 	// Decode JSON response from server
-	var b64EncryptedRecoveryData RecoveryDataResp
+	var b64EncryptedRecoveryData recoveryDataResp
 	require.NoError(json.Unmarshal(resp.Body.Bytes(), &b64EncryptedRecoveryData))
 	encryptedRecoveryData, err := base64.StdEncoding.DecodeString(b64EncryptedRecoveryData.EncryptionKey)
 	require.NoError(err)

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -79,7 +79,7 @@ func TestManifestWithRecoveryKey(t *testing.T) {
 	require.Equal(http.StatusOK, resp.Code)
 
 	// Decode JSON response from server
-	var b64EncryptedRecoveryData recoveryData
+	var b64EncryptedRecoveryData RecoveryDataResp
 	require.NoError(json.Unmarshal(resp.Body.Bytes(), &b64EncryptedRecoveryData))
 	encryptedRecoveryData, err := base64.StdEncoding.DecodeString(b64EncryptedRecoveryData.EncryptionKey)
 	require.NoError(err)

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -290,11 +290,11 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	require.NotNil(coordinatorProc)
 	defer coordinatorProc.Kill()
 
-	// Query status API, check if status response begins with Code -1 (recovery state)
+	// Query status API, check if status response begins with Code 1 (recovery state)
 	log.Println("Checking status...")
 	statusResponse, err := getStatus()
 	require.NoError(err)
-	assert.Contains(statusResponse, "{\"Code\":-1,")
+	assert.Contains(statusResponse, "{\"Code\":1,")
 
 	// Decode & Decrypt recovery data from when we set the manifest
 	var recoveryDataUnmarshalled server.RecoveryDataResp
@@ -309,7 +309,7 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	log.Println("Performed recovery, now checking status again...")
 	statusResponse, err = getStatus()
 	require.NoError(err)
-	assert.Contains(statusResponse, "{\"Code\":2,", "Server is in wrong status after recovery.")
+	assert.Contains(statusResponse, "{\"Code\":3,", "Server is in wrong status after recovery.")
 
 	// Simulate restart of coordinator
 	log.Println("Simulating a restart of the coordinator enclave...")
@@ -326,7 +326,7 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	log.Println("Restarted instance, now let's see if the state can be restored again successfully.")
 	statusResponse, err = getStatus()
 	require.NoError(err)
-	assert.Contains(statusResponse, "{\"Code\":2,", "Server is in wrong status after recovery.")
+	assert.Contains(statusResponse, "{\"Code\":3,", "Server is in wrong status after recovery.")
 }
 
 func TestRecoveryReset(t *testing.T) {
@@ -374,11 +374,11 @@ func TestRecoveryReset(t *testing.T) {
 	require.NotNil(coordinatorProc)
 	defer coordinatorProc.Kill()
 
-	// Query status API, check if status response begins with Code -1 (recovery state)
+	// Query status API, check if status response begins with Code 1 (recovery state)
 	log.Println("Checking status...")
 	statusResponse, err := getStatus()
 	require.NoError(err)
-	assert.Contains(statusResponse, "{\"Code\":-1,")
+	assert.Contains(statusResponse, "{\"Code\":1,")
 
 	// Set manifest again
 	log.Println("Setting the Manifest")
@@ -389,7 +389,7 @@ func TestRecoveryReset(t *testing.T) {
 	log.Println("Check if the manifest was accepted and we are ready to accept Marbles")
 	statusResponse, err = getStatus()
 	require.NoError(err)
-	assert.Contains(statusResponse, "{\"Code\":2,", "Server is in wrong status after recovery.")
+	assert.Contains(statusResponse, "{\"Code\":3,", "Server is in wrong status after recovery.")
 
 	// simulate restart of coordinator
 	log.Println("Simulating a restart of the coordinator enclave...")
@@ -406,7 +406,7 @@ func TestRecoveryReset(t *testing.T) {
 	log.Println("Restarted instance, now let's see if the new state can be decrypted successfully...")
 	statusResponse, err = getStatus()
 	require.NoError(err)
-	assert.Contains(statusResponse, "{\"Code\":2,", "Server is in wrong status after recovery.")
+	assert.Contains(statusResponse, "{\"Code\":3,", "Server is in wrong status after recovery.")
 }
 
 type coordinatorConfig struct {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -330,6 +330,7 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	clientAPIURL.Path = "status"
 	resp, err = client.Get(clientAPIURL.String())
 	require.NoError(err)
+	resp.Body.Close()
 	require.Equal(http.StatusOK, resp.StatusCode)
 
 	// Simulate restart of coordinator
@@ -351,12 +352,9 @@ func TestRecoveryRestoreKey(t *testing.T) {
 
 	// test with certificate
 	log.Println("Verifying certificate after restart.")
-	pool = x509.NewCertPool()
-	require.True(pool.AppendCertsFromPEM([]byte(cert)))
-	client = http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
-	clientAPIURL.Path = "status"
 	resp, err = client.Get(clientAPIURL.String())
 	require.NoError(err)
+	resp.Body.Close()
 	require.Equal(http.StatusOK, resp.StatusCode)
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -277,7 +277,7 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	require.NoError(coordinatorProc.Kill())
 
 	// Garble encryption key to trigger recovery state
-	log.Println("Garbeling sealed key...")
+	log.Println("Purposely corrupt sealed key to trigger recovery state...")
 	pathToKeyFile := filepath.Join(cfg.sealDir, core.SealedKeyFname)
 	sealedKeyData, err := ioutil.ReadFile(pathToKeyFile)
 	require.NoError(err)
@@ -361,7 +361,7 @@ func TestRecoveryReset(t *testing.T) {
 	require.NoError(coordinatorProc.Kill())
 
 	// Garble encryption key to trigger recovery state
-	log.Println("Garbeling sealed key...")
+	log.Println("Purposely corrupt sealed key to trigger recovery state...")
 	pathToKeyFile := filepath.Join(cfg.sealDir, core.SealedKeyFname)
 	sealedKeyData, err := ioutil.ReadFile(pathToKeyFile)
 	require.NoError(err)

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -135,7 +135,7 @@ var ManifestJSONWithRecoveryKey string = `{
 }`
 
 // IntegrationManifestJSON is a test manifest
-const IntegrationManifestJSON string = `{
+var IntegrationManifestJSON string = `{
 	"Packages": {
 		"backend": {
 			"Debug": true,
@@ -211,7 +211,8 @@ const IntegrationManifestJSON string = `{
 	},
 	"Clients": {
 		"owner": [9,9,9]
-	}
+	},
+	"RecoveryKey": "` + strings.ReplaceAll(string(RecoveryPublicKey), "\n", "\\n") + `"
 }`
 
 func generateTestRecoveryKey() (publicKeyPem []byte, privateKey *rsa.PrivateKey) {


### PR DESCRIPTION
Short overview:
- Add /recover API endpoint to set a new encryption key, in case the sealed state cannot be decrypted successfully with the key stored on disk
- When in "recovery" mode, the user can either upload a new valid encryption key (raw), or upload a new manifest 
- For how to use the recovery features, see [docs/recovery.md](https://github.com/edgelesssys/marblerun/blob/recovery_new/docs/recovery.md)
- When, instead of recovering the old key, a new manifest is set, we generate a new key automatically as the old one is likely botched and unusable.

Open questions:
- Is the way loadState(dnsName) is initiated by the recovery API endpoint okay? loadState takes dnsName as a parameter in case the it has to generate a new certificate. Right now, when calling from the /recover endpoint, it will use `nil` as parameter and inside loadState, we check for nil to see if we're stuck in recovery.
- Does it make sense to save the old recovery key? I thought directly overwriting the old key permanently seems a bit aggressive, but does it really make any sense to store the old key?