### PR TITLE
Print errors returned from coordinator

### DIFF
--- a/cli/cmd/manifestSet.go
+++ b/cli/cmd/manifestSet.go
@@ -87,7 +87,12 @@ func cliManifestSet(manifestName string, host string, configFilename string, ins
 			fmt.Printf("Manifest successfully set, recovery data saved to: %s.\n", recover)
 		}
 	case http.StatusBadRequest:
-		return fmt.Errorf("unable to set manifest: Server is not in expected state. Did you mean to update the manifest?")
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		response := gjson.GetBytes(respBody, "message")
+		return fmt.Errorf(response.String())
 	default:
 		return fmt.Errorf("error connecting to server: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}


### PR DESCRIPTION
Updates the manifest set command to print errors returned by the coordinator during the manifest set procedure, instead of printing its own