### PR TITLE
AB#494 & AB#496 : Allow updating the required SecurityVersion of a package

### DIFF
--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -116,8 +116,8 @@ func (c *Core) verifyManifestRequirement(tlsCert *x509.Certificate, quote []byte
 	}
 
 	// In case the administrator has updated a package, apply the updated security version
-	if _, ok := c.updateManifest.Packages[marble.Package]; ok {
-		pkg.SecurityVersion = c.updateManifest.Packages[marble.Package].SecurityVersion
+	if updpkg, ok := c.updateManifest.Packages[marble.Package]; ok {
+		pkg.SecurityVersion = updpkg.SecurityVersion
 	}
 
 	if !c.inSimulationMode() {

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -115,6 +115,11 @@ func (c *Core) verifyManifestRequirement(tlsCert *x509.Certificate, quote []byte
 		return status.Error(codes.Internal, "undefined package")
 	}
 
+	// In case the administrator has updated a package, apply the updated security version
+	if _, ok := c.updateManifest.Packages[marble.Package]; ok {
+		pkg.SecurityVersion = c.updateManifest.Packages[marble.Package].SecurityVersion
+	}
+
 	if !c.inSimulationMode() {
 		infraMatch := false
 		for _, infra := range c.manifest.Infrastructures {

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -412,4 +412,14 @@ func TestSecurityLevelUpdate(t *testing.T) {
 
 	// try to activate another first backend, should fail as required SecurityLevel is now higher after manifest update
 	spawner.newMarble("frontend", "Azure", false)
+
+	// Use a new core and test if updated manifest persisted after restart
+	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, sealer, zapLogger)
+	require.NoError(err)
+	assert.Equal(stateAcceptingMarbles, coreServer2.state)
+	assert.EqualValues(5, *coreServer2.updateManifest.Packages["frontend"].SecurityVersion)
+
+	// This should still fail after a restart, as the update manifest should have been reloaded from the sealed state correctly
+	spawner.coreServer = coreServer2
+	spawner.newMarble("frontend", "Azure", false)
 }

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -164,11 +164,8 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 	})
 
 	mux.HandleFunc("/update", func(w http.ResponseWriter, r *http.Request) {
-		clientCerts := r.TLS.PeerCertificates
-		verifiedAdmin := cc.VerifyAdmin(r.Context(), clientCerts)
-
 		// Abort if no admin client certificate was provided
-		if verifiedAdmin != true {
+		if r.TLS == nil || !cc.VerifyAdmin(r.Context(), r.TLS.PeerCertificates) {
 			http.Error(w, "", http.StatusUnauthorized)
 			return
 		}
@@ -182,7 +179,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 			}
 			err = cc.UpdateManifest(r.Context(), updateManifest)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 		default:


### PR DESCRIPTION
Short summary of changes:

- New section `Admins` in manifest, allowing to specify **user-defined** certificates (which get saved to the core)
- Introduction of an 'update manifest', which allows to specify a new, higher SecurityLevel than set in the original manifest
- This 'update manifest' does not overwrite the original manifest, but is saved additionally in the core.
- `verifyManifestRequirement` in `marbleapi.go` overwrites the SecurityVersion for each specified package in the update manifest. This should replace the SecurityLevel right in time before it passes the Validator.
- The update manifest can be set over the '/update' API endpoint, when one of the client certificates from `Admins` was used (and if none was set, this API endpoint stays locked)
- The certificates are **not fully verified**. We only check if the supplied one is equal to one of the defined ones in `Admins`, and Go's TLS stack should ensure that the user calling the API endpoint does own the private key to its own certificate. Expiration and trust anchors are not checked here, we basically just abuse TLS client certificates here for a public/private key check and do not care about the rest of the X.509 certificate stuff. Guess we need to check carefully here if this provides sufficient security.