### PR TITLE
AB#361 Change manifest placeholders to Go templates

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -71,10 +71,10 @@ Here is an example that has only the `SecurityVersion` and `ProductID` set:
 					"serve"
 				],
 				"Env": {
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
 		},
@@ -85,10 +85,10 @@ Here is an example that has only the `SecurityVersion` and `ProductID` set:
 					"./marble"
 				],
 				"Env": {
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
 	    }

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -7,6 +7,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
@@ -56,6 +57,14 @@ type Secret struct {
 	Name    string
 	Private PrivateKey
 	Public  PublicKey
+}
+
+// Key defines a shortcut to clarify a reference to symmetric keys in templates.
+func (s Secret) Key() []byte {
+	if bytes.Equal(s.Public, s.Private) {
+		return s.Private
+	}
+	return nil
 }
 
 func encodeSecretDataToPem(data interface{}) string {

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -77,16 +77,16 @@ func encodeSecretDataToHex(data interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(raw), nil
+	return hex.EncodeToString([]byte(raw)), nil
 }
-func encodeSecretDataToRaw(data interface{}) ([]byte, error) {
+func encodeSecretDataToRaw(data interface{}) (string, error) {
 	if bytes, ok := data.([]byte); ok {
-		return bytes, nil
+		return string(bytes), nil
 	}
 	if secret, ok := data.(Secret); ok {
-		return secret.Public, nil
+		return string(secret.Public), nil
 	}
-	return nil, errors.New("invalid secret type")
+	return "", errors.New("invalid secret type")
 }
 
 func encodeSecretDataToBase64(data interface{}) (string, error) {
@@ -94,7 +94,7 @@ func encodeSecretDataToBase64(data interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return base64.StdEncoding.EncodeToString(raw), nil
+	return base64.StdEncoding.EncodeToString([]byte(raw)), nil
 }
 
 var manifestTemplateFuncMap = template.FuncMap{

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -18,14 +18,6 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 )
 
-// Manifest placeholder variables
-const (
-	rootCAPlaceholder     = "$$root_ca"
-	marbleCertPlaceholder = "$$marble_cert"
-	marbleKeyPlaceholder  = "$$marble_key"
-	sealKeyPlaceholder    = "$$seal_key"
-)
-
 // Manifest defines the rules of a mesh.
 type Manifest struct {
 	// Packages contains the allowed enclaves and their properties.

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -55,10 +55,10 @@ const ManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 				},
 				"Argv": [
 					"--first",
@@ -70,10 +70,10 @@ const ManifestJSON string = `{
 			"Package": "backend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 				},
 				"Argv": [
 					"serve"
@@ -84,10 +84,10 @@ const ManifestJSON string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 				}
 			}
 		}
@@ -120,10 +120,10 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.public }}",
+					"SEAL_KEY": "{{ hex .SealKey.private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 				}
 			}
 		}
@@ -170,10 +170,10 @@ var IntegrationManifestJSON string = `{
 				],
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 			}
 			}
 		},
@@ -186,10 +186,10 @@ var IntegrationManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 			}
 			}
 		},
@@ -201,10 +201,10 @@ var IntegrationManifestJSON string = `{
 					"/tmp/coordinator_test/jkl.mno": "bar"
 				},
 				"Env": {
-					"ROOT_CA": "$$root_ca",
-					"SEAL_KEY": "$$seal_key",
-					"MARBLE_CERT": "$$marble_cert",
-					"MARBLE_KEY": "$$marble_key"
+					"ROOT_CA": "{{ pem .RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
 			}
 		}
 		}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -56,7 +56,7 @@ const ManifestJSON string = `{
 				"Env": {
 					"IS_FIRST": "true",
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
@@ -71,7 +71,7 @@ const ManifestJSON string = `{
 			"Parameters": {
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
@@ -85,7 +85,7 @@ const ManifestJSON string = `{
 			"Parameters": {
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
@@ -121,7 +121,7 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Parameters": {
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
@@ -171,7 +171,7 @@ var IntegrationManifestJSON string = `{
 				"Env": {
 					"IS_FIRST": "true",
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
@@ -187,7 +187,7 @@ var IntegrationManifestJSON string = `{
 				"Env": {
 					"IS_FIRST": "true",
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
@@ -202,7 +202,7 @@ var IntegrationManifestJSON string = `{
 				},
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -55,10 +55,10 @@ const ManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .SealKey.Private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
 				"Argv": [
 					"--first",
@@ -70,10 +70,10 @@ const ManifestJSON string = `{
 			"Package": "backend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .SealKey.Private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
 				"Argv": [
 					"serve"
@@ -84,10 +84,10 @@ const ManifestJSON string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .SealKey.Private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
 		}
@@ -120,10 +120,10 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .RootCA.public }}",
-					"SEAL_KEY": "{{ hex .SealKey.private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
 		}
@@ -170,10 +170,10 @@ var IntegrationManifestJSON string = `{
 				],
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .SealKey.Private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
 			}
 		},
@@ -186,10 +186,10 @@ var IntegrationManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .SealKey.Private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
 			}
 		},
@@ -201,10 +201,10 @@ var IntegrationManifestJSON string = `{
 					"/tmp/coordinator_test/jkl.mno": "bar"
 				},
 				"Env": {
-					"ROOT_CA": "{{ pem .RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .SealKey.Private }}",
-					"MARBLE_CERT": "{{ pem .MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .MarbleCert.Private }}"
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
 		}
 		}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -56,7 +56,7 @@ const ManifestJSON string = `{
 				"Env": {
 					"IS_FIRST": "true",
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
@@ -71,7 +71,7 @@ const ManifestJSON string = `{
 			"Parameters": {
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
@@ -85,7 +85,7 @@ const ManifestJSON string = `{
 			"Parameters": {
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
@@ -120,8 +120,8 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.private }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
@@ -171,7 +171,7 @@ var IntegrationManifestJSON string = `{
 				"Env": {
 					"IS_FIRST": "true",
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
@@ -187,7 +187,7 @@ var IntegrationManifestJSON string = `{
 				"Env": {
 					"IS_FIRST": "true",
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
@@ -202,7 +202,7 @@ var IntegrationManifestJSON string = `{
 				},
 				"Env": {
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Private }}",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey.Key }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}


### PR DESCRIPTION
First attempt of using Go templates for secrets.

This is not the final design for storing & accessing secrets yet. So far, it's only a replacement for the $$ placeholder strings in the manifest so far.

Tests should be covered with the existing TestActivate test in marbleapi_test.go.