### PR TITLE
AB#495: Use Intermediate CA for Marble authentication

### DIFF
--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -183,17 +183,25 @@ func (c *Core) inSimulationMode() bool {
 // GetTLSConfig gets the core's TLS configuration
 func (c *Core) GetTLSConfig() (*tls.Config, error) {
 	return &tls.Config{
-		GetCertificate: c.GetTLSCertificate,
+		GetCertificate: c.GetTLSRootCertificate,
 		ClientAuth:     tls.RequestClientCert,
 	}, nil
 }
 
-// GetTLSCertificate creates a TLS certificate for the Coordinators self-signed x509 certificate
-func (c *Core) GetTLSCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+// GetTLSRootCertificate creates a TLS certificate for the Coordinators self-signed x509 certificate
+func (c *Core) GetTLSRootCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	if c.state == stateUninitialized {
 		return nil, errors.New("don't have a cert yet")
 	}
 	return util.TLSCertFromDER(c.rootCert.Raw, c.rootPrivK), nil
+}
+
+// GetTLSIntermediateCertificate creates a TLS certificate for the Coordinator's x509 intermediate certificate based on the self-signed x509 root certificate
+func (c *Core) GetTLSIntermediateCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if c.state == stateUninitialized {
+		return nil, errors.New("don't have a cert yet")
+	}
+	return util.TLSCertFromDER(c.intermediateCert.Raw, c.intermediatePrivK), nil
 }
 
 func (c *Core) loadState() (*x509.Certificate, *ecdsa.PrivateKey, *x509.Certificate, *ecdsa.PrivateKey, error) {

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -25,7 +25,7 @@ func TestCore(t *testing.T) {
 
 	c := NewCoreWithMocks()
 	assert.Equal(stateAcceptingManifest, c.state)
-	assert.Equal(CoordinatorName, c.cert.Subject.CommonName)
+	assert.Equal(coordinatorName, c.rootCert.Subject.CommonName)
 
 	cert, err := c.GetTLSCertificate(nil)
 	assert.NoError(err)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -173,7 +173,7 @@ func TestGenerateSecrets(t *testing.T) {
 	c := NewCoreWithMocks()
 
 	// This should return valid secrets
-	generatedSecrets, err := c.generateSecrets(context.TODO(), secretsToGenerate, uuid.Nil)
+	generatedSecrets, err := c.generateSecrets(context.TODO(), secretsToGenerate, uuid.Nil, c.rootCert, c.rootPrivK)
 	require.NoError(err)
 	// Check if rawTest1 has 128 Bits/16 Bytes and rawTest2 256 Bits/8 Bytes
 	assert.Len(generatedSecrets["rawTest1"].Public, 16)
@@ -187,28 +187,28 @@ func TestGenerateSecrets(t *testing.T) {
 	assert.NotNil(generatedSecrets["cert-rsa-specified-test"].Cert.Raw)
 
 	// Check if we get an empty secret map as output for an empty map as input
-	generatedSecrets, err = c.generateSecrets(context.TODO(), secretsEmptyMap, uuid.Nil)
+	generatedSecrets, err = c.generateSecrets(context.TODO(), secretsEmptyMap, uuid.Nil, c.rootCert, c.rootPrivK)
 	assert.IsType(map[string]manifest.Secret{}, generatedSecrets)
 	assert.Len(generatedSecrets, 0)
 
 	// Check if we get an empty secret map as output for nil
-	generatedSecrets, err = c.generateSecrets(context.TODO(), nil, uuid.Nil)
+	generatedSecrets, err = c.generateSecrets(context.TODO(), nil, uuid.Nil, c.rootCert, c.rootPrivK)
 	assert.IsType(map[string]manifest.Secret{}, generatedSecrets)
 	assert.Len(generatedSecrets, 0)
 
 	// If no size is specified, the function should fail
-	_, err = c.generateSecrets(context.TODO(), secretsNoSize, uuid.Nil)
+	_, err = c.generateSecrets(context.TODO(), secretsNoSize, uuid.Nil, c.rootCert, c.rootPrivK)
 	assert.Error(err)
 
 	// Also, it should fail if we try to generate a secret with an unknown type
-	_, err = c.generateSecrets(context.TODO(), secretsInvalidType, uuid.Nil)
+	_, err = c.generateSecrets(context.TODO(), secretsInvalidType, uuid.Nil, c.rootCert, c.rootPrivK)
 	assert.Error(err)
 
 	// If Ed25519 key size is specified, we should fail
-	_, err = c.generateSecrets(context.TODO(), secretsEd25519WrongKeySize, uuid.Nil)
+	_, err = c.generateSecrets(context.TODO(), secretsEd25519WrongKeySize, uuid.Nil, c.rootCert, c.rootPrivK)
 	assert.Error(err)
 
 	// However, for ECDSA we fail as we can have multiple curves
-	_, err = c.generateSecrets(context.TODO(), secretsECDSAWrongKeySize, uuid.Nil)
+	_, err = c.generateSecrets(context.TODO(), secretsECDSAWrongKeySize, uuid.Nil, c.rootCert, c.rootPrivK)
 	assert.Error(err)
 }

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -27,7 +27,7 @@ func TestCore(t *testing.T) {
 	assert.Equal(stateAcceptingManifest, c.state)
 	assert.Equal(coordinatorName, c.rootCert.Subject.CommonName)
 
-	cert, err := c.GetTLSCertificate(nil)
+	cert, err := c.GetTLSRootCertificate(nil)
 	assert.NoError(err)
 	assert.NotNil(cert)
 
@@ -69,7 +69,7 @@ func TestSeal(t *testing.T) {
 	require.NoError(err)
 
 	// Get certificate and signature.
-	cert, err := c.GetTLSCertificate(nil)
+	cert, err := c.GetTLSRootCertificate(nil)
 	assert.NoError(err)
 	signature := c.GetManifestSignature(context.TODO())
 
@@ -78,7 +78,7 @@ func TestSeal(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(stateAcceptingMarbles, c2.state)
 
-	cert2, err := c2.GetTLSCertificate(nil)
+	cert2, err := c2.GetTLSRootCertificate(nil)
 	assert.NoError(err)
 	assert.Equal(cert, cert2)
 

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -75,7 +75,7 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (*rpc.Activ
 	}
 
 	// Generate user-defined unique (= per marble) secrets
-	secrets, err := c.generateSecrets(ctx, c.manifest.Secrets, marbleUUID)
+	secrets, err := c.generateSecrets(ctx, c.manifest.Secrets, marbleUUID, c.intermediateCert, c.intermediatePrivK)
 	if err != nil {
 		c.zaplogger.Error("Could not generate specified secrets for the given manifest.", zap.Error(err))
 		return nil, err

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -182,7 +182,7 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	ms.assert.NotNil(p)
 	newCert, err := x509.ParseCertificate(p.Bytes)
 	ms.assert.NoError(err)
-	ms.assert.Equal(CoordinatorName, newCert.Issuer.CommonName)
+	ms.assert.Equal(coordinatorName, newCert.Issuer.CommonName)
 	// Check CommonName
 	_, err = uuid.Parse(newCert.Subject.CommonName)
 	ms.assert.NoError(err, "cert.Subject.CommonName is not a valid UUID: %v", err)
@@ -194,7 +194,7 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	ms.assert.Equal(cert.DNSNames, newCert.DNSNames)
 	ms.assert.Equal(cert.IPAddresses, newCert.IPAddresses)
 	// Check Signature
-	ms.assert.NoError(ms.coreServer.cert.CheckSignature(newCert.SignatureAlgorithm, newCert.RawTBSCertificate, newCert.Signature))
+	ms.assert.NoError(ms.coreServer.rootCert.CheckSignature(newCert.SignatureAlgorithm, newCert.RawTBSCertificate, newCert.Signature))
 
 	// Validate generated secret (only specified in backend_first)
 	if marbleType == "backend_first" {

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -57,7 +57,7 @@ type recoveryStatusResp struct {
 // The effective TCP address is returned via `addrChan`.
 func RunMarbleServer(core *core.Core, addr string, addrChan chan string, errChan chan error, zapLogger *zap.Logger) {
 	tlsConfig := tls.Config{
-		GetCertificate: core.GetTLSCertificate,
+		GetCertificate: core.GetTLSIntermediateCertificate,
 		// NOTE: we'll verify the cert later using the given quote
 		ClientAuth: tls.RequireAnyClientCert,
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/edgelesssys/era v0.1.0
-	github.com/edgelesssys/ertgolib v0.1.4
+	github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855
 	github.com/gofrs/flock v0.8.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edgelesssys/era v0.1.0 h1:13xUhHo61VE0k4xUKPVuRLfpWbMuM0WKBWs3CgeWLDM=
 github.com/edgelesssys/era v0.1.0/go.mod h1:rEv/EPEWTUpu8gGOUWp97Bk1kFFvgYwcJY0yA4cKG8U=
 github.com/edgelesssys/ertgolib v0.1.1/go.mod h1:QV27eWmoYHCNMkPMnz2XcER13+XdhPyG5qLQu5iDL0I=
-github.com/edgelesssys/ertgolib v0.1.4 h1:hncFuwrB2wz9LqsOce5UUwer4wA0aaRjnN35dT8/jtw=
-github.com/edgelesssys/ertgolib v0.1.4/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
+github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855 h1:3iTzGhF0FJf5ZFDPfU54NAfObJwlexJYFR3ShITYlEk=
+github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -399,7 +399,7 @@ func startCoordinator(cfg coordinatorConfig) *os.Process {
 	output := startCommand(cmd)
 
 	client := http.Client{Transport: transportSkipVerify}
-	url := url.URL{Scheme: "https", Host: clientServerAddr, Path: "quote"}
+	url := url.URL{Scheme: "https", Host: clientServerAddr, Path: "status"}
 
 	log.Println("Coordinator starting...")
 	for {


### PR DESCRIPTION
This still lacks some good tests cases to check against the desired behavior, but I guess it can already be checked for sanity (it does pass all current tests).

Right now, the following certificates are used:

- Marbles: Intermediate CA
- Quoting: Root CA
- Secrets (non-shared symmetric-key derivation): Root CA Private Key
- Secrets (certificates): Intermediate CA

The intermediate CA uses a separate private/public key pair than the root CA. 

Shared Certificate secrets are re-generated when a new manifest is set and the old ones in the core will be overwritten (or should, there's no test for that yet ;)). Non-shared certificate secrets are regenerated when a Marble is activated as before , so theoretically nothing should've changed here in terms of general behavior.

Feedback would be appreciated :)