### PR TITLE
AB#607 Add manual integration test for cli

### DIFF
--- a/test/cli/Dockerfile
+++ b/test/cli/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine/git:latest AS pull
+RUN git clone https://github.com/edgelesssys/marblerun.git /hello-marble
+WORKDIR /marble-injector
+
+FROM ghcr.io/edgelesssys/ego-dev:latest AS build
+COPY --from=pull /hello-marble /hello-marble
+WORKDIR /hello-marble/samples/helloworld
+RUN ego-go build
+RUN ego sign helloworld
+
+FROM ghcr.io/edgelesssys/ego-deploy:latest AS release
+LABEL description="HelloMarble"
+COPY --from=build /hello-marble/samples/helloworld /
+ENTRYPOINT [ "ego", "marblerun", "/helloworld" ]

--- a/test/cli/hello-marble.yaml
+++ b/test/cli/hello-marble.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-marble
+  labels:
+    marblerun/marbletype: hello
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      marblerun/marbletype: hello
+  template:
+    metadata:
+      labels:
+        marblerun/marbletype: hello
+    spec:
+      containers:
+        - env:
+          - name: OE_SIMULATION
+            value: "1"
+          name: hello-marble
+          image: ghcr.io/edgelesssys/hello-marble:v0.3.0
+          imagePullPolicy: IfNotPresent
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-marble
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    marblerun/marbletype: hello
+
+

