### PR TITLE
AB#673 Add uninstall command and unit test

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -22,4 +22,5 @@ func init() {
 	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newNamespaceCmd())
 	rootCmd.AddCommand(newRecoverCmd())
+	rootCmd.AddCommand(newUninstallCmd())
 }

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func newUninstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Removes Marblerun from a kubernetes cluster",
+		Long:  `Removes Marblerun from a kubernetes cluster`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			settings := cli.New()
+			kubeClient, err := getKubernetesInterface()
+			if err != nil {
+				return fmt.Errorf("failed setting up kubernetes client: %v", err)
+			}
+			return cliUninstall(settings, kubeClient)
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+// cliUninstall uninstalls marblerun
+func cliUninstall(settings *cli.EnvSettings, kubeClient kubernetes.Interface) error {
+	if err := removeHelmRelease(settings); err != nil {
+		return err
+	}
+
+	// If we get a "not found" error the resource was already removed / never created
+	// and we can continue on without a problem
+	err := cleanupSecrets(kubeClient)
+	if err != nil {
+		if !strings.HasSuffix(err.Error(), "not found") {
+			return err
+		}
+	}
+
+	err = cleanupCSR(kubeClient)
+	if err != nil {
+		if !strings.HasSuffix(err.Error(), "not found") {
+			return err
+		}
+	}
+
+	fmt.Println("Marblerun successfully removed from your cluster")
+
+	return nil
+}
+
+// removeHelmRelease removes kubernetes resources installed using helm
+func removeHelmRelease(settings *cli.EnvSettings) error {
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(settings.RESTClientGetter(), "marblerun", os.Getenv("HELM_DRIVER"), debug); err != nil {
+		return err
+	}
+
+	uninstallAction := action.NewUninstall(actionConfig)
+	_, err := uninstallAction.Run("marblerun-coordinator")
+
+	return err
+}
+
+// cleanupSecrets removes secretes set for the Admission Controller
+func cleanupSecrets(kubeClient kubernetes.Interface) error {
+	return kubeClient.CoreV1().Secrets("marblerun").Delete(context.TODO(), "marble-injector-webhook-certs", metav1.DeleteOptions{})
+}
+
+// cleanupCSR removes a potentially leftover CSR from the Admission Controller
+func cleanupCSR(kubeClient kubernetes.Interface) error {
+	// in case of kubernetes version < 1.19 no CSR was created by the install command
+	versionInfo, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return err
+	}
+	majorVersion, err := strconv.Atoi(versionInfo.Major)
+	if err != nil {
+		return err
+	}
+	minorVersion, err := strconv.Atoi(versionInfo.Minor)
+	if err != nil {
+		return err
+	}
+	if majorVersion == 1 && minorVersion < 19 {
+		return nil
+	}
+
+	return kubeClient.CertificatesV1().CertificateSigningRequests().Delete(context.TODO(), webhookName, metav1.DeleteOptions{})
+}

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -43,17 +43,13 @@ func cliUninstall(settings *cli.EnvSettings, kubeClient kubernetes.Interface) er
 	// If we get a "not found" error the resource was already removed / never created
 	// and we can continue on without a problem
 	err := cleanupSecrets(kubeClient)
-	if err != nil {
-		if !strings.HasSuffix(err.Error(), "not found") {
-			return err
-		}
+	if !errors.IsNotFound(err) {
+		return err
 	}
 
 	err = cleanupCSR(kubeClient)
-	if err != nil {
-		if !strings.HasSuffix(err.Error(), "not found") {
-			return err
-		}
+	if !errors.IsNotFound(err) {
+		return err
 	}
 
 	fmt.Println("Marblerun successfully removed from your cluster")

--- a/cli/cmd/uninstall_test.go
+++ b/cli/cmd/uninstall_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	certv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCleanupWebhook(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	testClient := fake.NewSimpleClientset()
+	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: "1",
+		Minor: "19",
+	}
+
+	// Try to remove non existant CSR using function
+	_, err := testClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), webhookName, metav1.GetOptions{})
+	require.Error(err)
+
+	err = cleanupCSR(testClient)
+	require.Error(err)
+	assert.Contains(err.Error(), "not found", "function returned an error other than not found")
+
+	// Create and test for CSR
+	csr := &certv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhookName,
+		},
+		Spec: certv1.CertificateSigningRequestSpec{
+			Request:    []byte{0xAA, 0xAA, 0xAA},
+			SignerName: "kubernetes.io/kubelet-serving",
+			Usages: []certv1.KeyUsage{
+				"key encipherment", "digital signature", "server auth",
+			},
+		},
+	}
+
+	_, err = testClient.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
+	require.NoError(err)
+
+	_, err = testClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), webhookName, metav1.GetOptions{})
+	require.NoError(err)
+
+	// Remove CSR using function
+	err = cleanupCSR(testClient)
+	require.NoError(err)
+
+	_, err = testClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), webhookName, metav1.GetOptions{})
+	require.Error(err)
+
+	// try changing to version lower than 19 and removing CSR (this should always return nil)
+	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: "1",
+		Minor: "18",
+	}
+	err = cleanupCSR(testClient)
+	require.NoError(err)
+
+	// Try to remove non existant Secret using function
+	_, err = testClient.CoreV1().Secrets("marblerun").Get(context.TODO(), "marble-injector-webhook-certs", metav1.GetOptions{})
+	require.Error(err)
+
+	err = cleanupSecrets(testClient)
+	require.Error(err)
+	assert.Contains(err.Error(), "not found", "function returned an error other than not found")
+
+	// Create Secret and test for Secret
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "marble-injector-webhook-certs",
+			Namespace: "marblerun",
+		},
+		Data: map[string][]byte{
+			"cert.pem": {0xAA, 0xAA, 0xAA},
+			"key.pem":  {0xBB, 0xBB, 0xBB},
+		},
+	}
+
+	_, err = testClient.CoreV1().Secrets("marblerun").Create(context.TODO(), secret, metav1.CreateOptions{})
+	require.NoError(err)
+
+	_, err = testClient.CoreV1().Secrets("marblerun").Get(context.TODO(), "marble-injector-webhook-certs", metav1.GetOptions{})
+	require.NoError(err)
+
+	err = cleanupSecrets(testClient)
+	require.NoError(err)
+}

--- a/cli/cmd/uninstall_test.go
+++ b/cli/cmd/uninstall_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	certv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -29,7 +30,7 @@ func TestCleanupWebhook(t *testing.T) {
 
 	err = cleanupCSR(testClient)
 	require.Error(err)
-	assert.Contains(err.Error(), "not found", "function returned an error other than not found")
+	assert.True(errors.IsNotFound(err), "function returned an error other than not found")
 
 	// Create and test for CSR
 	csr := &certv1.CertificateSigningRequest{
@@ -72,7 +73,7 @@ func TestCleanupWebhook(t *testing.T) {
 
 	err = cleanupSecrets(testClient)
 	require.Error(err)
-	assert.Contains(err.Error(), "not found", "function returned an error other than not found")
+	assert.True(errors.IsNotFound(err), "function returned an error other than not found")
 
 	// Create Secret and test for Secret
 	secret := &corev1.Secret{


### PR DESCRIPTION
Adds an uninstall command that removes the mablerun-coordinator helm release, as well as any secrets and certificate requests generated by the install command