### PR TITLE
AB#592 Add CLI namespace add/get commands

### DIFF
--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -16,12 +16,13 @@ const marblerunAnnotation = "marblerun/monitor"
 func newNamespaceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace",
-		Short: "Manages marblerun namespaces",
-		Long:  "Manages marblerun namespaces",
+		Short: "Manages namespaces associated with Marblerun installations",
+		Long:  "Manages namespaces associated with Marblerun installations",
 		Args:  cobra.NoArgs,
 	}
 	cmd.AddCommand(newNameSpaceAdd())
-	cmd.AddCommand(newNameSpaceGet())
+	cmd.AddCommand(newNameSpaceList())
+	cmd.AddCommand(newNameSpaceRemove())
 
 	return cmd
 }

--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type envSettings struct {
+	namespace string
+	config    *genericclioptions.ConfigFlags
+}
+
+// injected monitor annotation
+const marblerunAnnotation = "marblerun/monitor"
+
+func newNamespaceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "namespace",
+		Short: "Manages marblerun namespaces",
+		Long:  "Manages marblerun namespaces",
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newNameSpaceAdd())
+	cmd.AddCommand(newNameSpaceGet())
+
+	return cmd
+}

--- a/cli/cmd/namespaceAdd.go
+++ b/cli/cmd/namespaceAdd.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+func newNameSpaceAdd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add NAMESPACE ...",
+		Short: "Add namespaces to marblerun coordinator",
+		Long:  `Add namespaces to marblerun coordinator`,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespaces := args
+
+			localSettings := envSettings{
+				namespace: "marblerun",
+			}
+			localSettings.config = &genericclioptions.ConfigFlags{
+				Namespace: &localSettings.namespace,
+			}
+
+			config, err := localSettings.config.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			clientSet, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return err
+			}
+
+			return cliNameSpaceAdd(namespaces, clientSet)
+		},
+		SilenceUsage: true,
+	}
+	return cmd
+}
+
+// cliNameSpaceAdd adds specified namespaces to the marblerun coordinator
+func cliNameSpaceAdd(namespaces []string, clientSet kubernetes.Interface) error {
+	for _, ns := range namespaces {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var patch string
+		patch = fmt.Sprintf(`
+{
+	"metadata": {
+		"labels": {
+			"%s": "marblerun"
+		}
+	}
+}`, marblerunAnnotation)
+		// apply patch to namespace
+		if _, err := clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, ""); err != nil {
+			fmt.Printf("Could not apply patch\n")
+			return err
+		}
+
+		fmt.Printf("Added namespace [%s] to marblerun-coordinator\n", ns)
+	}
+	return nil
+}

--- a/cli/cmd/namespaceAdd.go
+++ b/cli/cmd/namespaceAdd.go
@@ -14,8 +14,8 @@ import (
 func newNameSpaceAdd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add NAMESPACE ...",
-		Short: "Add namespaces to marblerun coordinator",
-		Long:  `Add namespaces to marblerun coordinator`,
+		Short: "Add namespaces to a Marblerun mesh",
+		Long:  `Add namespaces to a Marblerun mesh`,
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespaces := args
@@ -64,7 +64,7 @@ func cliNameSpaceAdd(namespaces []string, clientSet kubernetes.Interface) error 
 			return err
 		}
 
-		fmt.Printf("Added namespace [%s] to marblerun-coordinator\n", ns)
+		fmt.Printf("Added namespace [%s] to Marblerun mesh\n", ns)
 	}
 	return nil
 }

--- a/cli/cmd/namespaceGet.go
+++ b/cli/cmd/namespaceGet.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+func newNameSpaceGet() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Shows all namespaces added to marblerun",
+		Long:  `Shows all namespaces added to marblerun`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			localSettings := envSettings{
+				namespace: "marblerun",
+			}
+			localSettings.config = &genericclioptions.ConfigFlags{
+				Namespace: &localSettings.namespace,
+			}
+
+			config, err := localSettings.config.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			clientSet, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return err
+			}
+
+			return cliNameSpaceGet(clientSet)
+		},
+		SilenceUsage: true,
+	}
+	return cmd
+}
+
+// cliNameSpaceGet prints out all namespaces added to marblerun
+func cliNameSpaceGet(clientSet kubernetes.Interface) error {
+	namespaces, err := selectNamespaces(clientSet)
+	if err != nil {
+		return err
+	}
+
+	if len(namespaces.Items) == 0 {
+		fmt.Printf("No namespaces have been added to marblerun\n")
+	}
+
+	for _, ns := range namespaces.Items {
+		fmt.Printf("%s\n", ns.Name)
+	}
+
+	return nil
+}
+
+func selectNamespaces(clientSet kubernetes.Interface) (*v1.NamespaceList, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	selector := fmt.Sprintf("%s=marblerun", marblerunAnnotation)
+
+	return clientSet.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+}

