### PR TITLE
AB#377: Modularize recovery

### DIFF
--- a/cmd/coordinator/enclavemain.go
+++ b/cmd/coordinator/enclavemain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/config"
 	"github.com/edgelesssys/marblerun/coordinator/core"
 	"github.com/edgelesssys/marblerun/coordinator/quote/ertvalidator"
+	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/util"
 )
 
@@ -24,5 +25,6 @@ func main() {
 	sealDir := util.MustGetenv(config.SealDir)
 	sealDir = filepath.Join(sealDirPrefix, sealDir)
 	sealer := core.NewAESGCMSealer(sealDir)
-	run(validator, issuer, sealDir, sealer)
+	recovery := recovery.NewSinglePartyRecovery()
+	run(validator, issuer, sealDir, sealer, recovery)
 }

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/config"
 	"github.com/edgelesssys/marblerun/coordinator/core"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
+	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/util"
 )
 
@@ -20,5 +21,6 @@ func main() {
 	issuer := quote.NewFailIssuer()
 	sealDir := util.MustGetenv(config.SealDir)
 	sealer := core.NewNoEnclaveSealer(sealDir)
-	run(validator, issuer, sealDir, sealer)
+	recovery := recovery.NewSinglePartyRecovery()
+	run(validator, issuer, sealDir, sealer, recovery)
 }

--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -14,12 +14,13 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/config"
 	"github.com/edgelesssys/marblerun/coordinator/core"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
+	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/server"
 	"github.com/edgelesssys/marblerun/util"
 	"go.uber.org/zap"
 )
 
