### PR TITLE
AB#729 Add version command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(coordinator)
+project(marblerun VERSION 0.3.0)
+string(TIMESTAMP date)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -23,12 +25,14 @@ add_custom_command(
 add_custom_target(coordinatorlib
   ertgo build ${TRIMPATH} -buildmode=c-archive -tags enclave
   -o libcoordinator.a
+  -ldflags "-X 'main.Version=${PROJECT_VERSION}' -X 'main.BuildDate=${date}'"
   ${CMAKE_SOURCE_DIR}/cmd/coordinator
 )
 
 add_custom_target(coordinator-noenclave ALL
   go build ${TRIMPATH}
   -o coordinator-noenclave
+  -ldflags "-X 'main.Version=${PROJECT_VERSION}' -X 'main.BuildDate=${date}'"
   ${CMAKE_SOURCE_DIR}/cmd/coordinator)
 
 add_executable(coordinator-enclave enclave/main.c)
@@ -71,14 +75,11 @@ add_custom_target(marble-injector ALL
 # Build CLI
 # 
 
-
-# Version information will need to be adjusted for each new release
 set(cliPath "github.com/edgelesssys/marblerun/cli/cmd")
-string(TIMESTAMP date)
 add_custom_target(cli ALL
   go build ${TRIMPATH}
   -o marblerun
-  -ldflags "-X '${cliPath}.Major=0' -X '${cliPath}.Minor=3' -X '${cliPath}.Patch=0' -X '${cliPath}.BuildTime=${date}'"
+  -ldflags "-X '${cliPath}.Version=${PROJECT_VERSION}' -X '${cliPath}.BuildDate=${date}'"
   ${CMAKE_SOURCE_DIR}/cli
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(coordinator)
 project(marblerun VERSION 0.3.0)
-string(TIMESTAMP date)
+execute_process(COMMAND bash "-c" "git rev-parse HEAD | tr -d '\n'" OUTPUT_VARIABLE GIT_COMMIT) 
 find_package(OpenEnclave CONFIG REQUIRED)
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -25,14 +24,14 @@ add_custom_command(
 add_custom_target(coordinatorlib
   ertgo build ${TRIMPATH} -buildmode=c-archive -tags enclave
   -o libcoordinator.a
-  -ldflags "-X 'main.Version=${PROJECT_VERSION}' -X 'main.BuildDate=${date}'"
+  -ldflags "-X 'main.Version=${PROJECT_VERSION}' -X 'main.GitCommit=${GIT_COMMIT}'"
   ${CMAKE_SOURCE_DIR}/cmd/coordinator
 )
 
 add_custom_target(coordinator-noenclave ALL
   go build ${TRIMPATH}
   -o coordinator-noenclave
-  -ldflags "-X 'main.Version=${PROJECT_VERSION}' -X 'main.BuildDate=${date}'"
+  -ldflags "-X 'main.Version=${PROJECT_VERSION}' -X 'main.GitCommit=${GIT_COMMIT}'"
   ${CMAKE_SOURCE_DIR}/cmd/coordinator)
 
 add_executable(coordinator-enclave enclave/main.c)
@@ -79,7 +78,7 @@ set(cliPath "github.com/edgelesssys/marblerun/cli/cmd")
 add_custom_target(cli ALL
   go build ${TRIMPATH}
   -o marblerun
-  -ldflags "-X '${cliPath}.Version=${PROJECT_VERSION}' -X '${cliPath}.BuildDate=${date}'"
+  -ldflags "-X '${cliPath}.Version=${PROJECT_VERSION}' -X '${cliPath}.GitCommit=${GIT_COMMIT}'"
   ${CMAKE_SOURCE_DIR}/cli
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,16 @@ add_custom_target(marble-injector ALL
 
 #
 # Build CLI
-#
+# 
 
+
+# Version information will need to be adjusted for each new release
+set(cliPath "github.com/edgelesssys/marblerun/cli/cmd")
+string(TIMESTAMP date)
 add_custom_target(cli ALL
   go build ${TRIMPATH}
   -o marblerun
+  -ldflags "-X '${cliPath}.Major=0' -X '${cliPath}.Minor=3' -X '${cliPath}.Patch=0' -X '${cliPath}.BuildTime=${date}'"
   ${CMAKE_SOURCE_DIR}/cli
 )
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -31,4 +31,5 @@ func init() {
 	rootCmd.AddCommand(newNamespaceCmd())
 	rootCmd.AddCommand(newRecoverCmd())
 	rootCmd.AddCommand(newUninstallCmd())
+	rootCmd.AddCommand(newVersionCmd())
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var Major = "0"
+var Minor = "3"
+var Patch = "0-dev"
+var BuildTime string
+
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display version of this CLI and (if running) the Marblerun coordinator",
+		Long:  `Display version of this CLI and (if running) the Marblerun coordinator`,
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("CLI Version: v%s.%s.%s \nBuild Date: %s\n", Major, Minor, Patch, BuildTime)
+
+			cVersion, err := getCoordinatorVersion()
+			if err != nil {
+				fmt.Println("Unable to find Marblerun coordinator")
+				return
+			}
+			fmt.Printf("Coordinator Version: %s\n", cVersion)
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+func getCoordinatorVersion() (string, error) {
+	kubeClient, err := getKubernetesInterface()
+	if err != nil {
+		return "", err
+	}
+
+	coordinatorDeployment, err := kubeClient.AppsV1().Deployments("marblerun").Get(context.TODO(), "marblerun-coordinator", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	version := coordinatorDeployment.Labels["app.kubernetes.io/version"]
+	if len(version) <= 0 {
+		return "", fmt.Errorf("deployment has no label [app.kubernetes.io/version]")
+	}
+	return version, nil
+}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -8,10 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var Major = "0"
-var Minor = "3"
-var Patch = "0-dev"
-var BuildTime string
+var Version = "0.3.0-dev"
+var BuildDate string
 
 func newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,7 +18,7 @@ func newVersionCmd() *cobra.Command {
 		Long:  `Display version of this CLI and (if running) the Marblerun coordinator`,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("CLI Version: v%s.%s.%s \nBuild Date: %s\n", Major, Minor, Patch, BuildTime)
+			fmt.Printf("CLI Version: v%s \nBuild Date: %s\n", Version, BuildDate)
 
 			cVersion, err := getCoordinatorVersion()
 			if err != nil {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 var Version = "0.3.0-dev"
-var BuildDate string
+var GitCommit string
 
 func newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -18,7 +18,7 @@ func newVersionCmd() *cobra.Command {
 		Long:  `Display version of this CLI and (if running) the Marblerun coordinator`,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("CLI Version: v%s \nBuild Date: %s\n", Version, BuildDate)
+			fmt.Printf("CLI Version: v%s \nCommit: %s\n", Version, GitCommit)
 
 			cVersion, err := getCoordinatorVersion()
 			if err != nil {

--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -20,6 +20,9 @@ import (
 	"go.uber.org/zap"
 )
 
+var Version = "0.3.0-dev"
+var BuildDate = ""
+
 func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer core.Sealer, recovery recovery.Recovery) {
 	// Setup logging with Zap Logger
 	var zapLogger *zap.Logger
@@ -38,7 +41,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 	}
 	defer zapLogger.Sync() // flushes buffer, if any
 
-	zapLogger.Info("starting coordinator")
+	zapLogger.Info("starting coordinator", zap.String("version", Version), zap.String("build date", BuildDate))
 
 	// fetching env vars
 	dnsNamesString := util.MustGetenv(config.DNSNames)

--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -21,7 +21,7 @@ import (
 )
 
 var Version = "0.3.0-dev"
-var BuildDate = ""
+var GitCommit string
 
 func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer core.Sealer, recovery recovery.Recovery) {
 	// Setup logging with Zap Logger
@@ -41,7 +41,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 	}
 	defer zapLogger.Sync() // flushes buffer, if any
 
-	zapLogger.Info("starting coordinator", zap.String("version", Version), zap.String("build date", BuildDate))
+	zapLogger.Info("starting coordinator", zap.String("version", Version), zap.String("commit", GitCommit))
 
 	// fetching env vars
 	dnsNamesString := util.MustGetenv(config.DNSNames)


### PR DESCRIPTION
Adds a version command to the CLI
Also allows the user to specify what version of Marblerun to install and fixes an issue where the Marblerun helm chart needed to be manually updated for the CLI to install the latest release.