### PR TITLE
AB#617: Use a consistent JSON output format for the API

### DIFF
--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
 )
 
 func newManifestGet() *cobra.Command {
@@ -58,10 +59,11 @@ func cliManifestGet(targetFile string, host string, configFilename string, insec
 	switch resp.StatusCode {
 	case http.StatusOK:
 		respBody, err := ioutil.ReadAll(resp.Body)
+		manifestData := gjson.GetBytes(respBody, "data")
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(targetFile, respBody, 0644); err != nil {
+		if err := ioutil.WriteFile(targetFile, []byte(manifestData.String()), 0644); err != nil {
 			return err
 		}
 		fmt.Printf("Manifest written to: %s.\n", targetFile)

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
 )
 
 type coordinatorResponse struct {
@@ -73,8 +74,9 @@ func cliRecover(host string, keyFile string, configFilename string, insecure boo
 		}
 
 		// if a response was sent another recovery key will be needed, print message to user
+		jsonResponse := gjson.GetBytes(respBody, "data")
 		var response coordinatorResponse
-		if err := json.Unmarshal(respBody, &response); err != nil {
+		if err := json.Unmarshal([]byte(jsonResponse.String()), &response); err != nil {
 			return err
 		}
 		fmt.Printf("%s \n", response)

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -29,8 +29,8 @@ The Coordinator will be in one of these 4 states:
 `
 
 type statusResponse struct {
-	Code   int    `json:"Code"`
-	Status string `json:"Status"`
+	StatusCode    int    `json:"StatusCode"`
+	StatusMessage string `json:"StatusMessage"`
 }
 
 func newStatusCmd() *cobra.Command {
@@ -82,7 +82,7 @@ func cliStatus(host string, configFilename string, insecure bool) error {
 		if err := json.Unmarshal([]byte(jsonResponse.String()), &statusResp); err != nil {
 			return err
 		}
-		fmt.Printf("%d: %s\n", statusResp.Code, statusResp.Status)
+		fmt.Printf("%d: %s\n", statusResp.StatusCode, statusResp.StatusMessage)
 	default:
 		return fmt.Errorf("error connecting to server: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
 )
 
 const statusDesc = `
@@ -19,7 +20,7 @@ The Coordinator will be in one of these 4 states:
 
   1 uninitialized: Fresh start, initializing the Coordinator.
 	The Coordinator is in its starting phase.
-	
+
   2 waiting for manifest: Waiting for user input on /manifest.
 	Send a manifest to the Coordinator using [marblerun manifest set] to start.
 
@@ -76,8 +77,9 @@ func cliStatus(host string, configFilename string, insecure bool) error {
 		if err != nil {
 			return err
 		}
+		jsonResponse := gjson.GetBytes(respBody, "data")
 		var statusResp statusResponse
-		if err := json.Unmarshal(respBody, &statusResp); err != nil {
+		if err := json.Unmarshal([]byte(jsonResponse.String()), &statusResp); err != nil {
 			return err
 		}
 		fmt.Printf("%d: %s\n", statusResp.Code, statusResp.Status)

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -130,7 +130,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 			}
 
 			// If recovery data is set, return it
-			if recoverySecretMap != nil {
+			if len(recoverySecretMap) > 0 {
 				secretMap := make(map[string]string, len(recoverySecretMap))
 				for name, secret := range recoverySecretMap {
 					secretMap[name] = base64.StdEncoding.EncodeToString(secret)

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -42,8 +42,8 @@ type certQuoteResp struct {
 	Quote []byte
 }
 type statusResp struct {
-	Code   int
-	Status string
+	StatusCode   int
+	StatusMessage string
 }
 type manifestSignatureResp struct {
 	ManifestSignature string

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestQuote(t *testing.T) {
@@ -57,7 +58,7 @@ func TestManifest(t *testing.T) {
 	require.Equal(http.StatusOK, resp.Code)
 
 	sig := hex.EncodeToString(c.GetManifestSignature(context.TODO()))
-	assert.JSONEq(`{"ManifestSignature":"`+sig+`"}`, resp.Body.String())
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":"`+sig+`"}}`, resp.Body.String())
 
 	// try setting manifest again, should fail
 	req = httptest.NewRequest(http.MethodPost, "/manifest", strings.NewReader(test.ManifestJSON))
@@ -80,7 +81,8 @@ func TestManifestWithRecoveryKey(t *testing.T) {
 
 	// Decode JSON response from server
 	var b64EncryptedRecoveryData recoveryDataResp
-	require.NoError(json.Unmarshal(resp.Body.Bytes(), &b64EncryptedRecoveryData))
+	b64EncryptedRecoveryDataJSON := gjson.Get(resp.Body.String(), "data")
+	require.NoError(json.Unmarshal([]byte(b64EncryptedRecoveryDataJSON.String()), &b64EncryptedRecoveryData))
 
 	var encryptedRecoveryData []byte
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -276,7 +276,7 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	log.Println("Performed recovery, now checking status again...")
 	statusResponse, err := getStatus()
 	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.Code").Int(), "Server is in wrong status after recovery.")
+	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
 
 	// Verify if old certificate is still valid
 	coordinatorProc = verifyCertAfterRecovery(cert, coordinatorProc, cfg, assert, require)
@@ -708,7 +708,7 @@ func triggerRecovery(manifest manifest.Manifest, assert *assert.Assertions, requ
 	log.Println("Checking status...")
 	statusResponse, err := getStatus()
 	require.NoError(err)
-	assert.EqualValues(1, gjson.Get(statusResponse, "data.Code").Int(), "Server is not in recovery state, but should be.")
+	assert.EqualValues(1, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is not in recovery state, but should be.")
 
 	return recoveryResponse, coordinatorProc, serverProc, cfg, serverCfg, cert
 }
@@ -739,7 +739,7 @@ func verifyCertAfterRecovery(cert string, coordinatorProc *os.Process, cfg coord
 	log.Println("Restarted instance, now let's see if the state can be restored again successfully.")
 	statusResponse, err := getStatus()
 	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.Code").Int(), "Server is in wrong status after recovery.")
+	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
 
 	// test with certificate
 	log.Println("Verifying certificate after restart.")
@@ -756,7 +756,7 @@ func verifyResetAfterRecovery(coordinatorProc *os.Process, cfg coordinatorConfig
 	log.Println("Check if the manifest was accepted and we are ready to accept Marbles")
 	statusResponse, err := getStatus()
 	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.Code").Int(), "Server is in wrong status after recovery.")
+	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
 
 	// simulate restart of coordinator
 	log.Println("Simulating a restart of the coordinator enclave...")
@@ -772,7 +772,7 @@ func verifyResetAfterRecovery(coordinatorProc *os.Process, cfg coordinatorConfig
 	log.Println("Restarted instance, now let's see if the new state can be decrypted successfully...")
 	statusResponse, err = getStatus()
 	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.Code").Int(), "Server is in wrong status after recovery.")
+	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
 
 	return coordinatorProc
 }


### PR DESCRIPTION
This... breaks stuff, so let's discuss that. Feedback is appreciated :)

## Idea
The general idea of this PR is to introduce a common JSON output format which always contains the status of the response, so that we do not receive an empty response after an user issued an API command such as setting a manifest and wondering what happened. Also, this might make error handling or integrating Marblerun into other tool sets more easier, as we always return a consistent JSON format, even for errors (unless the JSON marshaller fails badly...).

## Style
My idea was to follow the [JSend](https://github.com/omniti-labs/jsend) style in some way. There's not really a standard out there, but many APIs seem to follow a similar style. 

However, what the changes in this PR don't really use so far is the return type **fail**. Normally, we should return this if the server can handle the data, but the data is invalid. However, so far we really do not really differentiate error types, and even "internal" errors can result in returning an internal error with an HTTP 4xx code. Also, the **fail** type also "requires" the field `data`, but so far we would just embed one string inside which basically would work in the same way as **error** does... 

Therefore, so far, only **success** and **error** are implemented as types.

## Examples:
/status:
```json
{"status":"success","data":{"StatusCode":3,"StatusMessage":"Coordinator is running correctly and ready to accept marbles."}}
```
/quote:
```json
{"status":"success","data":{"Cert":"-----BEGIN CERTIFICATE-----\nMIIBwzCCAWmgAwIBAgIRAI2Wq/yoCXRqPu3NbbKwyB4wCgYIKoZIzj0EAwIwIDEe\nMBwGA1UEAxMVTWFyYmxlcnVuIENvb3JkaW5hdG9yMCAXDTIxMDIxNjA5NDUwN1oY\nDzIzMTMwNTI5MDkzMjI0WjAyMTAwLgYDVQQDEydNYXJibGVydW4gQ29vcmRpbmF0\nb3IgLSBJbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQy\nVl7JkbaLVPDO0qRx+kTpES+ltBFFkrj5kP9TWuOHpYz8l4SUta6ZQBh9/lOxHVKy\ne3jBJ/xmtkfIAJTrrJsno3AwbjAOBgNVHQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYI\nKwYBBQUHAwEGCCsGAQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wLAYDVR0RBCUwI4IJ\nbG9jYWxob3N0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAABMAoGCCqGSM49BAMCA0gA\nMEUCIQC9VFtQsOyuj0FojOin5V8yOFlfIY93ixCXI6Ln2H16iAIgLIMjCddu11I0\nTVmKyLgahdAn55gksYEqWD2rD7npm1s=\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBsTCCAVagAwIBAgIQZ7Ja3c7iTSUtGLob9KkQdjAKBggqhkjOPQQDAjAgMR4w\nHAYDVQQDExVNYXJibGVydW4gQ29vcmRpbmF0b3IwIBcNMjEwMjE2MDk0NTA3WhgP\nMjMxMzA1MjkwOTMyMjRaMCAxHjAcBgNVBAMTFU1hcmJsZXJ1biBDb29yZGluYXRv\ncjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAb//36qEfuWWYC98DlyFfDpy1Rv\nj+7mNjMjFrktcdZPLT6epUtNtvQN4blN0JCNnYuUAtMVeoQ7xJRFiqAeUMajcDBu\nMA4GA1UdDwEB/wQEAwIChDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\nDwYDVR0TAQH/BAUwAwEB/zAsBgNVHREEJTAjgglsb2NhbGhvc3SHBH8AAAGHEAAA\nAAAAAAAAAAAAAAAAAAEwCgYIKoZIzj0EAwIDSQAwRgIhANK15I85Th4l0NeMW7Qh\nlHEn80Tr3y420f08f0mLE7rIAiEAtD+jLNwy/2wGkQb5vK3l6ahypHXKW8mdB5hW\ny8/vEs8=\n-----END CERTIFICATE-----\n","Quote":""}}
```

/manifest (GET):
```json
{"status":"success","data":{"ManifestSignature":"3fff78e99dd9bd801e0a3a22b7f7a24a492302c4d00546d18c7f7ed6e26e95c3"}}
```

/manifest (POST, failed):
```json
{"status":"error","data":null,"message":"server is not in expected state"}
```

/manifest (POST, success, no secrets):
```json
{"status":"success","data":null}
```

/update (POST, failed):
```json
{"status":"error","data":null,"message":"unauthorized user"}
```

Think, you get the idea here. The old successful responses are embedded into "data", the error messages under "message".

## Issues
* It breaks quite some stuff, the documentation needs to be adjusted, and we need to adjust our tools here (e.g. `era`).
* Maybe we should add the type "fail"...?
* CLI stuff so far is untested, so maybe @daniel-weisse you want to take a look if the CLI stuff still works? Or maybe add some feedback on that in general, since you worked quite a bit recently with these API endpoints? :)