--- a/cli/cmd/namespaceList.go
+++ b/cli/cmd/namespaceList.go
@@ -11,11 +11,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func newNameSpaceGet() *cobra.Command {
+func newNameSpaceList() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: "Shows all namespaces added to marblerun",
-		Long:  `Shows all namespaces added to marblerun`,
+		Use:   "list",
+		Short: "Lists all namespaces added to a Marblerun mesh",
+		Long:  `Lists all namespaces added to a Marblerun mesh`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			localSettings := envSettings{
@@ -35,22 +35,22 @@ func newNameSpaceGet() *cobra.Command {
 				return err
 			}
 
-			return cliNameSpaceGet(clientSet)
+			return cliNameSpaceList(clientSet)
 		},
 		SilenceUsage: true,
 	}
 	return cmd
 }
 
-// cliNameSpaceGet prints out all namespaces added to marblerun
-func cliNameSpaceGet(clientSet kubernetes.Interface) error {
+// cliNameSpaceList prints out all namespaces added to marblerun
+func cliNameSpaceList(clientSet kubernetes.Interface) error {
 	namespaces, err := selectNamespaces(clientSet)
 	if err != nil {
 		return err
 	}
 
 	if len(namespaces.Items) == 0 {
-		fmt.Printf("No namespaces have been added to marblerun\n")
+		fmt.Printf("No namespaces have been added to the Marblerun mesh\n")
 	}
 
 	for _, ns := range namespaces.Items {

--- a/cli/cmd/namespaceRemove.go
+++ b/cli/cmd/namespaceRemove.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+func newNameSpaceRemove() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove NAMESPACE",
+		Short: "Remove namespaces from a Marblerun mesh",
+		Long:  `Remove namespaces from a Marblerun mesh`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			localSettings := envSettings{
+				namespace: "marblerun",
+			}
+			localSettings.config = &genericclioptions.ConfigFlags{
+				Namespace: &localSettings.namespace,
+			}
+
+			config, err := localSettings.config.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+
+			clientSet, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return err
+			}
+
+			namespace := args[0]
+
+			return cliNameSpaceRemove(namespace, clientSet)
+		},
+		SilenceUsage: true,
+	}
+	return cmd
+}
+
+func cliNameSpaceRemove(namespace string, clientSet kubernetes.Interface) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	k8sNamespace, err := clientSet.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	val, exists := k8sNamespace.ObjectMeta.Labels[marblerunAnnotation]
+	if exists {
+		if val == "marblerun" {
+			patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"labels": {
+			"%s": null
+		}
+	}
+}
+`, marblerunAnnotation)
+			if _, err := clientSet.CoreV1().Namespaces().Patch(ctx, namespace, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, ""); err != nil {
+				return err
+			}
+
+			fmt.Printf("Namespace [%s] succesfully removed from the Marblerun mesh\n", namespace)
+		} else {
+			return fmt.Errorf("unexpected value in namespace label: %s", val)
+		}
+	} else {
+		return fmt.Errorf("Namespace [%s] does not belong to the Marblerun mesh", namespace)
+	}
+
+	return nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -20,4 +20,5 @@ func init() {
 	rootCmd.AddCommand(newInstallCmd())
 	rootCmd.AddCommand(newManifestCmd())
 	rootCmd.AddCommand(newStatusCmd())
+	rootCmd.AddCommand(newNamespaceCmd())
 }

--- a/go.mod
+++ b/go.mod
@@ -23,5 +23,9 @@ require (
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.5.1
+	k8s.io/api v0.20.1
+	k8s.io/apimachinery v0.20.1
+	k8s.io/cli-runtime v0.20.1
+	k8s.io/client-go v0.20.1
 	rsc.io/letsencrypt v0.0.3 // indirect
 )


### PR DESCRIPTION
currently the add command injects 'marblerun/monitor=marblerun' into the label field of the selected namespaces, this should maybe be changes to a more fitting string