### PR TITLE
Fix seg fault on marble activation

### DIFF
--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -62,7 +62,11 @@ func (m Manifest) Check(ctx context.Context, zaplogger *zap.Logger) error {
 	// if len(m.Infrastructures) <= 0 {
 	// 	return errors.New("no allowed infrastructures defined")
 	// }
-	for _, marble := range m.Marbles {
+	for idx, marble := range m.Marbles {
+		if marble.Parameters == nil {
+			marble.Parameters = &rpc.Parameters{}
+			m.Marbles[idx] = marble
+		}
 		singlePackage, ok := m.Packages[marble.Package]
 		if !ok {
 			return errors.New("manifest does not contain marble package " + marble.Package)

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -249,6 +249,30 @@ var IntegrationManifestJSON string = `{
 	}
 }`
 
+var ManifestJSONMissingParameters string = `{
+	"Packages": {
+		"frontend": {
+			"SignerID": "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+			"ProductID": 44,
+			"SecurityVersion": 3,
+			"Debug": true
+		}
+	},
+	"Infrastructures": {
+		"Azure": {
+			"QESVN": 2,
+			"PCESVN": 3,
+			"CPUSVN": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],
+			"RootCA": [3,3,3]
+		}
+	},
+	"Marbles": {
+		"frontend": {
+			"Package": "frontend"
+		}
+	}
+}`
+
 func generateTestRecoveryKey() (publicKeyPem []byte, privateKey *rsa.PrivateKey) {
 	key, err := rsa.GenerateKey(rand.Reader, 3096)
 	if err != nil {

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -249,6 +249,7 @@ var IntegrationManifestJSON string = `{
 	}
 }`
 
+// ManifestJSONMissingParameters is a test manifest
 var ManifestJSONMissingParameters string = `{
 	"Packages": {
 		"frontend": {


### PR DESCRIPTION
There was an error where a segmentation fault occurred when a marble sent an activation request to the coordinator but the "Parameters" field in the Marblerun manifest was left empty. 
The coordinator would then try reading a value from a nil pointer and crash
This fixes that error by setting the Parameters field to default values if it was not provided by the Manifest (same as if the Manifest had specified '"Parameters": {}')