### PR TITLE
AB#351 & AB#362 : Secret store in core & ability to generate symmetric secrets

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"log"
 
 	"go.uber.org/zap"
 )
@@ -82,9 +81,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) ([]byte, err
 
 	c.manifest = manifest
 	c.rawManifest = rawManifest
-	log.Println("Saving secrets in core")
 	c.secrets = secrets
-	log.Println(c.secrets)
 
 	c.advanceState(stateAcceptingMarbles)
 	encryptionKey, err := c.sealState()

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -325,7 +325,7 @@ func (c *Core) generateSecrets(ctx context.Context, secrets map[string]Secret) (
 		// Raw = Symmetric Key
 		switch secret.Type {
 		case "raw":
-			c.zaplogger.Info("generating secret", zap.String("name", name), zap.String("type", secret.Type))
+			c.zaplogger.Info("generating secret", zap.String("name", name), zap.String("type", secret.Type), zap.Int("size", secret.Size))
 			// Generate a random key of specified size
 			generatedValue := make([]byte, secret.Size)
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -328,7 +328,7 @@ func (c *Core) generateSecrets(ctx context.Context, secrets map[string]Secret) (
 		// Raw = Symmetric Key
 		switch secret.Type {
 		case "raw":
-			c.zaplogger.Info("Generating secret", zap.String("name", name), zap.String("type", secret.Type))
+			c.zaplogger.Info("generating secret", zap.String("name", name), zap.String("type", secret.Type))
 			// Generate a random key of specified size
 			generatedValue := make([]byte, secret.Size)
 
@@ -353,7 +353,7 @@ func (c *Core) generateSecrets(ctx context.Context, secrets map[string]Secret) (
 
 		// Everything else so far is not supported
 		default:
-			c.zaplogger.Error("This type of secret is not supported.", zap.String("name", name), zap.String("type", secret.Type))
+			return nil, fmt.Errorf("unsupported secret of type %s", secret.Type)
 		}
 	}
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"net"
 	"sync"
@@ -200,8 +199,6 @@ func (c *Core) loadState() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	c.state = loadedState.State
 	c.activations = loadedState.Activations
 	c.secrets = loadedState.Secrets
-	log.Println("Restoring secrets")
-	log.Println(c.secrets)
 	return cert, privk, err
 }
 

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -123,3 +123,38 @@ func TestRecover(t *testing.T) {
 	assert.NoError(c2.Recover(context.TODO(), key))
 	assert.Equal(stateAcceptingMarbles, c2.state)
 }
+
+func TestGenerateSecrets(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Some secret maps which should represent secret entries from an unmarshaled JSON manifest
+	secretsToGenerate := map[string]Secret{
+		"rawTest1": {Type: "raw", Size: 16},
+		"rawTest2": {Type: "raw", Size: 32},
+	}
+
+	secretsNoSize := map[string]Secret{
+		"noSize": {Type: "raw"},
+	}
+
+	secretsInvalidType := map[string]Secret{
+		"unknownType": {Type: "crap"},
+	}
+
+	c := NewCoreWithMocks()
+
+	// This should return valid secrets
+	generatedSecrets, err := c.generateSecrets(context.TODO(), secretsToGenerate)
+	require.NoError(err)
+	assert.NotEmpty(generatedSecrets["rawTest1"].Public)
+	assert.NotEmpty(generatedSecrets["rawTest2"].Public)
+
+	// If no size is specified, the function should fail
+	_, err = c.generateSecrets(context.TODO(), secretsNoSize)
+	assert.Error(err)
+
+	// Also, it should fail if we try to generate a secret with an unknown type
+	_, err = c.generateSecrets(context.TODO(), secretsInvalidType)
+	assert.Error(err)
+}

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -28,6 +28,8 @@ type Manifest struct {
 	Marbles map[string]Marble
 	// Clients contains TLS certificates for authenticating clients that use the ClientAPI.
 	Clients map[string][]byte
+	// Secrets holds user-specified secrets, which should be generated and later on stored in the core.
+	Secrets map[string]Secret
 	// Recovery holds a RSA public key to encrypt the state encryption key, which gets returned over the Client API when setting a manifest.
 	RecoveryKey string
 }
@@ -53,6 +55,8 @@ type PublicKey []byte
 
 // Secret defines a structure for storing certificates & encryption keys
 type Secret struct {
+	Type    string
+	Size    int
 	Private PrivateKey
 	Public  PublicKey
 }

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -56,7 +56,7 @@ type PublicKey []byte
 // Secret defines a structure for storing certificates & encryption keys
 type Secret struct {
 	Type    string
-	Size    int
+	Size    uint
 	Private PrivateKey
 	Public  PublicKey
 }

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -13,6 +13,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"log"
 	"math"
 	"text/template"
 	"time"
@@ -32,8 +33,9 @@ type reservedSecrets struct {
 }
 
 // Defines the "Marblerun" prefix when mentioned in a manifest
-type reservedSecretsWrapper struct {
+type secretsWrapper struct {
 	Marblerun reservedSecrets
+	Secrets   map[string]Secret
 }
 
 // Activate implements the MarbleAPI function to authenticate a marble (implements the MarbleServer interface)
@@ -98,7 +100,7 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (*rpc.Activ
 	}
 
 	marble := c.manifest.Marbles[req.GetMarbleType()] // existence has been checked in verifyManifestRequirement
-	params, err := customizeParameters(marble.Parameters, authSecrets)
+	params, err := customizeParameters(marble.Parameters, authSecrets, c.secrets)
 	if err != nil {
 		c.zaplogger.Error("Could not customize parameters.", zap.Error(err))
 		return nil, err
@@ -193,7 +195,7 @@ func (c *Core) generateCertFromCSR(csrReq []byte, pubk ecdsa.PublicKey, marbleTy
 }
 
 // customizeParameters replaces the placeholders in the manifest's parameters with the actual values
-func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets) (*rpc.Parameters, error) {
+func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets, userSecrets map[string]Secret) (*rpc.Parameters, error) {
 	customParams := rpc.Parameters{
 		Argv:  params.Argv,
 		Files: make(map[string]string),
@@ -201,13 +203,14 @@ func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets)
 	}
 
 	// Wrap the authentication secrets to have the "Marblerun" prefix in front of them when mentioned in a manifest
-	authSecretsWrapped := reservedSecretsWrapper{
+	secretsWrapped := secretsWrapper{
 		Marblerun: specialSecrets,
+		Secrets:   userSecrets,
 	}
 
 	// replace placeholders in files
 	for path, data := range params.Files {
-		newValue, err := parseReservedSecrets(data, authSecretsWrapped)
+		newValue, err := parseSecrets(data, secretsWrapped)
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +219,7 @@ func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets)
 	}
 
 	for name, data := range params.Env {
-		newValue, err := parseReservedSecrets(data, authSecretsWrapped)
+		newValue, err := parseSecrets(data, secretsWrapped)
 		if err != nil {
 			return nil, err
 		}
@@ -227,17 +230,21 @@ func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets)
 	return &customParams, nil
 }
 
-func parseReservedSecrets(data string, authSecretsWrapped reservedSecretsWrapper) (string, error) {
+func parseSecrets(data string, secretsWrapped secretsWrapper) (string, error) {
 	var templateResult bytes.Buffer
+
+	log.Println("parseSecrets Entry: " + data)
 
 	tpl, err := template.New("data").Funcs(manifestTemplateFuncMap).Parse(data)
 	if err != nil {
 		return "", err
 	}
 
-	if err := tpl.Execute(&templateResult, authSecretsWrapped); err != nil {
+	if err := tpl.Execute(&templateResult, secretsWrapped); err != nil {
 		return "", err
 	}
+
+	log.Println("parseSecrets Exit: " + templateResult.String())
 
 	return templateResult.String(), nil
 }

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -13,7 +13,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
-	"log"
 	"math"
 	"text/template"
 	"time"
@@ -233,8 +232,6 @@ func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets,
 func parseSecrets(data string, secretsWrapped secretsWrapper) (string, error) {
 	var templateResult bytes.Buffer
 
-	log.Println("parseSecrets Entry: " + data)
-
 	tpl, err := template.New("data").Funcs(manifestTemplateFuncMap).Parse(data)
 	if err != nil {
 		return "", err
@@ -243,8 +240,6 @@ func parseSecrets(data string, secretsWrapped secretsWrapper) (string, error) {
 	if err := tpl.Execute(&templateResult, secretsWrapped); err != nil {
 		return "", err
 	}
-
-	log.Println("parseSecrets Exit: " + templateResult.String())
 
 	return templateResult.String(), nil
 }

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -177,6 +177,13 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	// Check Signature
 	ms.assert.NoError(ms.coreServer.cert.CheckSignature(newCert.SignatureAlgorithm, newCert.RawTBSCertificate, newCert.Signature))
 
+	// Validate generated secret (only specified in backend_first)
+	if marbleType == "backend_first" {
+		ms.assert.Len(params.Env["TEST_SECRET_RAW"], 16)
+	} else {
+		ms.assert.Empty(params.Env["TEST_SECRET_RAW"])
+	}
+
 	// Check cert-chain
 	roots := x509.NewCertPool()
 	ms.assert.True(roots.AppendCertsFromPEM([]byte(params.Env["ROOT_CA"])), "cannot parse rootCA")

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -196,3 +196,70 @@ func (ms *marbleSpawner) newMarbleAsync(marbleType string, infraName string, sho
 		ms.wg.Done()
 	}()
 }
+
+func TestParseSecrets(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testSecrets := map[string]Secret{
+		"mysecret":          {Type: "raw", Size: 16, Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+		"anothercoolsecret": {Type: "raw", Size: 8, Public: []byte{7, 6, 5, 4, 3, 2, 1, 0}, Private: []byte{7, 6, 5, 4, 3, 2, 1, 0}},
+	}
+
+	testReservedSecrets := reservedSecrets{
+		RootCA:     Secret{Type: "cert", Public: []byte{0, 0, 42}, Private: []byte{0, 0, 7}},
+		MarbleCert: Secret{Type: "cert", Public: []byte{42, 0, 0}, Private: []byte{7, 0, 0}},
+		SealKey:    Secret{Type: "raw", Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	}
+
+	testWrappedSecrets := secretsWrapper{
+		Marblerun: testReservedSecrets,
+		Secrets:   testSecrets,
+	}
+
+	// Test all formats, pem should fail for raw/symmetric secrets
+	parsedSecret, err := parseSecrets("{{ raw .Secrets.mysecret }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues(testSecrets["mysecret"].Public, []byte(parsedSecret))
+
+	parsedSecret, err = parseSecrets("{{ hex .Secrets.mysecret }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues("000102030405060708090a0b0c0d0e0f", parsedSecret)
+
+	_, err = parseSecrets("{{ pem .Secrets.mysecret }}", testWrappedSecrets)
+	assert.Error(err)
+
+	parsedSecret, err = parseSecrets("{{ base64 .Secrets.mysecret }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues("AAECAwQFBgcICQoLDA0ODw==", parsedSecret)
+
+	// Test if we can access a second secret
+	parsedSecret, err = parseSecrets("{{ raw .Secrets.anothercoolsecret }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues(testSecrets["anothercoolsecret"].Public, []byte(parsedSecret))
+
+	// Test all the reserved placeholder secrets
+	expectedResult := "-----BEGIN CERTIFICATE-----\nAAAq\n-----END CERTIFICATE-----\n"
+	parsedSecret, err = parseSecrets("{{ pem .Marblerun.RootCA.Public }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues(expectedResult, parsedSecret)
+
+	expectedResult = "-----BEGIN CERTIFICATE-----\nKgAA\n-----END CERTIFICATE-----\n"
+	parsedSecret, err = parseSecrets("{{ pem .Marblerun.MarbleCert.Public }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues(expectedResult, parsedSecret)
+
+	expectedResult = "-----BEGIN PRIVATE KEY-----\nBwAA\n-----END PRIVATE KEY-----\n"
+
+	parsedSecret, err = parseSecrets("{{ pem .Marblerun.MarbleCert.Private }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues(expectedResult, parsedSecret)
+
+	parsedSecret, err = parseSecrets("{{ hex .Marblerun.SealKey }}", testWrappedSecrets)
+	require.NoError(err)
+	assert.EqualValues("000102030405060708090a0b0c0d0e0f", parsedSecret)
+
+	// We should get an error if we try to get a non-existing secret
+	_, err = parseSecrets("{{ hex .Secrets.idontexist }}", testWrappedSecrets)
+	assert.Error(err)
+}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -58,7 +58,10 @@ const ManifestJSON string = `{
 					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
+					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}",
+					"TEST_SECRET_RAW": "{{ raw .Secrets.testsecret_raw }}",
+					"TEST_SECRET_HEX": "{{ hex .Secrets.testsecret_raw }}",
+					"TEST_SECRET_BASE64": "{{ base64 .Secrets.testsecret_raw }}"
 				},
 				"Argv": [
 					"--first",
@@ -94,7 +97,17 @@ const ManifestJSON string = `{
 	},
 	"Clients": {
 		"owner": [9,9,9]
-	}
+	},
+	"Secrets": {
+        "testsecret_raw": {
+            "size": 16,
+            "type": "raw"
+		},
+		"testsecret_cert": {
+			"size": 2048,
+			"type": "cert"
+		}
+    }
 }`
 
 // ManifestJSONWithRecoveryKey is a test manifest with a dynamically generated RSA key

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -99,11 +99,11 @@ const ManifestJSON string = `{
 		"owner": [9,9,9]
 	},
 	"Secrets": {
-        "testsecret_raw": {
-            "size": 16,
-            "type": "raw"
+		"testsecret_raw": {
+			"size": 16,
+			"type": "raw"
 		}
-    }
+	}
 }`
 
 // ManifestJSONWithRecoveryKey is a test manifest with a dynamically generated RSA key

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -59,9 +59,7 @@ const ManifestJSON string = `{
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}",
-					"TEST_SECRET_RAW": "{{ raw .Secrets.testsecret_raw }}",
-					"TEST_SECRET_HEX": "{{ hex .Secrets.testsecret_raw }}",
-					"TEST_SECRET_BASE64": "{{ base64 .Secrets.testsecret_raw }}"
+					"TEST_SECRET_RAW": "{{ raw .Secrets.testsecret_raw }}"
 				},
 				"Argv": [
 					"--first",
@@ -100,7 +98,7 @@ const ManifestJSON string = `{
 	},
 	"Secrets": {
 		"testsecret_raw": {
-			"size": 16,
+			"size": 128,
 			"type": "raw"
 		}
 	}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -102,10 +102,6 @@ const ManifestJSON string = `{
         "testsecret_raw": {
             "size": 16,
             "type": "raw"
-		},
-		"testsecret_cert": {
-			"size": 2048,
-			"type": "cert"
 		}
     }
 }`


### PR DESCRIPTION
(Based on #70 , check the base branch before merging!)

Let's get this ready for a review. Based on the other PR, this one adds storing secrets in the client's core, specifying secrets in a manifest and injecting them secrets into a marble.

This PR only covers shared secrets of the type "raw" so far.

One question that comes to my mind is that if we should enforce some kind of boundaries, limits or some additional sanity check? Right now, anything can be defined e.g. when it comes to size. Is this desirable, or do we want some stricter limits?