### PR TITLE
Replace ertgolib with ego

### DIFF
--- a/cmd/marble-test/main.go
+++ b/cmd/marble-test/main.go
@@ -13,7 +13,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/edgelesssys/ertgolib/marble"
+	"github.com/edgelesssys/ego/marble"
 	"github.com/edgelesssys/marblerun/util"
 )
 

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -17,7 +17,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/edgelesssys/ertgolib/marble"
+	"github.com/edgelesssys/ego/marble"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	libMarble "github.com/edgelesssys/ertgolib/marble"
+	libMarble "github.com/edgelesssys/ego/marble"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/coordinator/recovery"

--- a/coordinator/core/seal.go
+++ b/coordinator/core/seal.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/edgelesssys/ertgolib/ertcrypto"
+	"github.com/edgelesssys/ego/ecrypto"
 )
 
 // SealedDataFname contains the file name in which the state is sealed on disk in seal_dir
@@ -80,7 +80,7 @@ func (s *AESGCMSealer) Unseal() ([]byte, []byte, error) {
 	}
 
 	// Decrypt data with the unsealed encryption key and return it
-	decryptedData, err := ertcrypto.Decrypt(ciphertext, s.encryptionKey)
+	decryptedData, err := ecrypto.Decrypt(ciphertext, s.encryptionKey)
 	if err != nil {
 		return unencryptedData, nil, err
 	}
@@ -101,7 +101,7 @@ func (s *AESGCMSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) error 
 	}
 
 	// Encrypt data to seal with generated encryption key
-	encryptedData, err := ertcrypto.Encrypt(toBeEncrypted, s.encryptionKey)
+	encryptedData, err := ecrypto.Encrypt(toBeEncrypted, s.encryptionKey)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (s *AESGCMSealer) unsealEncryptionKey() error {
 	}
 
 	// Decrypt stored encryption key with seal key
-	encryptionKey, err := ertcrypto.Unseal(sealedKeyData)
+	encryptionKey, err := ecrypto.Unseal(sealedKeyData)
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
 	}
 
 	// Encrypt encryption key with seal key
-	encryptedKeyData, err := ertcrypto.SealWithProductKey(encryptionKey)
+	encryptedKeyData, err := ecrypto.SealWithProductKey(encryptionKey)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func NewNoEnclaveSealer(sealDir string) *NoEnclaveSealer {
 // Seal writes the given data encrypted and the used key as plaintext to the disk
 func (s *NoEnclaveSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) error {
 	// Encrypt data
-	sealedData, err := ertcrypto.Encrypt(toBeEncrypted, s.encryptionKey)
+	sealedData, err := ecrypto.Encrypt(toBeEncrypted, s.encryptionKey)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func (s *NoEnclaveSealer) Unseal() ([]byte, []byte, error) {
 	ciphertext := sealedData[4+encodedUnencryptDataLength:]
 
 	// Decrypt data with key from disk
-	decryptedData, err := ertcrypto.Decrypt(ciphertext, keyData)
+	decryptedData, err := ecrypto.Decrypt(ciphertext, keyData)
 	if err != nil {
 		return unencryptedData, nil, ErrEncryptionKey
 	}

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -13,7 +13,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/edgelesssys/ertgolib/ertenclave"
+	"github.com/edgelesssys/ego/enclave"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 )
 
@@ -29,7 +29,7 @@ func NewERTValidator() *ERTValidator {
 // Validate implements the Validator interface for ERTValidator
 func (m *ERTValidator) Validate(givenQuote []byte, cert []byte, pp quote.PackageProperties, ip quote.InfrastructureProperties) error {
 	// Verify Quote
-	report, err := ertenclave.VerifyRemoteReport(givenQuote)
+	report, err := enclave.VerifyRemoteReport(givenQuote)
 	if err != nil {
 		return fmt.Errorf("verifying quote failed: %v", err)
 	}
@@ -68,5 +68,5 @@ func NewERTIssuer() *ERTIssuer {
 // Issue implements the Issuer interface
 func (m *ERTIssuer) Issue(cert []byte) ([]byte, error) {
 	hash := sha256.Sum256(cert)
-	return ertenclave.GetRemoteReport(hash[:])
+	return enclave.GetRemoteReport(hash[:])
 }

--- a/go.mod
+++ b/go.mod
@@ -3,28 +3,27 @@ module github.com/edgelesssys/marblerun
 go 1.14
 
 require (
+	github.com/edgelesssys/ego v0.1.2
 	github.com/edgelesssys/era v0.3.0
-	github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855
 	github.com/gofrs/flock v0.8.0
 	github.com/golang/protobuf v1.4.3
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v1.8.0
-	github.com/spf13/afero v1.4.1
+	github.com/spf13/afero v1.5.1
 	github.com/spf13/cobra v1.1.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.6.8
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
-	google.golang.org/grpc v1.33.1
+	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.5.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
-	rsc.io/letsencrypt v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
@@ -193,6 +194,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/edgelesssys/ego v0.1.2 h1:ypDC5r+6+SHuIy+ArBPlnUhSH8bkUsnUHerNUP3xUc8=
+github.com/edgelesssys/ego v0.1.2/go.mod h1:2w3REN6B9YUdc98PF8d5jh6cmGNHORbKaJxTlLl5vxM=
 github.com/edgelesssys/era v0.1.1-0.20210209072546-fb6c08a3562c h1:tHXDurmMedmO1dWopD6qR24T93hnBd6Jf0tuIyHTXm8=
 github.com/edgelesssys/era v0.1.1-0.20210209072546-fb6c08a3562c/go.mod h1:rEv/EPEWTUpu8gGOUWp97Bk1kFFvgYwcJY0yA4cKG8U=
 github.com/edgelesssys/era v0.3.0 h1:YX2K+S24J1F0eP/T1eEHo0wDYBOWZbEOk2VWjZPby5M=
@@ -200,6 +203,7 @@ github.com/edgelesssys/era v0.3.0/go.mod h1:5OB1KAIEjbCqrs+5VOK5Im28wbcNiyc/RD3A
 github.com/edgelesssys/ertgolib v0.1.1/go.mod h1:QV27eWmoYHCNMkPMnz2XcER13+XdhPyG5qLQu5iDL0I=
 github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855 h1:3iTzGhF0FJf5ZFDPfU54NAfObJwlexJYFR3ShITYlEk=
 github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855/go.mod h1:1E8jAgXZp9wyP3n43wCsLCiEGXxjBQ35+uzxUkypBNs=
+github.com/edgelesssys/marblerun v0.2.1-0.20210312084731-95118a77f617/go.mod h1:8HWnA9SmYZeK3Jmq0meqOwp6/avuLAMTMgtwRlnhRRw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -210,6 +214,7 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -323,6 +328,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -648,6 +655,8 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
+github.com/spf13/afero v1.5.1 h1:VHu76Lk0LSP1x254maIu2bplkWpfBWI+B+6fdoZprcg=
+github.com/spf13/afero v1.5.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -677,6 +686,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
@@ -1012,6 +1023,8 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
+google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
We decided that ertgolib is deprecated and should use ego instead. This also fixes the issue where the coordinator crashes whenever it receives an empty quote:

https://github.com/edgelesssys/ego/commit/3d9a417efb206230a78490fc9773465480c92b9a

Guess that's an important fix, we don't want crashes I think!