### PR TITLE
AB#457 : Check combination of package properties

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -42,7 +42,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) ([]byte, err
 	if err := json.Unmarshal(rawManifest, &manifest); err != nil {
 		return nil, err
 	}
-	if err := manifest.Check(ctx); err != nil {
+	if err := manifest.Check(ctx, c.zaplogger); err != nil {
 		return nil, err
 	}
 

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,6 @@ func TestGetManifestSignature(t *testing.T) {
 
 func TestSetManifest(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
 
 	c, manifest := mustSetup()
 	_, err := c.SetManifest(context.TODO(), []byte(test.ManifestJSON))
@@ -65,9 +65,14 @@ func TestSetManifest(t *testing.T) {
 	_, err = c.SetManifest(context.TODO(), []byte(test.ManifestJSON))
 	assert.NoError(err, "SetManifest should succed after failed tries")
 	assert.Equal(*manifest, c.manifest, "Manifest should be set correctly")
+}
+
+func TestSetManifestInvalid(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 
 	// try setting manifest with unallowed marble package, but proper json
-	c, _ = mustSetup()
+	c, manifest := mustSetup()
 	// get any element of the map
 	for _, marble := range manifest.Marbles {
 		marble.Package = "foo"
@@ -79,26 +84,75 @@ func TestSetManifest(t *testing.T) {
 	_, err = c.SetManifest(context.TODO(), modRawManifest)
 	assert.Equal("manifest does not contain marble package foo", err.Error())
 
-	// Try setting manifest with UniqueID + other value set, no debug mode (this should fail)
+	// Try setting manifest with all values unset, no debug mode (this should fail)
 	c, manifest = mustSetup()
 
 	backendPackage := manifest.Packages["backend"]
+	backendPackage.Debug = false
+	backendPackage.UniqueID = ""
+	backendPackage.SignerID = ""
+	backendPackage.ProductID = nil
+	backendPackage.SecurityVersion = nil
+
+	manifest.Packages["backend"] = backendPackage
+	modRawManifest, err = json.Marshal(manifest)
+	require.NoError(err)
+	_, err = c.SetManifest(context.TODO(), modRawManifest)
+	assert.Equal("manifest misses value for SignerID in package backend", err.Error())
+
+	// Enable debug mode, should work now
+	c = testManifestInvalidDebugCase(c, manifest, backendPackage, assert, require)
+
+	// Set SignerID, now should complain about missing ProductID
 	backendPackage.SignerID = "some signer"
 	manifest.Packages["backend"] = backendPackage
 
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
 	_, err = c.SetManifest(context.TODO(), modRawManifest)
-	assert.Equal("manifest specfies both UniqueID *and* SignerID/ProductID/SecurityVersion", err.Error())
+	assert.Equal("manifest misses value for ProductID in package backend", err.Error())
 
-	// Try setting manifest with Unique + other value set, with debug mode (this should pass)
-	backendPackage.Debug = true
+	// Enable debug mode, should work now
+	c = testManifestInvalidDebugCase(c, manifest, backendPackage, assert, require)
+
+	// Set ProductID, now should complain about missing SecurityVersion
+	productIDValue := uint64(42)
+	backendPackage.ProductID = &productIDValue
+	manifest.Packages["backend"] = backendPackage
+
+	modRawManifest, err = json.Marshal(manifest)
+	require.NoError(err)
+	_, err = c.SetManifest(context.TODO(), modRawManifest)
+	assert.Equal("manifest misses value for SecurityVersion in package backend", err.Error())
+
+	// Enable debug mode, should work now
+	c = testManifestInvalidDebugCase(c, manifest, backendPackage, assert, require)
+
+	// Set SecurityVersion, now we should pass
+	securityVersion := uint(1)
+	backendPackage.SecurityVersion = &securityVersion
 	manifest.Packages["backend"] = backendPackage
 
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
 	_, err = c.SetManifest(context.TODO(), modRawManifest)
 	assert.NoError(err)
+
+	// Reset & enable debug mode, should also work now
+	c, _ = mustSetup()
+	c = testManifestInvalidDebugCase(c, manifest, backendPackage, assert, require)
+
+	// Try setting manifest with UniqueID + other value set, this should fail again
+	backendPackage.UniqueID = "something unique"
+	manifest.Packages["backend"] = backendPackage
+
+	modRawManifest, err = json.Marshal(manifest)
+	require.NoError(err)
+	_, err = c.SetManifest(context.TODO(), modRawManifest)
+	assert.Equal("manifest specfies both UniqueID *and* SignerID/ProductID/SecurityVersion in package backend", err.Error())
+
+	// Enable debug mode, should work now
+	c = testManifestInvalidDebugCase(c, manifest, backendPackage, assert, require)
 }
 
 func TestGetCertQuote(t *testing.T) {
@@ -132,4 +186,19 @@ func TestGetStatus(t *testing.T) {
 	assert.NoError(err, "GetStatus failed")
 	assert.EqualValues(stateAcceptingMarbles, statusCode, "We should be ready to accept Marbles now, but GetStatus does tell us we don't.")
 	assert.NotEmpty(status, "Status string was empty, but should not.")
+}
+
+func testManifestInvalidDebugCase(c *Core, manifest *Manifest, marblePackage quote.PackageProperties, assert *assert.Assertions, require *require.Assertions) *Core {
+	marblePackage.Debug = true
+	manifest.Packages["backend"] = marblePackage
+
+	modRawManifest, err := json.Marshal(manifest)
+	require.NoError(err)
+	_, err = c.SetManifest(context.TODO(), modRawManifest)
+	assert.NoError(err)
+	marblePackage.Debug = false
+
+	// Since debug case should pass, return a resetted fresh core
+	c, _ = mustSetup()
+	return c
 }

--- a/coordinator/core/manifest.go
+++ b/coordinator/core/manifest.go
@@ -182,27 +182,30 @@ func (m Manifest) Check(ctx context.Context, zaplogger *zap.Logger) error {
 			}
 		} else if singlePackage.UniqueID == "" {
 			if singlePackage.SignerID == "" {
-				if singlePackage.Debug {
-					zaplogger.Warn("Manifest misses value for SignedID. This is not accepted in non-debug mode, please check your configuration.", zap.String("packageName", marble.Package))
-				} else {
-					return fmt.Errorf("manifest misses value for SignerID in package %s", marble.Package)
+				if err := warnOrFailForMissingValue(singlePackage.Debug, "SignerID", marble.Package, zaplogger); err != nil {
+					return err
 				}
 			}
 			if singlePackage.ProductID == nil {
-				if singlePackage.Debug {
-					zaplogger.Warn("Manifest misses value for ProductID. This is not accepted in non-debug mode, please check your configuration.", zap.String("packageName", marble.Package))
-				} else {
-					return fmt.Errorf("manifest misses value for ProductID in package %s", marble.Package)
+				if err := warnOrFailForMissingValue(singlePackage.Debug, "ProductID", marble.Package, zaplogger); err != nil {
+					return err
 				}
 			}
 			if singlePackage.SecurityVersion == nil {
-				if singlePackage.Debug {
-					zaplogger.Warn("Manifest misses value for SecurityVersion. This is not accepted in non-debug mode, please check your configuration.", zap.String("packageName", marble.Package))
-				} else {
-					return fmt.Errorf("manifest misses value for SecurityVersion in package %s", marble.Package)
+				if err := warnOrFailForMissingValue(singlePackage.Debug, "SecurityVersion", marble.Package, zaplogger); err != nil {
+					return err
 				}
 			}
-		} 
+		}
 	}
 	return nil
+}
+
+func warnOrFailForMissingValue(debugMode bool, parameter string, packageName string, zaplogger *zap.Logger) error {
+	if debugMode {
+		zaplogger.Warn("Manifest misses value in package declaration. This is not accepted in non-debug mode, please check your configuration.", zap.String("parameter", parameter), zap.String("packageName", packageName))
+		return nil
+	}
+
+	return fmt.Errorf("manifest misses value for %s in package %s", parameter, packageName)
 }


### PR DESCRIPTION
Note: This does not cover ERTValidator (it's still reports that  it would be compliant package), the coordinator does the check when setting the manifest. This is so we can handle debug/non-debug mode differently without introducing larger changes.