### PR TITLE
AB#447 : Use ertgolib for Marble TLS configuration

### DIFF
--- a/cmd/marble-test/main.go
+++ b/cmd/marble-test/main.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"fmt"
 	"log"
 	"net/http"
@@ -21,25 +20,22 @@ import (
 func main() {
 	addr := util.MustGetenv("EDG_TEST_ADDR")
 
-	serverTLSConfig, err := marble.GetServerTLSConfig()
-	if err != nil {
-		panic(err)
-	}
-
-	clientTLSConfig, err := marble.GetClientTLSConfig()
-	if err != nil {
-		panic(err)
-	}
-
 	if len(os.Args) > 1 && os.Args[1] == "serve" {
-		runServer(addr, serverTLSConfig)
+		runServer(addr)
 		return
 	}
 
-	runClient(addr, clientTLSConfig)
+	runClient(addr)
 }
 
-func runServer(addr string, tlsConfig *tls.Config) {
+func runServer(addr string) {
+	// Retrieve server TLS config from ertgolib
+	tlsConfig, err := marble.GetServerTLSConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	// Setup server
 	srv := &http.Server{
 		Addr:      addr,
 		TLSConfig: tlsConfig,
@@ -55,7 +51,14 @@ func runServer(addr string, tlsConfig *tls.Config) {
 	log.Fatal(srv.ListenAndServeTLS("", ""))
 }
 
-func runClient(addr string, tlsConfig *tls.Config) error {
+func runClient(addr string) error {
+	// Retrieve client TLS config from ertgolib
+	tlsConfig, err := marble.GetClientTLSConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	// Setup client
 	client := http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
 	url := url.URL{Scheme: "https", Host: addr}
 	resp, err := client.Get(url.String())

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -126,6 +126,10 @@ func encodeSecretDataToRaw(data interface{}) (string, error) {
 	switch secret := data.(type) {
 	case []byte:
 		return string(secret), nil
+	case PrivateKey:
+		return string(secret), nil
+	case PublicKey:
+		return string(secret), nil
 	case Secret:
 		return string(secret.Public), nil
 	case Certificate:

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -212,6 +212,24 @@ func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets,
 		customParams.Env[name] = newValue
 	}
 
+	// Set as environment variables
+	rootCaPem, err := encodeSecretDataToPem(specialSecrets.RootCA.Cert)
+	if err != nil {
+		return nil, err
+	}
+	marbleCertPem, err := encodeSecretDataToPem(specialSecrets.MarbleCert.Cert)
+	if err != nil {
+		return nil, err
+	}
+	encodedPrivKey, err := encodeSecretDataToPem(specialSecrets.MarbleCert.Private)
+	if err != nil {
+		return nil, err
+	}
+
+	customParams.Env["MARBLE_PREDEFINED_ROOT_CA"] = rootCaPem
+	customParams.Env["MARBLE_PREDEFINED_MARBLE_CERT"] = marbleCertPem
+	customParams.Env["MARBLE_PREDEFINED_PRIVATE_KEY"] = encodedPrivKey
+
 	return &customParams, nil
 }
 

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -17,6 +17,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/edgelesssys/ertgolib/marble"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/google/uuid"
@@ -226,9 +227,9 @@ func customizeParameters(params *rpc.Parameters, specialSecrets reservedSecrets,
 		return nil, err
 	}
 
-	customParams.Env["MARBLE_PREDEFINED_ROOT_CA"] = rootCaPem
-	customParams.Env["MARBLE_PREDEFINED_MARBLE_CERT"] = marbleCertPem
-	customParams.Env["MARBLE_PREDEFINED_PRIVATE_KEY"] = encodedPrivKey
+	customParams.Env[marble.MarbleEnvironmentRootCA] = rootCaPem
+	customParams.Env[marble.MarbleEnvironmentCertificate] = marbleCertPem
+	customParams.Env[marble.MarbleEnvironmentPrivateKey] = encodedPrivKey
 
 	return &customParams, nil
 }

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -170,11 +170,11 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	ms.assert.Len(sealKey, 32)
 
 	// Validate Marble Key
-	p, _ := pem.Decode([]byte(params.Env["MARBLE_KEY"]))
+	p, _ := pem.Decode([]byte(params.Env["MARBLE_PREDEFINED_PRIVATE_KEY"]))
 	ms.assert.NotNil(p)
 
 	// Validate Cert
-	p, _ = pem.Decode([]byte(params.Env["MARBLE_CERT"]))
+	p, _ = pem.Decode([]byte(params.Env["MARBLE_PREDEFINED_MARBLE_CERT"]))
 	ms.assert.NotNil(p)
 	newCert, err := x509.ParseCertificate(p.Bytes)
 	ms.assert.NoError(err)
@@ -201,7 +201,7 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 
 	// Check cert-chain
 	roots := x509.NewCertPool()
-	ms.assert.True(roots.AppendCertsFromPEM([]byte(params.Env["ROOT_CA"])), "cannot parse rootCA")
+	ms.assert.True(roots.AppendCertsFromPEM([]byte(params.Env["MARBLE_PREDEFINED_ROOT_CA"])), "cannot parse rootCA")
 	opts := x509.VerifyOptions{
 		Roots:     roots,
 		DNSName:   "localhost",

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	libMarble "github.com/edgelesssys/ertgolib/marble"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/test"
@@ -170,11 +171,11 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	ms.assert.Len(sealKey, 32)
 
 	// Validate Marble Key
-	p, _ := pem.Decode([]byte(params.Env["MARBLE_PREDEFINED_PRIVATE_KEY"]))
+	p, _ := pem.Decode([]byte(params.Env[libMarble.MarbleEnvironmentPrivateKey]))
 	ms.assert.NotNil(p)
 
 	// Validate Cert
-	p, _ = pem.Decode([]byte(params.Env["MARBLE_PREDEFINED_MARBLE_CERT"]))
+	p, _ = pem.Decode([]byte(params.Env[libMarble.MarbleEnvironmentCertificate]))
 	ms.assert.NotNil(p)
 	newCert, err := x509.ParseCertificate(p.Bytes)
 	ms.assert.NoError(err)
@@ -201,7 +202,7 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 
 	// Check cert-chain
 	roots := x509.NewCertPool()
-	ms.assert.True(roots.AppendCertsFromPEM([]byte(params.Env["MARBLE_PREDEFINED_ROOT_CA"])), "cannot parse rootCA")
+	ms.assert.True(roots.AppendCertsFromPEM([]byte(params.Env[libMarble.MarbleEnvironmentRootCA])), "cannot parse rootCA")
 	opts := x509.VerifyOptions{
 		Roots:     roots,
 		DNSName:   "localhost",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelesssys/marblerun
 go 1.14
 
 require (
-	github.com/edgelesssys/ertgolib v0.1.3-0.20201215132249-6f978b61cb71
+	github.com/edgelesssys/ertgolib v0.1.3
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelesssys/marblerun
 go 1.14
 
 require (
-	github.com/edgelesssys/ertgolib v0.1.3-0.20201215075232-c044d27a45a3
+	github.com/edgelesssys/ertgolib v0.1.3-0.20201215132249-6f978b61cb71
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelesssys/marblerun
 go 1.14
 
 require (
-	github.com/edgelesssys/ertgolib v0.1.2
+	github.com/edgelesssys/ertgolib v0.1.3-0.20201215075232-c044d27a45a3
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -51,10 +51,8 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/edgelesssys/ertgolib v0.1.2-0.20201214150630-a29d75e8c4c3 h1:wNqxExJ0VkIGqJIDgp9eFHZgfY5N4fhwEJVle0N8R/g=
-github.com/edgelesssys/ertgolib v0.1.2-0.20201214150630-a29d75e8c4c3/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
-github.com/edgelesssys/ertgolib v0.1.2 h1:/lGmx8ASCWMsxt3mt2XgU36506dB09z/pLiY17J7tZY=
-github.com/edgelesssys/ertgolib v0.1.2/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
+github.com/edgelesssys/ertgolib v0.1.3-0.20201215075232-c044d27a45a3 h1:BRVrkxH+e6STNfHit8+9VVVN1SNiROuKseuAhthwiE4=
+github.com/edgelesssys/ertgolib v0.1.3-0.20201215075232-c044d27a45a3/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -360,7 +358,6 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200421231249-e086a090c8fd h1:QPwSajcTUrFriMF1nJ3XzgoqakqQEsnZf9LdXdi2nkI=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -391,7 +388,6 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/edgelesssys/ertgolib v0.1.3-0.20201215075232-c044d27a45a3 h1:BRVrkxH+e6STNfHit8+9VVVN1SNiROuKseuAhthwiE4=
-github.com/edgelesssys/ertgolib v0.1.3-0.20201215075232-c044d27a45a3/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
+github.com/edgelesssys/ertgolib v0.1.3-0.20201215132249-6f978b61cb71 h1:TOHRU388JrDqFW0dBGfTtBtTda68/M0pf4UG9Oauz6E=
+github.com/edgelesssys/ertgolib v0.1.3-0.20201215132249-6f978b61cb71/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edgelesssys/ertgolib v0.1.3-0.20201215132249-6f978b61cb71 h1:TOHRU388JrDqFW0dBGfTtBtTda68/M0pf4UG9Oauz6E=
 github.com/edgelesssys/ertgolib v0.1.3-0.20201215132249-6f978b61cb71/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
+github.com/edgelesssys/ertgolib v0.1.3 h1:rsovbVQNs6oqNXSdRUaTZkgn6yhi7zbAHBsTNlcQpVM=
+github.com/edgelesssys/ertgolib v0.1.3/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -55,10 +55,7 @@ const ManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}",
 					"TEST_SECRET_RAW": "{{ raw .Secrets.raw_shared }}",
 					"TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
 					"TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
@@ -73,10 +70,7 @@ const ManifestJSON string = `{
 			"Package": "backend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}",
 					"TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
 					"TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
 				},
@@ -89,10 +83,7 @@ const ManifestJSON string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}"
 				}
 			}
 		}
@@ -160,10 +151,7 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Package": "frontend",
 			"Parameters": {
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}"
 				}
 			}
 		}
@@ -210,10 +198,7 @@ var IntegrationManifestJSON string = `{
 				],
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}"
 			}
 			}
 		},
@@ -226,10 +211,7 @@ var IntegrationManifestJSON string = `{
 				},
 				"Env": {
 					"IS_FIRST": "true",
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}"
 			}
 			}
 		},
@@ -241,10 +223,7 @@ var IntegrationManifestJSON string = `{
 					"/tmp/coordinator_test/jkl.mno": "bar"
 				},
 				"Env": {
-					"ROOT_CA": "{{ pem .Marblerun.RootCA.Cert }}",
-					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"MARBLE_CERT": "{{ pem .Marblerun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .Marblerun.MarbleCert.Private }}"
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}"
 			}
 		}
 		}


### PR DESCRIPTION
Requires https://github.com/edgelesssys/ertgolib/pull/3

Changes:
    MARBLE_CERT -> MARBLE_PREDEFINED_MARBLE_CERT
    ROOT_CA -> MARBLE_PREDEFINED_ROOT_CA
    MARBLE_KEY -> MARBLE_PREDEFINED_PRIVATE_KEY

These three new environment variables are also now automatically defined, so there's no need to manually define them in the manifest.