### PR TITLE
AB#363 Generate certificates as secret

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -71,9 +71,9 @@ Here is an example that has only the `SecurityVersion` and `ProductID` set:
 					"serve"
 				],
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
@@ -85,9 +85,9 @@ Here is an example that has only the `SecurityVersion` and `ProductID` set:
 					"./marble"
 				],
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -480,7 +480,7 @@ func (c *Core) generateCertificateForSecret(secret Secret, privKey crypto.Privat
 		}
 
 		template.NotAfter = time.Now().AddDate(0, 0, int(secret.ValidFor))
-	} else if !template.NotAfter.IsZero() && secret.ValidFor != 0 {
+	} else if secret.ValidFor != 0 {
 		return Secret{}, errors.New("ambigious certificate validity duration, both NotAfter and ValidFor are specified")
 	}
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -512,7 +512,15 @@ func (c *Core) generateCertificateForSecret(secret Secret, key interface{}) (*x5
 	template.IPAddresses = c.cert.IPAddresses
 	template.IsCA = false
 	template.NotBefore = time.Now()
-	template.NotAfter = time.Now().Add(time.Hour * 24 * 365)
+
+	if secret.ValidFor != 0 {
+		template.NotAfter = time.Now().Add(time.Hour * 24 * time.Duration(secret.ValidFor))
+	} else {
+		template.NotAfter = time.Now().Add(time.Hour * 24 * 365)
+	}
+
+	template.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign
+	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 
 	var secretCertRaw []byte
 	var err error

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -481,7 +481,7 @@ func (c *Core) generateCertificateForSecret(secret Secret, privKey crypto.Privat
 	if secret.ValidFor == 0 {
 		secret.ValidFor = 365
 	}
-	template.NotAfter = time.Now().Add(time.Hour * 24 * time.Duration(secret.ValidFor))
+	template.NotAfter = time.Now().AddDate(0, 0, int(secret.ValidFor))
 
 	// Generate certificate with given public key
 	var secretCertRaw []byte

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -512,6 +512,7 @@ func (c *Core) generateCertificateForSecret(secret Secret, privKey crypto.Privat
 
 	// Assemble secret object
 	secret.Cert = *cert
+	secret.CertEncoded = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
 	secret.Private, err = x509.MarshalPKCS8PrivateKey(privKey)
 	if err != nil {
 		c.zaplogger.Error("Failed to marshal private key to secret object", zap.Error(err))

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -361,7 +361,7 @@ func (c *Core) generateSecrets(ctx context.Context, secrets map[string]Secret) (
 	// Generate secrets
 	for name, secret := range secrets {
 		// Check secret size
-		if secret.Size == 0 || secret.Size%8 != 0 {
+		if secret.Size == 0 {
 			return nil, fmt.Errorf("invalid secret size: %v", name)
 		}
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -234,6 +234,7 @@ func (c *Core) sealState() ([]byte, error) {
 	}
 
 	// Encode secret certificates to PEM to avoid JSON unmarshal errors due to BigInt
+	modifiedSecrets := make(map[string]Secret)
 	for name, secret := range c.secrets {
 		secretObject := c.secrets[name]
 		cert := secret.Cert
@@ -242,8 +243,8 @@ func (c *Core) sealState() ([]byte, error) {
 			pemData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 			secretObject.CertEncoded = string(pemData)
 			secretObject.Cert = nil
-			c.secrets[name] = secretObject
 		}
+		modifiedSecrets[name] = secretObject
 	}
 
 	// seal with manifest set
@@ -252,7 +253,7 @@ func (c *Core) sealState() ([]byte, error) {
 		RawManifest: c.rawManifest,
 		RawCert:     c.cert.Raw,
 		State:       c.state,
-		Secrets:     c.secrets,
+		Secrets:     modifiedSecrets,
 		Activations: c.activations,
 	}
 	stateRaw, err := json.Marshal(state)

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -233,27 +233,13 @@ func (c *Core) sealState() ([]byte, error) {
 		return nil, err
 	}
 
-	// Encode secret certificates to PEM to avoid JSON unmarshal errors due to BigInt
-	modifiedSecrets := make(map[string]Secret)
-	for name, secret := range c.secrets {
-		secretObject := c.secrets[name]
-		cert := secret.Cert
-
-		if cert != nil {
-			pemData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
-			secretObject.CertEncoded = string(pemData)
-			secretObject.Cert = nil
-		}
-		modifiedSecrets[name] = secretObject
-	}
-
 	// seal with manifest set
 	state := sealedState{
 		Privk:       x509Encoded,
 		RawManifest: c.rawManifest,
 		RawCert:     c.cert.Raw,
 		State:       c.state,
-		Secrets:     modifiedSecrets,
+		Secrets:     c.secrets,
 		Activations: c.activations,
 	}
 	stateRaw, err := json.Marshal(state)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -8,7 +8,6 @@ package core
 
 import (
 	"context"
-	"crypto/x509"
 	"testing"
 
 	"github.com/edgelesssys/marblerun/coordinator/quote"
@@ -142,7 +141,7 @@ func TestGenerateSecrets(t *testing.T) {
 		"cert-ecdsa256-test":      {Type: "cert-ecdsa", Size: 256, ValidFor: 14},
 		"cert-ecdsa384-test":      {Type: "cert-ecdsa", Size: 384, ValidFor: 14},
 		"cert-ecdsa521-test":      {Type: "cert-ecdsa", Size: 521, ValidFor: 14},
-		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: x509.Certificate{}},
+		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: Certificate{}},
 	}
 
 	secretsNoSize := map[string]Secret{

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -144,7 +144,7 @@ func TestGenerateSecrets(t *testing.T) {
 		"cert-ecdsa256-test":      {Type: "cert-ecdsa", Size: 256, ValidFor: 14},
 		"cert-ecdsa384-test":      {Type: "cert-ecdsa", Size: 384, ValidFor: 14},
 		"cert-ecdsa521-test":      {Type: "cert-ecdsa", Size: 521, ValidFor: 14},
-		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: &x509.Certificate{}},
+		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: x509.Certificate{}},
 	}
 
 	secretsNoSize := map[string]Secret{
@@ -173,9 +173,9 @@ func TestGenerateSecrets(t *testing.T) {
 	// Check if rawTest1 has 128 Bits/16 Bytes and rawTest2 256 Bits/8 Bytes
 	assert.Len(generatedSecrets["rawTest1"].Public, 16)
 	assert.Len(generatedSecrets["rawTest2"].Public, 32)
-	assert.IsType(&x509.Certificate{}, generatedSecrets["cert-rsa-test"].Cert)
-	assert.IsType(&x509.Certificate{}, generatedSecrets["cert-ed25519-test"].Cert)
-	assert.IsType(&x509.Certificate{}, generatedSecrets["cert-ecdsa-test"].Cert)
+	assert.IsType(x509.Certificate{}, generatedSecrets["cert-rsa-test"].Cert)
+	assert.IsType(x509.Certificate{}, generatedSecrets["cert-ed25519-test"].Cert)
+	assert.IsType(x509.Certificate{}, generatedSecrets["cert-ecdsa-test"].Cert)
 
 	// Check if we get an empty secret map as output for an empty map as input
 	generatedSecrets, err = c.generateSecrets(context.TODO(), secretsEmptyMap)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -139,7 +139,7 @@ func TestGenerateSecrets(t *testing.T) {
 		"rawTest1":                {Type: "raw", Size: 128},
 		"rawTest2":                {Type: "raw", Size: 256},
 		"cert-rsa-test":           {Type: "cert-rsa", Size: 2048, ValidFor: 365},
-		"cert-ed25519-test":       {Type: "cert-ed25519", Size: 256},
+		"cert-ed25519-test":       {Type: "cert-ed25519"},
 		"cert-ecdsa224-test":      {Type: "cert-ecdsa", Size: 224, ValidFor: 14},
 		"cert-ecdsa256-test":      {Type: "cert-ecdsa", Size: 256, ValidFor: 14},
 		"cert-ecdsa384-test":      {Type: "cert-ecdsa", Size: 384, ValidFor: 14},
@@ -195,9 +195,9 @@ func TestGenerateSecrets(t *testing.T) {
 	_, err = c.generateSecrets(context.TODO(), secretsInvalidType)
 	assert.Error(err)
 
-	// If Ed25519 key size is not 256, we should not fail as we automatically fix the size
+	// If Ed25519 key size is specified, we should fail
 	_, err = c.generateSecrets(context.TODO(), secretsEd25519WrongKeySize)
-	assert.NoError(err)
+	assert.Error(err)
 
 	// However, for ECDSA we fail as we can have multiple curves
 	_, err = c.generateSecrets(context.TODO(), secretsECDSAWrongKeySize)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -83,9 +83,7 @@ func TestSeal(t *testing.T) {
 	assert.Error(err)
 
 	// Check if the secret specified in the test manifest is unsealed correctly
-	assert.IsType(Secret{}, c.secrets["testsecret_raw"])
-	assert.Len(c.secrets["testsecret_raw"].Public, 16)
-	assert.Len(c.secrets["testsecret_raw"].Private, 16)
+	assert.Equal(c.secrets, c2.secrets)
 
 	signature2 := c2.GetManifestSignature(context.TODO())
 	assert.Equal(signature, signature2, "manifest signature differs after restart")
@@ -173,9 +171,13 @@ func TestGenerateSecrets(t *testing.T) {
 	// Check if rawTest1 has 128 Bits/16 Bytes and rawTest2 256 Bits/8 Bytes
 	assert.Len(generatedSecrets["rawTest1"].Public, 16)
 	assert.Len(generatedSecrets["rawTest2"].Public, 32)
-	assert.IsType(x509.Certificate{}, generatedSecrets["cert-rsa-test"].Cert)
-	assert.IsType(x509.Certificate{}, generatedSecrets["cert-ed25519-test"].Cert)
-	assert.IsType(x509.Certificate{}, generatedSecrets["cert-ecdsa-test"].Cert)
+	assert.NotNil(generatedSecrets["cert-rsa-test"].Cert.Raw)
+	assert.NotNil(generatedSecrets["cert-ed25519-test"].Cert.Raw)
+	assert.NotNil(generatedSecrets["cert-ecdsa224-test"].Cert.Raw)
+	assert.NotNil(generatedSecrets["cert-ecdsa256-test"].Cert.Raw)
+	assert.NotNil(generatedSecrets["cert-ecdsa384-test"].Cert.Raw)
+	assert.NotNil(generatedSecrets["cert-ecdsa521-test"].Cert.Raw)
+	assert.NotNil(generatedSecrets["cert-rsa-specified-test"].Cert.Raw)
 
 	// Check if we get an empty secret map as output for an empty map as input
 	generatedSecrets, err = c.generateSecrets(context.TODO(), secretsEmptyMap)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"crypto/x509"
 	"testing"
 
 	"github.com/edgelesssys/marblerun/coordinator/quote"
@@ -135,8 +136,12 @@ func TestGenerateSecrets(t *testing.T) {
 
 	// Some secret maps which should represent secret entries from an unmarshaled JSON manifest
 	secretsToGenerate := map[string]Secret{
-		"rawTest1": {Type: "raw", Size: 128},
-		"rawTest2": {Type: "raw", Size: 256},
+		"rawTest1":                {Type: "raw", Size: 128},
+		"rawTest2":                {Type: "raw", Size: 256},
+		"cert-rsa-test":           {Type: "cert-rsa", Size: 2048, ValidFor: 365},
+		"cert-ed25519-test":       {Type: "cert-ed25519", Size: 256},
+		"cert-ecdsa-test":         {Type: "cert-ecdsa", Size: 256, ValidFor: 14},
+		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: &x509.Certificate{}},
 	}
 
 	secretsNoSize := map[string]Secret{
@@ -145,6 +150,14 @@ func TestGenerateSecrets(t *testing.T) {
 
 	secretsInvalidType := map[string]Secret{
 		"unknownType": {Type: "crap"},
+	}
+
+	secretsEd25519WrongKeySize := map[string]Secret{
+		"cert-ed25519-invalidsize": {Type: "cert-ed25519", Size: 384},
+	}
+
+	secretsECDSAWrongKeySize := map[string]Secret{
+		"cert-ecdsa-invalidsize": {Type: "cert-ecdsa", Size: 512},
 	}
 
 	secretsEmptyMap := map[string]Secret{}
@@ -157,6 +170,9 @@ func TestGenerateSecrets(t *testing.T) {
 	// Check if rawTest1 has 128 Bits/16 Bytes and rawTest2 256 Bits/8 Bytes
 	assert.Len(generatedSecrets["rawTest1"].Public, 16)
 	assert.Len(generatedSecrets["rawTest2"].Public, 32)
+	assert.IsType(&x509.Certificate{}, generatedSecrets["cert-rsa-test"].Cert)
+	assert.IsType(&x509.Certificate{}, generatedSecrets["cert-ed25519-test"].Cert)
+	assert.IsType(&x509.Certificate{}, generatedSecrets["cert-ecdsa-test"].Cert)
 
 	// Check if we get an empty secret map as output for an empty map as input
 	generatedSecrets, err = c.generateSecrets(context.TODO(), secretsEmptyMap)
@@ -174,5 +190,13 @@ func TestGenerateSecrets(t *testing.T) {
 
 	// Also, it should fail if we try to generate a secret with an unknown type
 	_, err = c.generateSecrets(context.TODO(), secretsInvalidType)
+	assert.Error(err)
+
+	// If Ed25519 key size is not 256, we should not fail as we automatically fix the size
+	_, err = c.generateSecrets(context.TODO(), secretsEd25519WrongKeySize)
+	assert.NoError(err)
+
+	// However, for ECDSA we fail as we can have multiple curves
+	_, err = c.generateSecrets(context.TODO(), secretsECDSAWrongKeySize)
 	assert.Error(err)
 }

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -140,7 +140,10 @@ func TestGenerateSecrets(t *testing.T) {
 		"rawTest2":                {Type: "raw", Size: 256},
 		"cert-rsa-test":           {Type: "cert-rsa", Size: 2048, ValidFor: 365},
 		"cert-ed25519-test":       {Type: "cert-ed25519", Size: 256},
-		"cert-ecdsa-test":         {Type: "cert-ecdsa", Size: 256, ValidFor: 14},
+		"cert-ecdsa224-test":      {Type: "cert-ecdsa", Size: 224, ValidFor: 14},
+		"cert-ecdsa256-test":      {Type: "cert-ecdsa", Size: 256, ValidFor: 14},
+		"cert-ecdsa384-test":      {Type: "cert-ecdsa", Size: 384, ValidFor: 14},
+		"cert-ecdsa521-test":      {Type: "cert-ecdsa", Size: 521, ValidFor: 14},
 		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: &x509.Certificate{}},
 	}
 

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"text/template"
@@ -63,6 +64,29 @@ type Secret struct {
 	ValidFor    uint
 	Private     PrivateKey
 	Public      PublicKey
+}
+
+// MarshalJSON defines a custom marshaller which does not export a x509.Certificate object, otherwise we will be running into bugs due to JSON marshalled BitInts
+func (s Secret) MarshalJSON() ([]byte, error) {
+	type SecretWithoutCert struct {
+		Type        string
+		Size        uint
+		CertEncoded string
+		ValidFor    uint
+		Private     PrivateKey
+		Public      PublicKey
+	}
+
+	secretWithoutCert := SecretWithoutCert{
+		Type:        s.Type,
+		Size:        s.Size,
+		CertEncoded: s.CertEncoded,
+		ValidFor:    s.ValidFor,
+		Private:     s.Private,
+		Public:      s.Public,
+	}
+
+	return json.Marshal(secretWithoutCert)
 }
 
 func encodeSecretDataToPem(data interface{}) (string, error) {

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -119,17 +119,18 @@ func encodeSecretDataToHex(data interface{}) (string, error) {
 	}
 	return hex.EncodeToString([]byte(raw)), nil
 }
+
 func encodeSecretDataToRaw(data interface{}) (string, error) {
-	if bytes, ok := data.([]byte); ok {
-		return string(bytes), nil
-	}
-	if secret, ok := data.(Secret); ok {
+	switch secret := data.(type) {
+	case []byte:
+		return string(secret), nil
+	case Secret:
 		return string(secret.Public), nil
+	case x509.Certificate:
+		return string(secret.Raw), nil
+	default:
+		return "", errors.New("invalid secret type")
 	}
-	if cert, ok := data.(x509.Certificate); ok {
-		return string(cert.Raw), nil
-	}
-	return "", errors.New("invalid secret type")
 }
 
 func encodeSecretDataToBase64(data interface{}) (string, error) {

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -126,6 +126,9 @@ func encodeSecretDataToRaw(data interface{}) (string, error) {
 	if secret, ok := data.(Secret); ok {
 		return string(secret.Public), nil
 	}
+	if cert, ok := data.(x509.Certificate); ok {
+		return string(cert.Raw), nil
+	}
 	return "", errors.New("invalid secret type")
 }
 

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -77,6 +77,12 @@ func (s Secret) MarshalJSON() ([]byte, error) {
 		Public      PublicKey
 	}
 
+	// Convert certificate object to PEM when marshalling to JSON (e.g. sealing the state)
+	if s.Cert.Raw != nil {
+		pemData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: s.Cert.Raw})
+		s.CertEncoded = string(pemData)
+	}
+
 	secretWithoutCert := SecretWithoutCert{
 		Type:        s.Type,
 		Size:        s.Size,

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
@@ -55,10 +56,13 @@ type PublicKey []byte
 
 // Secret defines a structure for storing certificates & encryption keys
 type Secret struct {
-	Type    string
-	Size    uint
-	Private PrivateKey
-	Public  PublicKey
+	Type        string
+	Size        uint
+	Cert        *x509.Certificate `json:",omitempty"`
+	CertEncoded string
+	ValidFor    string
+	Private     PrivateKey
+	Public      PublicKey
 }
 
 func encodeSecretDataToPem(data interface{}) (string, error) {

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -59,7 +59,7 @@ type PublicKey []byte
 type Secret struct {
 	Type        string
 	Size        uint
-	Cert        *x509.Certificate `json:",omitempty"`
+	Cert        x509.Certificate `json:",omitempty"`
 	CertEncoded string
 	ValidFor    uint
 	Private     PrivateKey
@@ -93,7 +93,7 @@ func encodeSecretDataToPem(data interface{}) (string, error) {
 	var pemData []byte
 
 	switch x := data.(type) {
-	case *x509.Certificate:
+	case x509.Certificate:
 		pemData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x.Raw})
 	case PublicKey:
 		pemData = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x})

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -60,7 +60,7 @@ type Secret struct {
 	Size        uint
 	Cert        *x509.Certificate `json:",omitempty"`
 	CertEncoded string
-	ValidFor    string
+	ValidFor    uint
 	Private     PrivateKey
 	Public      PublicKey
 }

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -69,8 +69,10 @@ func encodeSecretDataToPem(data interface{}) (string, error) {
 	var pemData []byte
 
 	switch x := data.(type) {
+	case *x509.Certificate:
+		pemData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x.Raw})
 	case PublicKey:
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x})
+		pemData = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x})
 	case PrivateKey:
 		pemData = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x})
 	default:

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -102,8 +102,8 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (*rpc.Activ
 
 	// customize marble's parameters
 	authSecrets := reservedSecrets{
-		RootCA:     Secret{Cert: *c.cert},
-		MarbleCert: Secret{Cert: *marbleCert, Public: encodedPubKey, Private: encodedPrivKey},
+		RootCA:     Secret{Cert: Certificate(*c.cert)},
+		MarbleCert: Secret{Cert: Certificate(*marbleCert), Public: encodedPubKey, Private: encodedPrivKey},
 		SealKey:    Secret{Public: sealKey, Private: sealKey},
 	}
 

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -102,8 +102,8 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (*rpc.Activ
 
 	// customize marble's parameters
 	authSecrets := reservedSecrets{
-		RootCA:     Secret{Cert: c.cert},
-		MarbleCert: Secret{Cert: marbleCert, Public: encodedPubKey, Private: encodedPrivKey},
+		RootCA:     Secret{Cert: *c.cert},
+		MarbleCert: Secret{Cert: *marbleCert, Public: encodedPubKey, Private: encodedPrivKey},
 		SealKey:    Secret{Public: sealKey, Private: sealKey},
 	}
 

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -198,6 +198,17 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	}
 	_, err = newCert.Verify(opts)
 	ms.assert.NoError(err, "failed to verify new certificate: %v", err)
+
+	if marbleType == "backend_first" {
+		// Validate generated secret certificate
+		p, _ = pem.Decode([]byte(params.Env["TEST_SECRET_CERT"]))
+		ms.assert.NotNil(p)
+		secretCert, err := x509.ParseCertificate(p.Bytes)
+		ms.assert.NotNil(p)
+		ms.assert.NoError(err)
+		_, err = secretCert.Verify(opts)
+		ms.assert.NoError(err, "failed to verify secret certificate with root CA: %v", err)
+	}
 }
 
 func (ms *marbleSpawner) newMarbleAsync(marbleType string, infraName string, shouldSucceed bool) {

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -256,7 +256,7 @@ func TestParseSecrets(t *testing.T) {
 	testSecrets := map[string]Secret{
 		"mysecret":          {Type: "raw", Size: 16, Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
 		"anothercoolsecret": {Type: "raw", Size: 8, Public: []byte{7, 6, 5, 4, 3, 2, 1, 0}, Private: []byte{7, 6, 5, 4, 3, 2, 1, 0}},
-		"testcertificate":   {Type: "cert-rsa", Size: 2048, Cert: *testCert, Public: pubKey, Private: privKey},
+		"testcertificate":   {Type: "cert-rsa", Size: 2048, Cert: Certificate(*testCert), Public: pubKey, Private: privKey},
 	}
 
 	testReservedSecrets := reservedSecrets{
@@ -299,6 +299,7 @@ func TestParseSecrets(t *testing.T) {
 
 	// Check if we can parse a certificate from the outputted raw type
 	parsedSecret, err = parseSecrets("{{ raw .Secrets.testcertificate.Cert }}", testWrappedSecrets)
+	require.NoError(err)
 	parsedCertificate, err = x509.ParseCertificate([]byte(parsedSecret))
 	require.NoError(err)
 	assert.EqualValues(testCert, parsedCertificate)

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -259,7 +259,7 @@ func TestParseSecrets(t *testing.T) {
 	testSecrets := map[string]Secret{
 		"mysecret":          {Type: "raw", Size: 16, Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
 		"anothercoolsecret": {Type: "raw", Size: 8, Public: []byte{7, 6, 5, 4, 3, 2, 1, 0}, Private: []byte{7, 6, 5, 4, 3, 2, 1, 0}},
-		"testcertificate":   {Type: "cert-rsa", Size: 2048, Cert: testCert, Public: pubKey, Private: privKey},
+		"testcertificate":   {Type: "cert-rsa", Size: 2048, Cert: *testCert, Public: pubKey, Private: privKey},
 	}
 
 	testReservedSecrets := reservedSecrets{

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -297,6 +297,12 @@ func TestParseSecrets(t *testing.T) {
 	require.NoError(err)
 	assert.EqualValues(testCert, parsedCertificate)
 
+	// Check if we can parse a certificate from the outputted raw type
+	parsedSecret, err = parseSecrets("{{ raw .Secrets.testcertificate.Cert }}", testWrappedSecrets)
+	parsedCertificate, err = x509.ParseCertificate([]byte(parsedSecret))
+	require.NoError(err)
+	assert.EqualValues(testCert, parsedCertificate)
+
 	// Test if we can access a second secret
 	parsedSecret, err = parseSecrets("{{ raw .Secrets.anothercoolsecret }}", testWrappedSecrets)
 	require.NoError(err)

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -246,12 +246,12 @@ func TestParseSecrets(t *testing.T) {
 	assert.EqualValues(testSecrets["anothercoolsecret"].Public, []byte(parsedSecret))
 
 	// Test all the reserved placeholder secrets
-	expectedResult := "-----BEGIN CERTIFICATE-----\nAAAq\n-----END CERTIFICATE-----\n"
+	expectedResult := "-----BEGIN PUBLIC KEY-----\nAAAq\n-----END PUBLIC KEY-----\n"
 	parsedSecret, err = parseSecrets("{{ pem .Marblerun.RootCA.Public }}", testWrappedSecrets)
 	require.NoError(err)
 	assert.EqualValues(expectedResult, parsedSecret)
 
-	expectedResult = "-----BEGIN CERTIFICATE-----\nKgAA\n-----END CERTIFICATE-----\n"
+	expectedResult = "-----BEGIN PUBLIC KEY-----\nKgAA\n-----END PUBLIC KEY-----\n"
 	parsedSecret, err = parseSecrets("{{ pem .Marblerun.MarbleCert.Public }}", testWrappedSecrets)
 	require.NoError(err)
 	assert.EqualValues(expectedResult, parsedSecret)

--- a/marble/premain/premain.go
+++ b/marble/premain/premain.go
@@ -13,7 +13,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,7 +79,7 @@ func getUUID(appFs afero.Fs, uuidFile string) (uuid.UUID, error) {
 func generateCertificate() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	marbleDNSNamesString := util.MustGetenv(config.DNSNames)
 	marbleDNSNames := strings.Split(marbleDNSNamesString, ",")
-	ipAddrs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+	ipAddrs := util.DefaultCertificateIPAddresses
 	return util.GenerateCert(marbleDNSNames, ipAddrs, false)
 }
 

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -59,7 +59,8 @@ const ManifestJSON string = `{
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}",
-					"TEST_SECRET_RAW": "{{ raw .Secrets.testsecret_raw }}"
+					"TEST_SECRET_RAW": "{{ raw .Secrets.testsecret_raw }}",
+					"TEST_SECRET_CERT": "{{ pem .Secrets.testsecret_cert.Cert }}"
 				},
 				"Argv": [
 					"--first",

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -55,9 +55,9 @@ const ManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}",
 					"TEST_SECRET_RAW": "{{ raw .Secrets.testsecret_raw }}"
 				},
@@ -71,9 +71,9 @@ const ManifestJSON string = `{
 			"Package": "backend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				},
 				"Argv": [
@@ -85,9 +85,9 @@ const ManifestJSON string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
@@ -127,9 +127,9 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 				}
 			}
@@ -177,9 +177,9 @@ var IntegrationManifestJSON string = `{
 				],
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
 			}
@@ -193,9 +193,9 @@ var IntegrationManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
 			}
@@ -208,9 +208,9 @@ var IntegrationManifestJSON string = `{
 					"/tmp/coordinator_test/jkl.mno": "bar"
 				},
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Public }}",
+					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Public }}",
+					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
 					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
 			}
 		}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -100,6 +100,18 @@ const ManifestJSON string = `{
 		"testsecret_raw": {
 			"size": 128,
 			"type": "raw"
+		},
+		"testsecret_cert": {
+			"size": 2048,
+			"type": "cert-rsa",
+			"Cert": {
+				"SerialNumber": 42,
+				"Subject": {
+					"SerialNumber": "42",
+					"CommonName": "Marblerun Unit Test"
+				},
+			"validfor": 7
+			}
 		}
 	}
 }`

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -99,20 +99,20 @@ const ManifestJSON string = `{
 	},
 	"Secrets": {
 		"testsecret_raw": {
-			"size": 128,
-			"type": "raw"
+			"Size": 128,
+			"Type": "raw"
 		},
 		"testsecret_cert": {
-			"size": 2048,
-			"type": "cert-rsa",
+			"Size": 2048,
+			"Type": "cert-rsa",
 			"Cert": {
 				"SerialNumber": 42,
 				"Subject": {
 					"SerialNumber": "42",
 					"CommonName": "Marblerun Unit Test"
-				},
-			"validfor": 7
-			}
+				}
+			},
+			"ValidFor": 7
 		}
 	}
 }`

--- a/util/tls.go
+++ b/util/tls.go
@@ -26,7 +26,7 @@ const marbleName string = "Marblerun Marble"
 // MustGenerateTestMarbleCredentials returns dummy Marble TLS credentials for testing
 func MustGenerateTestMarbleCredentials() (cert *x509.Certificate, csrRaw []byte, privk *ecdsa.PrivateKey) {
 	dnsNames := []string{"localhost", "*.foobar.net", "*.example.org"}
-	ipAddrs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+	ipAddrs := DefaultCertificateIPAddresses
 
 	cert, privk, err := GenerateCert(dnsNames, ipAddrs, false)
 	if err != nil {
@@ -89,7 +89,7 @@ func GenerateCert(dnsNames []string, ipAddrs []net.IP, isCA bool) (*x509.Certifi
 func GenerateCSR(dnsNames []string, privk *ecdsa.PrivateKey) (*x509.CertificateRequest, error) {
 	template := x509.CertificateRequest{
 		DNSNames:    dnsNames,
-		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		IPAddresses: DefaultCertificateIPAddresses,
 	}
 	csrRaw, err := x509.CreateCertificateRequest(rand.Reader, &template, privk)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,9 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
+// DefaultCertificateIPAddresses defines a placeholder value used for automated x509 certificate generation
+var DefaultCertificateIPAddresses = []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+
 // DeriveKey derives a key from a secret.
 func DeriveKey(secret, salt []byte) ([]byte, error) {
 	hkdf := hkdf.New(sha256.New, secret, salt, nil)


### PR DESCRIPTION
This PR adds support to define a certificate as secret which should be generated.

This can be done by following the x509.Certificate golang object notation. Every field from the object can be defined in the manifest, the generator will take most values and overwrite some of them and generate a key pair + certificate based on them.

Right now, this is not completely done yet as tests are failing, documentation still needs to be provided etc., but it should be ready for review.