-func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer core.Sealer) {
+func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer core.Sealer, recovery recovery.Recovery) {
 	// Setup logging with Zap Logger
 	var zapLogger *zap.Logger
 	var err error
@@ -51,7 +52,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 	if err := os.MkdirAll(sealDir, 0700); err != nil {
 		zapLogger.Fatal("Cannot create or access sealdir. Please check the permissions for the specified path.", zap.Error(err))
 	}
-	core, err := core.NewCore(dnsNames, validator, issuer, sealer, zapLogger)
+	core, err := core.NewCore(dnsNames, validator, issuer, sealer, recovery, zapLogger)
 	if err != nil {
 		panic(err)
 	}

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
+	"github.com/edgelesssys/marblerun/util"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
@@ -102,7 +103,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) ([]byte, err
 
 	var recoveryData []byte
 	if recoveryk != nil {
-		recoveryData, err = rsa.EncryptOAEP(sha256.New(), rand.Reader, recoveryk, encryptionKey, nil)
+		recoveryData, err = util.EncryptOAEP(recoveryk, encryptionKey)
 		if err != nil {
 			c.zaplogger.Error("Creation of recovery data failed.", zap.Error(err))
 		}

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -16,6 +16,7 @@ import (
 	"encoding/pem"
 	"errors"
 
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
@@ -40,7 +41,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) ([]byte, err
 		return nil, err
 	}
 
-	var manifest Manifest
+	var manifest manifest.Manifest
 	if err := json.Unmarshal(rawManifest, &manifest); err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (c *Core) UpdateManifest(ctx context.Context, rawUpdateManifest []byte) err
 	}
 
 	// Unmarshal & check update manifest
-	var updateManifest Manifest
+	var updateManifest manifest.Manifest
 	if err := json.Unmarshal(rawUpdateManifest, &updateManifest); err != nil {
 		return err
 	}

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -13,14 +13,15 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func mustSetup() (*Core, *Manifest) {
-	var manifest Manifest
+func mustSetup() (*Core, *manifest.Manifest) {
+	var manifest manifest.Manifest
 	if err := json.Unmarshal([]byte(test.ManifestJSON), &manifest); err != nil {
 		panic(err)
 	}
@@ -227,7 +228,7 @@ func TestUpdateManifest(t *testing.T) {
 	assert.EqualValues(5, *c.updateManifest.Packages["frontend"].SecurityVersion)
 
 	// Test invalid manifests
-	var badUpdateManifest Manifest
+	var badUpdateManifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.UpdateManifest), &badUpdateManifest))
 
 	// Add non existing package, should fail
@@ -292,7 +293,7 @@ func TestUpdateManifest(t *testing.T) {
 	assert.Error(err)
 }
 
-func testManifestInvalidDebugCase(c *Core, manifest *Manifest, marblePackage quote.PackageProperties, assert *assert.Assertions, require *require.Assertions) *Core {
+func testManifestInvalidDebugCase(c *Core, manifest *manifest.Manifest, marblePackage quote.PackageProperties, assert *assert.Assertions, require *require.Assertions) *Core {
 	marblePackage.Debug = true
 	manifest.Packages["backend"] = marblePackage
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -175,7 +175,7 @@ func (c *Core) GetTLSCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certifi
 }
 
 func (c *Core) loadState() (*x509.Certificate, *ecdsa.PrivateKey, error) {
-	stateRaw, err := c.sealer.Unseal()
+	_, stateRaw, err := c.sealer.Unseal()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -228,11 +228,11 @@ func (c *Core) loadState() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	return cert, privk, err
 }
 
-func (c *Core) sealState() ([]byte, error) {
+func (c *Core) sealState() error {
 	// marshal private key
 	x509Encoded, err := x509.MarshalECPrivateKey(c.privk)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// seal with manifest set
@@ -247,9 +247,9 @@ func (c *Core) sealState() ([]byte, error) {
 	}
 	stateRaw, err := json.Marshal(state)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return c.sealer.Seal(stateRaw)
+	return c.sealer.Seal(nil, stateRaw)
 }
 
 func (c *Core) generateCert(dnsNames []string) (*x509.Certificate, *ecdsa.PrivateKey, error) {

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/google/uuid"
@@ -133,7 +134,7 @@ func TestGenerateSecrets(t *testing.T) {
 	require := require.New(t)
 
 	// Some secret maps which should represent secret entries from an unmarshaled JSON manifest
-	secretsToGenerate := map[string]Secret{
+	secretsToGenerate := map[string]manifest.Secret{
 		"rawTest1":                {Type: "symmetric-key", Size: 128, Shared: true},
 		"rawTest2":                {Type: "symmetric-key", Size: 256, Shared: true},
 		"cert-rsa-test":           {Type: "cert-rsa", Size: 2048, ValidFor: 365, Shared: true},
@@ -142,26 +143,26 @@ func TestGenerateSecrets(t *testing.T) {
 		"cert-ecdsa256-test":      {Type: "cert-ecdsa", Size: 256, ValidFor: 14, Shared: true},
 		"cert-ecdsa384-test":      {Type: "cert-ecdsa", Size: 384, ValidFor: 14, Shared: true},
 		"cert-ecdsa521-test":      {Type: "cert-ecdsa", Size: 521, ValidFor: 14, Shared: true},
-		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: Certificate{}, Shared: true},
+		"cert-rsa-specified-test": {Type: "cert-rsa", Size: 2048, Cert: manifest.Certificate{}, Shared: true},
 	}
 
-	secretsNoSize := map[string]Secret{
+	secretsNoSize := map[string]manifest.Secret{
 		"noSize": {Type: "symmetric-key", Shared: true},
 	}
 
-	secretsInvalidType := map[string]Secret{
+	secretsInvalidType := map[string]manifest.Secret{
 		"unknownType": {Type: "crap", Shared: true},
 	}
 
-	secretsEd25519WrongKeySize := map[string]Secret{
+	secretsEd25519WrongKeySize := map[string]manifest.Secret{
 		"cert-ed25519-invalidsize": {Type: "cert-ed25519", Size: 384, Shared: true},
 	}
 
-	secretsECDSAWrongKeySize := map[string]Secret{
+	secretsECDSAWrongKeySize := map[string]manifest.Secret{
 		"cert-ecdsa-invalidsize": {Type: "cert-ecdsa", Size: 512, Shared: true},
 	}
 
-	secretsEmptyMap := map[string]Secret{}
+	secretsEmptyMap := map[string]manifest.Secret{}
 
 	c := NewCoreWithMocks()
 
@@ -181,12 +182,12 @@ func TestGenerateSecrets(t *testing.T) {
 
 	// Check if we get an empty secret map as output for an empty map as input
 	generatedSecrets, err = c.generateSecrets(context.TODO(), secretsEmptyMap, uuid.Nil)
-	assert.IsType(map[string]Secret{}, generatedSecrets)
+	assert.IsType(map[string]manifest.Secret{}, generatedSecrets)
 	assert.Len(generatedSecrets, 0)
 
 	// Check if we get an empty secret map as output for nil
 	generatedSecrets, err = c.generateSecrets(context.TODO(), nil, uuid.Nil)
-	assert.IsType(map[string]Secret{}, generatedSecrets)
+	assert.IsType(map[string]manifest.Secret{}, generatedSecrets)
 	assert.Len(generatedSecrets, 0)
 
 	// If no size is specified, the function should fail

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -23,6 +23,7 @@ import (
 	libMarble "github.com/edgelesssys/ertgolib/marble"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
+	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/edgelesssys/marblerun/util"
@@ -51,7 +52,8 @@ func TestActivate(t *testing.T) {
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &MockSealer{}
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, sealer, zapLogger)
+	recovery := recovery.NewSinglePartyRecovery()
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, sealer, recovery, zapLogger)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -388,7 +390,8 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &MockSealer{}
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, sealer, zapLogger)
+	recovery := recovery.NewSinglePartyRecovery()
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, sealer, recovery, zapLogger)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -415,7 +418,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	spawner.newMarble("frontend", "Azure", false)
 
 	// Use a new core and test if updated manifest persisted after restart
-	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, sealer, zapLogger)
+	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, sealer, recovery, zapLogger)
 	require.NoError(err)
 	assert.Equal(stateAcceptingMarbles, coreServer2.state)
 	assert.EqualValues(5, *coreServer2.updateManifest.Packages["frontend"].SecurityVersion)

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	libMarble "github.com/edgelesssys/ertgolib/marble"
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/test"
@@ -38,7 +39,7 @@ func TestActivate(t *testing.T) {
 	require := require.New(t)
 
 	// parse manifest
-	var manifest Manifest
+	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
 
 	// setup mock zaplogger which can be passed to Core
@@ -100,7 +101,7 @@ func TestActivate(t *testing.T) {
 }
 
 type marbleSpawner struct {
-	manifest               Manifest
+	manifest               manifest.Manifest
 	validator              *quote.MockValidator
 	issuer                 quote.Issuer
 	coreServer             *Core
@@ -288,16 +289,16 @@ func TestParseSecrets(t *testing.T) {
 	}
 
 	// Define secrets
-	testSecrets := map[string]Secret{
+	testSecrets := map[string]manifest.Secret{
 		"mysecret":          {Type: "symmetric-key", Size: 16, Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
 		"anothercoolsecret": {Type: "symmetric-key", Size: 8, Public: []byte{7, 6, 5, 4, 3, 2, 1, 0}, Private: []byte{7, 6, 5, 4, 3, 2, 1, 0}},
-		"testcertificate":   {Type: "cert-rsa", Size: 2048, Cert: Certificate(*testCert), Public: pubKey, Private: privKey},
+		"testcertificate":   {Type: "cert-rsa", Size: 2048, Cert: manifest.Certificate(*testCert), Public: pubKey, Private: privKey},
 	}
 
 	testReservedSecrets := reservedSecrets{
-		RootCA:     Secret{Public: []byte{0, 0, 42}, Private: []byte{0, 0, 7}},
-		MarbleCert: Secret{Public: []byte{42, 0, 0}, Private: []byte{7, 0, 0}},
-		SealKey:    Secret{Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+		RootCA:     manifest.Secret{Public: []byte{0, 0, 42}, Private: []byte{0, 0, 7}},
+		MarbleCert: manifest.Secret{Public: []byte{42, 0, 0}, Private: []byte{7, 0, 0}},
+		SealKey:    manifest.Secret{Public: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, Private: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
 	}
 
 	testWrappedSecrets := secretsWrapper{
@@ -375,7 +376,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	require := require.New(t)
 
 	// parse manifest
-	var manifest Manifest
+	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
 
 	// setup mock zaplogger which can be passed to Core

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -36,8 +36,8 @@ type Manifest struct {
 	Clients map[string][]byte
 	// Secrets holds user-specified secrets, which should be generated and later on stored in a marble (if not shared) or in the core (if shared).
 	Secrets map[string]Secret
-	// RecoveryKey holds a RSA public key to encrypt the state encryption key, which gets returned over the Client API when setting a manifest.
-	RecoveryKey string
+	// RecoveryKeys holds one or multiple RSA public keys to encrypt multiple secrets, which can be used to decrypt the sealed state again in case the encryption key on disk was corrupted somehow.
+	RecoveryKeys map[string]string
 }
 
 // Marble describes a service in the mesh that should be handled and verified by the Coordinator

--- a/coordinator/recovery/recovery.go
+++ b/coordinator/recovery/recovery.go
@@ -1,0 +1,62 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package recovery
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+)
+
+// Recovery describes an interface which the core can use to choose a recoverer (e.g. only single-party recoverer, multi-party recoverer) depending on the version of Marblerun.
+type Recovery interface {
+	GenerateEncryptionKey(recoveryKeys map[string]string) ([]byte, error)
+	GenerateRecoveryData(recoveryKeys map[string]string) (map[string][]byte, []byte, error)
+	RecoverKey(secret []byte) (int, []byte, error)
+	GetRecoveryData() ([]byte, error)
+	SetRecoveryData(data []byte) error
+}
+
+func parseRSAPublicKeyFromPEM(pemContent string) (*rsa.PublicKey, error) {
+	// Retrieve RSA public key for potential key recovery
+	block, _ := pem.Decode([]byte(pemContent))
+
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, errors.New("invalid public key in manifest")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	recoveryk, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("unsupported type of public key")
+	}
+
+	return recoveryk, nil
+}
+
+func generateRandomKey() ([]byte, error) {
+	generatedValue := make([]byte, 16)
+	_, err := rand.Read(generatedValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return generatedValue, nil
+}
+
+func hash(input []byte) string {
+	hashSum := sha256.Sum256(input)
+	hashSumString := hex.EncodeToString(hashSum[:])
+
+	return hashSumString
+}

--- a/coordinator/recovery/single.go
+++ b/coordinator/recovery/single.go
@@ -1,0 +1,77 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package recovery
+
+import (
+	"errors"
+
+	"github.com/edgelesssys/marblerun/util"
+)
+
+// SinglePartyRecovery is a recoverer with support for single-party recovery only
+type SinglePartyRecovery struct {
+	encryptionKey []byte
+}
+
+// NewSinglePartyRecovery generates a single-party recoverer which the core can use to call recovery functions
+func NewSinglePartyRecovery() *SinglePartyRecovery {
+	return &SinglePartyRecovery{}
+}
+
+// GenerateEncryptionKey generates an encryption key according to the implicitly defined recovery mode
+func (r *SinglePartyRecovery) GenerateEncryptionKey(recoveryKeys map[string]string) ([]byte, error) {
+
+	// Generate a single random key for single-party recovery, or generate multiple keys and XOR them together for multi-party recovery
+	if len(recoveryKeys) > 1 {
+		return nil, errors.New("multi-party recovery is not supported in this version of Marblerun")
+	}
+
+	var err error
+	r.encryptionKey, err = generateRandomKey()
+
+	if err != nil {
+		return nil, err
+	}
+	return r.encryptionKey, nil
+}
+
+// GenerateRecoveryData generates the recovery data which is returned to the user
+func (r *SinglePartyRecovery) GenerateRecoveryData(recoveryKeys map[string]string) (map[string][]byte, []byte, error) {
+	// For single party recovery, just create a new map here and return one single key
+	secretMap := make(map[string][]byte, 1)
+	for index, value := range recoveryKeys {
+		// Parse RSA Public Key
+		recoveryk, err := parseRSAPublicKeyFromPEM(value)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Encrypt encryption key with user-specified RSA public key
+		secretMap[index], err = util.EncryptOAEP(recoveryk, r.encryptionKey)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Return freshly generated map for single-party recovery
+	return secretMap, nil, nil
+}
+
+// RecoverKey is called by the client api and directly returns the recovery key (this is different for multi-party recovery in other versions of Marblerun)
+func (r *SinglePartyRecovery) RecoverKey(secret []byte) (int, []byte, error) {
+	return 0, secret, nil
+}
+
+// GetRecoveryData returns the current recovery hash map. Given that we do not need to store any additional data in the state for Single Party Recovery, it does nothing here.
+func (r *SinglePartyRecovery) GetRecoveryData() ([]byte, error) {
+	return nil, nil
+}
+
+// SetRecoveryData sets the recovery hash map retrieved from the sealer on (failed) decryption. Given that we do not need to store any additional data in the state for Single Party Recovery, it does nothing here.
+func (r *SinglePartyRecovery) SetRecoveryData(data []byte) error {
+	return nil
+}

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -89,7 +89,7 @@ func TestManifestWithRecoveryKey(t *testing.T) {
 	// Decrypt recovery data and see if it matches the key used by the mock sealer
 	recoveryData, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, test.RecoveryPrivateKey, encryptedRecoveryData, nil)
 	require.NoError(err)
-	require.EqualValues([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, recoveryData)
+	require.NotNil(recoveryData)
 }
 
 func TestUpdate(t *testing.T) {

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -167,7 +167,9 @@ var ManifestJSONWithRecoveryKey string = `{
 	"Admins": {
 		"admin": "` + pemToJSONString(AdminCert) + `"
 	},
-	"RecoveryKey": "` + pemToJSONString(RecoveryPublicKey) + `"
+	"RecoveryKeys": {
+		"testRecKey1": "` + pemToJSONString(RecoveryPublicKey) + `"
+	}
 }`
 
 // IntegrationManifestJSON is a test manifest
@@ -242,7 +244,9 @@ var IntegrationManifestJSON string = `{
 	"Admins": {
 		"admin": "` + pemToJSONString(AdminCert) + `"
 	},
-	"RecoveryKey": "` + pemToJSONString(RecoveryPublicKey) + `"
+	"RecoveryKeys": {
+		"testRecKey1": "` + pemToJSONString(RecoveryPublicKey) + `"
+	}
 }`
 
 func generateTestRecoveryKey() (publicKeyPem []byte, privateKey *rsa.PrivateKey) {

--- a/util/util.go
+++ b/util/util.go
@@ -7,7 +7,10 @@
 package util
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -55,4 +58,26 @@ func MustGetLocalListenerAndAddr() (net.Listener, string) {
 		panic(err)
 	}
 	return listener, localhost + port
+}
+
+// XORBytes XORs two byte slices
+func XORBytes(a, b []byte) ([]byte, error) {
+	if len(a) != len(b) {
+		return nil, fmt.Errorf("lengths of byte slices differ: %v != %v", len(a), len(b))
+	}
+	result := make([]byte, len(a))
+	for i := range result {
+		result[i] = a[i] ^ b[i]
+	}
+	return result, nil
+}
+
+// EncryptOAEP is a wrapper function for rsa.EncryptOAEP for a nicer syntax
+func EncryptOAEP(pub *rsa.PublicKey, plaintext []byte) ([]byte, error) {
+	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, plaintext, nil)
+}
+
+// DecryptOAEP is a wrapper function for rsa.DecryptOAEP for a nicer syntax
+func DecryptOAEP(priv *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
+	return rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, ciphertext, nil)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeriveKey(t *testing.T) {
@@ -29,4 +30,17 @@ func TestMustGetenv(t *testing.T) {
 	assert.NoError(os.Setenv(name, value))
 	assert.Equal(value, MustGetenv(name))
 	assert.NoError(os.Unsetenv(name))
+}
+
+func TestXORBytes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	firstValue := []byte{0xD, 0xE, 0xA, 0xD, 0xC, 0x0, 0xD, 0xE}
+	secondValue := []byte{0xB, 0xA, 0xD, 0xD, 0xC, 0xA, 0xF, 0xE}
+	expectedResult := []byte{0x6, 0x4, 0x7, 0x0, 0x0, 0xa, 0x2, 0x0}
+
+	result, err := XORBytes(firstValue, secondValue)
+	require.NoError(err)
+	assert.Equal(expectedResult, result)
 }


### PR DESCRIPTION
This PR makes the recovery module interchangeable for upcoming features such as multi-party recovery.

Changes from the already reviewed internal version:

- recoveryMap is always loaded into the core, not just when an unsealing error occurs 
- GetRecoveryData() added (for when we need to reseal the state for an update manifest)
- Properly some other minor stuff to accompany changes from other changes to Marblerun while this was in development

Leftover issues:

- The integration test can fail badly across tests when one of the subfunctions fails, as they often invoke `require` but no defer functions are set in them as we want to return the cfgs and alive processes for the calling main function. This can cause the next test function to work with an unclean coordinator, causing further test failures due to an unexpected state.

Guess we need an idea on how to cleanup a failure in this subfunction in a way which is not totally ugly, so any ideas are appreciated here.

Apart from that, this is ready for a final review.