### PR TITLE
Add error message for unauthorized /update request

### DIFF
--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -166,7 +166,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 	mux.HandleFunc("/update", func(w http.ResponseWriter, r *http.Request) {
 		// Abort if no admin client certificate was provided
 		if r.TLS == nil || !cc.VerifyAdmin(r.Context(), r.TLS.PeerCertificates) {
-			http.Error(w, "", http.StatusUnauthorized)
+			http.Error(w, "unauthorized user", http.StatusUnauthorized)
 			return
 		}
 


### PR DESCRIPTION
Better than just to fail silently, especially since `curl` does not print the HTTP status code by default.