--- a/test/cli/integration_test.sh
+++ b/test/cli/integration_test.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+function wait_for_resource() {
+    while true; do
+        eval $1 > /dev/null
+        if [ $? -eq 0 ]; then
+            sleep 5
+            continue
+        fi
+        break
+    done
+}
+
+
+#-------------install marblerun on the cluster-----------------------
+
+echo "Starting integration test"
+if [[ $(minikube status | grep host) != "host: Running" ]];
+then
+    echo "Minikube seems to not be running"
+    exit 1
+fi
+
+marblerun install --simulation
+wait_for_resource "kubectl get pods -n marblerun | grep marble | grep -v Running"
+
+marblerun namespace add default --no-sgx-injection
+if [[ $(kubectl describe namespace default | grep marblerun/inject | grep -v enabled | xargs) != "marblerun/inject-sgx=disabled" ]];
+then
+    echo "failed to inject correct values into namespace"
+    exit 1
+fi
+
+
+#-------------test setting manifest----------------------------------
+
+echo ""
+kubectl -n marblerun port-forward svc/coordinator-client-api 25555:25555 --address localhost >/dev/null &
+sleep 2
+echo -n "Checking coordinator state: "
+if [[ $(marblerun status localhost:25555 --insecure | tail -n 1) != "2: Coordinator is ready to accept a manifest." ]]
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Setting manifest: "
+if [[ $(marblerun manifest set test-manifest.json localhost:25555 --insecure | tail -n 1) != "Manifest successfully set" ]]
+then
+    echo "[FAIL]"
+fi
+echo "[OK]"
+
+echo -n "Verifying set manifest: "
+if [[ $(marblerun manifest get localhost:25555 --insecure -o test-signature.json | tail -n 1) != "Manifest written to: test-signature.json." ]]
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+kubectl create -f hello-marble.yaml
+wait_for_resource "kubectl get pods -n default | grep hello-marble | grep -v Running"
+kubectl port-forward svc/hello-marble 8080:8080 --address localhost >/dev/null &
+sleep 2
+
+echo -n "Checking if hello-marble is running correctly: "
+if [[ $(curl http://localhost:8080 -s | tail -n 1) != "Commandline arguments: [foo bar]" ]]
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+#verify returned manifest
+
+
+#-------------test injection of env variables------------------------
+
+echo ""
+if [[ -n $(kubectl logs -n marblerun -l app.kubernetes.io/name=marble-injector | grep "injecting sgx tolerations") ]];
+then
+    echo "called the wrong webhook"
+    exit 1
+fi
+
+echo -n "Checking env variable EDG_COORDINATOR_ADDR: "
+if [[ -n $(kubectl get pod -l marblerun/marbletype=hello-world -o jsonpath='{.spec.containers[0].env[0]}' | grep -v coordinator-mesh-api.marblerun:25554) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_MARBLE_TYPE: "
+if [[ -n $(kubectl get pod -l marblerun/marbletype=hello-world -o jsonpath='{.spec.containers[0].env[1]}' | grep -v test) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_MARBLE_DNS_NAMES: "
+if [[ -n $(kubectl get pod -l marblerun/marbletype=hello-world -o jsonpath='{.spec.containers[0].env[2]}' | grep -v test,test.default,test.default.svc.cluster.local) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_MARBLE_UUID_FILE: "
+if [[ -n $(kubectl get pod -l marblerun/marbletype=hello-world -o jsonpath='{.spec.containers[0].env[3]}' | grep -v "/test-uid/uuid-file") ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking pod resource limits: "
+if [[ -n $(kubectl get pod -l marblerun/marbletype=hello-world -o jsonpath='{.spec.containers[0].resources.limits}' | grep kubernetes.azure.com/sgx_epc_mem_in_MiB) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+
+#-------------test injection of sgx values---------------------------
+
+echo ""
+marblerun namespace add default
+
+if [[ -n $(kubectl describe namespace default | grep marblerun/inject | grep -v enabled) ]];
+then
+    echo "failed to inject correct values into namespace"
+    exit 1
+fi
+
+kubectl apply -f test-pod.yaml
+wait_for_resource "kubectl get pods -n default | grep default | grep -v Pending"
+
+if [[ -n $(kubectl logs -n marblerun -l app.kubernetes.io/name=marble-injector | tail -n 2 | grep -v "successful" | grep "omitting sgx injection") ]];
+then
+    echo "called the wrong webhook"
+    exit 1
+fi
+
+if [[ -n $(kubectl describe pod test-pod | grep FailedScheduling | grep -v "Insufficient kubernetes.azure.com/sgx_epc_mem_in_MiB") ]];
+then
+    echo "pod creating stuck in pending due to unrelated issue"
+    exit 1
+fi
+
+echo -n "Checking pod tolerations: "
+if [[ -n $(kubectl get pod test-pod -o jsonpath='{.spec.tolerations}' | grep -v "kubernetes.azure.com/sgx_epc_mem_in_MiB") ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking pod resource limits: "
+if [[ -n $(kubectl get pod test-pod -o jsonpath='{.spec.containers[0].resources.limits}' | grep -v "kubernetes.azure.com/sgx_epc_mem_in_MiB") ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_COORDINATOR_ADDR: "
+if [[ -n $(kubectl get pod test-pod -o jsonpath='{.spec.containers[0].env[0]}' | grep -v coordinator-mesh-api.marblerun:25554) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_MARBLE_TYPE: "
+if [[ -n $(kubectl get pod test-pod -o jsonpath='{.spec.containers[0].env[1]}' | grep -v test) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_MARBLE_DNS_NAMES: "
+if [[ -n $(kubectl get pod test-pod -o jsonpath='{.spec.containers[0].env[2]}' | grep -v test,test.default,test.default.svc.cluster.local) ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo -n "Checking env variable EDG_MARBLE_UUID_FILE: "
+if [[ -n $(kubectl get pod test-pod -o jsonpath='{.spec.containers[0].env[3]}' | grep -v "/test-uid/uuid-file") ]];
+then
+    echo "[FAIL]"
+    exit 1
+fi
+echo "[OK]"
+
+echo ""
+kubectl delete pod test-pod
+marblerun namespace remove default
+
+if [[ -n $(marblerun namespace list | grep default) ]];
+then
+    echo "failed to remove default namespace from the Marblerun mesh"
+    exit 1
+fi
+
+kubectl delete deployments hello-marble
+kubectl delete svc hello-marble
+marblerun uninstall
+kubectl delete namespace marblerun
+wait_for_resource "kubectl get namespaces | grep marblerun"
+
+pkill kubectl
+echo -e "\nIntegration test successful"
+exit

--- a/test/cli/test-manifest.json
+++ b/test/cli/test-manifest.json
@@ -1,0 +1,22 @@
+{
+    "Packages": {
+        "world": {
+            "Debug": true,
+	    "SignerID": "6127426a53d0f5988d3c24f4e4f837c57ef49701aedb96d864420471f87a5f48",
+	    "SecurityVersion": 1,
+	    "ProductID": 1
+        }
+    },
+    "Marbles": {
+        "hello": {
+            "Package": "world",
+            "Parameters": {
+                "Argv": [
+                    "foo",
+                    "bar"
+                ]
+            }
+        }
+    }
+}
+

--- a/test/cli/test-manifest.json
+++ b/test/cli/test-manifest.json
@@ -2,9 +2,9 @@
     "Packages": {
         "world": {
             "Debug": true,
-	    "SignerID": "6127426a53d0f5988d3c24f4e4f837c57ef49701aedb96d864420471f87a5f48",
-	    "SecurityVersion": 1,
-	    "ProductID": 1
+	        "SignerID": "6127426a53d0f5988d3c24f4e4f837c57ef49701aedb96d864420471f87a5f48",
+	        "SecurityVersion": 1,
+	        "ProductID": 1
         }
     },
     "Marbles": {

--- a/test/cli/test-pod.yaml
+++ b/test/cli/test-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    marblerun/marbletype: test
+spec:
+  containers:
+    - name: client-container
+      resources:
+        limits:
+          cpu: "100m"
+      image: k8s.gcr.io/busybox
+      command: ["sh", "-c"]
+      args:
+      - while true; do
+          echo -en '\n\n'; cat /test-uid/uuid-file; echo -en '\n';
+          sleep 5;
+        done;


### PR DESCRIPTION
Files for the integration test are under test/cli

- Dockerfile: dockerfile to create the image used in the test, uses the hello-world sample
- hello-marble.yaml: k8s file to create a deployment and service for the helloworld image
- test-pod.yaml: k8s file to create a pod that does basically nothing, but can be used to check if correct values were injected
- test-manifest.json: manifest to be sent to the Marblerun coordinator during the test
- integration_test.sh: the test itself, probably not very pretty but does its job i hope

To run the test marblerun cli has to be installed and a minikube cluster has to be running
Start the test with `./integration_test.sh`