### PR TITLE
AB#695: Automatically adapt Graphene manifest for Marblerun's premain

### DIFF
--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -27,6 +27,24 @@ const premainNamePreload = "premain-graphene.so"
 // uuidName is the file name of a Marble's uuid
 const uuidName = "uuid"
 
+// longDescription is the help text shown for this command
+const longDescription = `Modifies a Graphene manifest for use with Marblerun.
+
+This command tries to automatically adjust the required parameters in an already existing Graphene manifest template, simplifying the migration of your existing Graphene application to Marblerun.
+Please note that you still need to manually create a Marblerun manifest.
+
+The first parameter of this command is either 'spawn' or 'preload'.
+
+'spawn': Replace the entrypoint of your application with Marblerun's premain. Dedicates argv provisioning to Marblerun's manifest, but takes longer to load.
+
+'preload': Loads Marblerun's premain as a shared library via LD_PRELOAD and keeps your original endpoint in tact.
+This feature delegates argv provisioning to Graphene, making Marblerun unable to supply its own arguments via the Marblerun manifest, but keeps better compability with existing Graphene applications and leads to faster load times.
+
+For more information about both modes, consult the documentation: https://www.marblerun.sh/docs/tasks/build-service-graphene/
+
+The second parameter of this command is the path of the Graphene manifest template you want to modify.
+`
+
 type diff struct {
 	manifestEntry   string
 	alreadyExisting bool
@@ -36,14 +54,11 @@ func newGraphenePrepareCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "graphene-prepare",
 		Short: "Modifies a Graphene manifest for use with Marblerun",
-		Long:  "Modifies a Graphene manifest for use with Marblerun",
+		Long:  longDescription,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mode := args[0]
 			fileName := args[1]
-
-			fmt.Println("Marblerun 🤝 Graphene")
-			fmt.Printf("Arg 1: %s, Arg 2: %s\n", mode, fileName)
 
 			mode = strings.ToLower(mode)
 			if mode != "spawn" && mode != "preload" {

--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -1,0 +1,186 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/cobra"
+)
+
+type diff struct {
+	manifestEntry   string
+	alreadyExisting bool
+}
+
+func newGraphenePrepareCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "graphene-prepare",
+		Short: "Modifies a Graphene manifest for use with Marblerun",
+		Long:  "Modifies a Graphene manifest for use with Marblerun",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mode := args[0]
+			fileName := args[1]
+
+			fmt.Println("Marblerun 🤝 Graphene")
+			fmt.Printf("Arg 1: %s, Arg 2: %s\n", mode, fileName)
+
+			switch strings.ToLower(mode) {
+			case "spawn":
+				return addSpawnToGrapheneManifest(fileName)
+			case "preload":
+				return addPreloadToGrapheneManifest(fileName)
+			default:
+				return fmt.Errorf("unknown mode was chosen, aborting")
+			}
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+func addSpawnToGrapheneManifest(fileName string) error {
+	// Read Graphene manifest and populate TOML tree
+	fmt.Println("Reading file:", fileName)
+	tree, err := toml.LoadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	// Create two maps, one with original values, one with the values we want to add or modify
+	original := make(map[string]interface{})
+	changes := make(map[string]interface{})
+
+	// The values we want to search in the original manifest
+	original["libos.entrypoint"] = tree.Get("libos.entrypoint")
+	original["loader.insecure__use_host_env"] = tree.Get("loader.insecure__use_host_env")
+	original["loader.argv0_override"] = tree.Get("loader.argv0_override")
+	original["sgx.remote_attestation"] = tree.Get("sgx.remote_attestation")
+	original["sgx.enclave_size"] = tree.Get("sgx.enclave_size")
+	original["sgx.thread_num"] = tree.Get("sgx.thread_num")
+	original["sgx.trusted_files.marblerun_premain"] = tree.Get("sgx.trusted_files.marblerun_premain")
+	original["sgx.allowed_files.marblerun_uuid"] = tree.Get("sgx.allowed_files.marblerun_uuid")
+
+	// Abort, if we cannot find an endpoint
+	if original["libos.entrypoint"] == nil {
+		return errors.New("cannot find libos.entrypoint")
+	}
+
+	// If Marblerun already touched the manifest, abort.
+	if original["libos.entrypoint"].(string) == "premain-graphene" || original["sgx.trusted_files.marblerun_premain"] != nil || original["sgx.allowed_files.marblerun_uuid"] != nil {
+		return errors.New("manifest already contains Marblerun changes")
+	}
+
+	// Set original endpoint as argv0. If one exists, keep the old one
+	if original["loader.argv0_override"] == nil {
+		fileEntry := strings.SplitAfter(original["libos.entrypoint"].(string), "file:")
+		if len(fileEntry) == 2 {
+			changes["loader.argv0_override"] = fileEntry[1]
+		} else {
+			return fmt.Errorf("cannot determine entrypoint for argv0 override correctly")
+		}
+	}
+
+	// Enable use "insecure" host env (which delegates the "secure" handling to Marblerun)
+	if original["loader.insecure__use_host_env"] == nil || original["loader.insecure__use_host_env"].(int64) == 0 {
+		changes["loader.insecure__use_host_env"] = 1
+	}
+
+	// Enable remote attestation
+	if original["sgx.remote_attestation"] == nil || original["sgx.remote_attestation"].(int64) == 0 {
+		changes["sgx.remote_attestation"] = 1
+	}
+
+	// Ensure at least 1024 MB of enclave memory for the premain Go runtime
+	if original["sgx.enclave_size"] != nil {
+		var v datasize.ByteSize
+		v.UnmarshalText([]byte(original["sgx.enclave_size"].(string)))
+		if v.GBytes() < 1.00 {
+			changes["sgx.enclave_size"] = "1024M"
+		}
+	}
+
+	// Ensure at least 16 SGX threads for the premain Go runtime
+	if original["sgx.thread_num"] == nil || original["sgx.thread_num"].(int64) < 16 {
+		changes["sgx.thread_num"] = 16
+	}
+
+	// Add Marblerun entries to manifest
+	changes["libos.entrypoint"] = "file:premain-graphene"
+	changes["sgx.trusted_files.marblerun_premain"] = "file:premain-graphene"
+	changes["sgx.allowed_files.marblerun_uuid"] = "file:uuid"
+
+	return performChanges(calculateChanges(original, changes))
+}
+
+func addPreloadToGrapheneManifest(fileName string) error {
+	return nil
+}
+
+// calculateChanges takes two maps with TOML indices and values as input and calculates the difference between them
+func calculateChanges(original map[string]interface{}, updates map[string]interface{}) []diff {
+	var changeDiffs []diff
+	for index, originalValue := range original {
+		if changedValue, ok := updates[index]; ok {
+			// Add quotation marks for strings, direct value if not
+			var diffLine string
+			switch v := changedValue.(type) {
+			case string:
+				diffLine = fmt.Sprintf("%s = \"%v\"", index, v)
+			default:
+				diffLine = fmt.Sprintf("%s = %v", index, v)
+			}
+
+			newDiff := diff{manifestEntry: diffLine}
+			if originalValue != nil {
+				newDiff.alreadyExisting = true
+			} else {
+				newDiff.alreadyExisting = false
+			}
+			changeDiffs = append(changeDiffs, newDiff)
+		}
+	}
+
+	// Sort changes alphabetically
+	sort.Slice(changeDiffs, func(i, j int) bool {
+		return changeDiffs[i].manifestEntry < changeDiffs[j].manifestEntry
+	})
+
+	return changeDiffs
+}
+
+// performChanges displays the suggested changes to the user and tries to automatically perform them
+func performChanges(changeDiffs []diff) error {
+	fmt.Println("\nMarblerun suggests the following changes to your Graphene manifest:")
+	for _, entry := range changeDiffs {
+		if entry.alreadyExisting {
+			fmt.Printf("\033[0;33m%s\033[0m\n", entry.manifestEntry)
+		} else {
+			fmt.Printf("\033[0;32m%s\033[0m\n", entry.manifestEntry)
+		}
+	}
+
+	// Prompt user for confirmation
+	fmt.Printf("Do you want to automatically apply the suggested changes [y/n]? ")
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+
+	if response != "y" && response != "yes" {
+		fmt.Println("Aborting.")
+		return nil
+	}
+
+	return nil
+}

--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -378,7 +378,7 @@ func appendAndReplace(changeDiffs []diff, manifestContent []byte) ([]byte, error
 			// If a value was previously existing, we replace the existing entry
 			key := strings.Split(value.manifestEntry, " =")
 			regexKey := strings.ReplaceAll(key[0], ".", "\\.")
-			regex := regexp.MustCompile("\\b" + regexKey + "\\b.*")
+			regex := regexp.MustCompile("(?m)^" + regexKey + "\\s?=.*$")
 			// Check if we actually found the entry we searched for. If not, we might be dealing with a TOML file we cannot handle correctly without a full parser.
 			regexMatches := regex.FindAll(newManifestContent, -1)
 			if regexMatches == nil {

--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/fatih/color"
 	"github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 )
@@ -82,7 +83,7 @@ func addToGrapheneManifest(fileName string, mode string) error {
 	fmt.Println("Reading file:", fileName)
 	tree, err := toml.LoadFile(fileName)
 	if err != nil {
-		fmt.Println("\033[0;31mERROR: Cannot parse manifest. Have you selected the corrected file?\033[0m")
+		color.Red("ERROR: Cannot parse manifest. Have you selected the corrected file?")
 		return err
 	}
 
@@ -249,9 +250,9 @@ func performChanges(changeDiffs []diff, fileName string, mode string) error {
 	fmt.Println("\nMarblerun suggests the following changes to your Graphene manifest:")
 	for _, entry := range changeDiffs {
 		if entry.alreadyExists {
-			fmt.Printf("\033[0;33m%s\033[0m\n", entry.manifestEntry)
+			color.Yellow(entry.manifestEntry)
 		} else {
-			fmt.Printf("\033[0;32m%s\033[0m\n", entry.manifestEntry)
+			color.Green(entry.manifestEntry)
 		}
 	}
 
@@ -279,7 +280,7 @@ func performChanges(changeDiffs []diff, fileName string, mode string) error {
 		} else if mode == "preload" {
 			fileName = premainNamePreload
 		}
-		fmt.Printf("\033[0;31mERROR: Cannot download '%s' from GitHub. Please add the file manually.\033[0m", fileName)
+		color.Red("ERROR: Cannot download '%s' from GitHub. Please add the file manually.", fileName)
 	}
 
 	// Read Graphene manifest as normal text file
@@ -370,9 +371,9 @@ func appendAndReplace(changeDiffs []diff, manifestContent []byte) ([]byte, error
 			regex := regexp.MustCompile("\\b" + regexKey + "\\b.*")
 			// Check if we actually found the entry we searched for. If not, we might be dealing with a TOML file we cannot handle correctly without a full parser.
 			if regex.Find(newManifestContent) == nil {
-				fmt.Println("\033[0;31mERROR: Cannot find specified entry. Your Graphene config might not be flat-mapped.")
-				fmt.Println("Marblerun can only automatically modify manifests using a flat hierarchy, as otherwise we would lose all styling & comments.")
-				fmt.Println("To continue, please manually perform the changes printed above in your Graphene manifest.\033[0m")
+				color.Red("ERROR: Cannot find specified entry. Your Graphene config might not be flat-mapped.")
+				color.Red("Marblerun can only automatically modify manifests using a flat hierarchy, as otherwise we would lose all styling & comments.")
+				color.Red("To continue, please manually perform the changes printed above in your Graphene manifest.")
 				return nil, errors.New("failed to detect position of config entry")
 			}
 			// But if everything went as expected, replace the entry

--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -245,6 +245,7 @@ func performChanges(changeDiffs []diff, fileName string, mode mode) error {
 		return err
 	}
 	if !accepted {
+		fmt.Println("Aborting.")
 		return nil
 	}
 

--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -124,6 +124,7 @@ func parseTreeForChanges(tree *toml.Tree, mode string) (map[string]interface{}, 
 		splittedPaths := strings.Split(original["loader.env.LD_PRELOAD"].(string), ":")
 		for _, value := range splittedPaths {
 			if strings.Contains(value, premainNamePreload) {
+				color.Yellow("The supplied manifest already contains changes for Marblerun. Have you selected the correct file?")
 				return nil, nil, errors.New("manifest already contains Marblerun changes")
 			}
 		}
@@ -142,6 +143,10 @@ func parseTreeForChanges(tree *toml.Tree, mode string) (map[string]interface{}, 
 			if len(fileEntry) == 2 {
 				changes["loader.argv0_override"] = fileEntry[1]
 			} else {
+				color.Red("ERROR: Cannot process the current entrypoint: %s", original["libos.entrypoint"].(string))
+				color.Red("Note: This tool only supports 'file:' URIs for automatic modifcation.")
+				color.Red("If you chose another type of path reference, please change it to 'file:' to continue.")
+				color.Red("Otherwise, please file a bug report!")
 				return nil, nil, fmt.Errorf("cannot determine entrypoint for argv0 override correctly")
 			}
 

--- a/cli/cmd/graphenePrepare_test.go
+++ b/cli/cmd/graphenePrepare_test.go
@@ -62,7 +62,7 @@ func TestParseTreeForChanges(t *testing.T) {
 	// Checking all possible combinations will result in tremendous effort...
 	// So for this, we check if we at least changed the entry point / PRELOAD and the memory/thread requirements for the Go runtime
 	// For 'spawn'
-	original, changes, err := parseTreeForChanges(tree, "spawn")
+	original, changes, err := parseTreeForChanges(tree, modeSpawn)
 	require.NoError(err)
 	assert.NotEmpty(original)
 	assert.NotEmpty(changes)
@@ -76,7 +76,7 @@ func TestParseTreeForChanges(t *testing.T) {
 	assert.GreaterOrEqual(v.GBytes(), 1.00)
 
 	// For 'preload'
-	original, changes, err = parseTreeForChanges(tree, "preload")
+	original, changes, err = parseTreeForChanges(tree, modePreload)
 	require.NoError(err)
 	assert.NotEmpty(original)
 	assert.NotEmpty(changes)
@@ -147,17 +147,17 @@ func TestDownloadPremain(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Try to download spawn & preload, fail for some invalid input
-	assert.NoError(downloadPremain(tempDir, "spawn"))
+	assert.NoError(downloadPremain(tempDir, modeSpawn))
 	content, err := ioutil.ReadFile(filepath.Join(tempDir, premainNameSpawn))
 	assert.NoError(err)
 	assert.Equal(testContent, content)
 
-	assert.NoError(downloadPremain(tempDir, "preload"))
+	assert.NoError(downloadPremain(tempDir, modePreload))
 	content, err = ioutil.ReadFile(filepath.Join(tempDir, premainNamePreload))
 	assert.NoError(err)
 	assert.Equal(testContent, content)
 
-	assert.Error(downloadPremain(tempDir, "someUnknownMode"))
+	assert.Error(downloadPremain(tempDir, modeInvalid))
 
 	// We should have two downloads here
 	info := httpmock.GetCallCountInfo()

--- a/cli/cmd/graphenePrepare_test.go
+++ b/cli/cmd/graphenePrepare_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/jarcoal/httpmock"
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const someManifest = `
+libos.entrypoint = "file:myapplication"
+sgx.remote_attestation = 0
+# Some comment here in between
+sgx.enclave_size = "128M"
+`
+
+func TestCalculateChanges(t *testing.T) {
+	assert := assert.New(t)
+
+	originalMap := make(map[string]interface{})
+	changedMap := make(map[string]interface{})
+
+	originalMap["someString"] = "test" // should be in diffs
+	originalMap["someNilValue"] = nil  // should be in diffs
+	originalMap["someInt"] = 4         // should not be in diffs
+
+	changedMap["someString"] = "This is a test."        // should be in diffs
+	changedMap["someNilValue"] = true                   // should be in diffs
+	changedMap["someNewEntry"] = "This is a new entry." // should not be in diffs
+
+	diffs := calculateChanges(originalMap, changedMap)
+
+	// NOTE: diffs only should contain changes which were at least defined on the original map
+	// Values which were undefined before should not be in here
+	for _, value := range diffs {
+		indexString := strings.Split(value.manifestEntry, " =")
+		_, ok := originalMap[indexString[0]]
+		assert.True(ok, "Diffs contains entries which were not defined in the original map initially")
+	}
+
+	// Check if we got TOML style output
+	// And check if diffs array was sorted correctly (is supposed to be sorted alphabetically)
+	assert.Len(diffs, 2, "diffs contains unexpected amount of entries")
+	assert.Equal(diffs[0].manifestEntry, "someNilValue = true")
+	assert.Equal(diffs[1].manifestEntry, "someString = \"This is a test.\"")
+}
+
+func TestParseTreeForChanges(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	tree, err := toml.Load(someManifest)
+	require.NoError(err)
+
+	// Checking all possible combinations will result in tremendous effort...
+	// So for this, we check if we at least changed the entry point / PRELOAD and the memory/thread requirements for the Go runtime
+	// For 'spawn'
+	original, changes, err := parseTreeForChanges(tree, "spawn")
+	require.NoError(err)
+	assert.NotEmpty(original)
+	assert.NotEmpty(changes)
+
+	// Verify minimum changes
+	var v datasize.ByteSize
+
+	assert.Equal("file:"+premainNameSpawn, changes["libos.entrypoint"])
+	assert.GreaterOrEqual(changes["sgx.thread_num"], 16)
+	require.NoError(v.UnmarshalText([]byte(changes["sgx.enclave_size"].(string))))
+	assert.GreaterOrEqual(v.GBytes(), 1.00)
+
+	// For 'preload'
+	original, changes, err = parseTreeForChanges(tree, "preload")
+	require.NoError(err)
+	assert.NotEmpty(original)
+	assert.NotEmpty(changes)
+
+	// Verify minimum changes
+	assert.Equal("./"+premainNamePreload, changes["loader.env.LD_PRELOAD"])
+	assert.Contains("/lib", changes["loader.env.LD_LIBRARY_PATH"])
+	assert.GreaterOrEqual(changes["sgx.thread_num"], 16)
+	require.NoError(v.UnmarshalText([]byte(changes["sgx.enclave_size"].(string))))
+	assert.GreaterOrEqual(v.GBytes(), 1.00)
+}
+
+func TestAppendAndReplace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Parse hardcoded test manifest
+	tomlTree, err := toml.Load(someManifest)
+	require.NoError(err)
+
+	// Get values from hardcoded test manifest
+	original := make(map[string]interface{})
+	changes := make(map[string]interface{})
+	original["sgx.remote_attestation"] = tomlTree.Get("sgx.remote_attestation")
+	original["sgx.enclave_size"] = tomlTree.Get("sgx.enclave_size")
+	original["sgx.thread_num"] = tomlTree.Get("sgx.thread_num")
+
+	// Set some changes we want to perform
+	changes["sgx.remote_attestation"] = 1
+	changes["sgx.enclave_size"] = "1024M"
+	changes["sgx.thread_num"] = 16
+
+	// Calculate the differences
+	diffs := calculateChanges(original, changes)
+
+	// Perform the modification
+	someNewManifest, err := appendAndReplace(diffs, []byte(someManifest))
+	assert.NoError(err)
+	assert.NotEqualValues(someManifest, someNewManifest)
+
+	// Check if it's still valid TOML & if changes were applied correctly
+	newTomlTree, err := toml.Load(string(someNewManifest))
+	assert.NoError(err)
+	newRemoteAttestation := newTomlTree.Get("sgx.remote_attestation")
+	assert.EqualValues(1, newRemoteAttestation.(int64))
+	newEnclaveSize := newTomlTree.Get("sgx.enclave_size")
+	assert.EqualValues("1024M", newEnclaveSize.(string))
+	newThreadNum := newTomlTree.Get("sgx.thread_num")
+	assert.EqualValues(16, newThreadNum.(int64))
+}
+
+func TestDownloadPremain(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Use HTTP mock for external download
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	testContent := []byte("this is obviously not a binary, but we gotta test this anyway!")
+
+	// We don't want to hardcode the version, so let's use a regexp match here
+	httpmock.RegisterResponder("GET", `=~^https://github\.com/edgelesssys/marblerun/releases/download/v[0-9\.]*/premain-graphene[\.so]{0}|[\.so]{3}`,
+		httpmock.NewBytesResponder(200, testContent))
+
+	// Create tempdir for downloads
+	tempDir, err := ioutil.TempDir("", "")
+	require.NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	// Try to download spawn & preload, fail for some invalid input
+	assert.NoError(downloadPremain(tempDir, "spawn"))
+	content, err := ioutil.ReadFile(filepath.Join(tempDir, premainNameSpawn))
+	assert.NoError(err)
+	assert.Equal(testContent, content)
+
+	assert.NoError(downloadPremain(tempDir, "preload"))
+	content, err = ioutil.ReadFile(filepath.Join(tempDir, premainNamePreload))
+	assert.NoError(err)
+	assert.Equal(testContent, content)
+
+	assert.Error(downloadPremain(tempDir, "someUnknownMode"))
+
+	// We should have two downloads here
+	info := httpmock.GetCallCountInfo()
+	assert.Equal(2, info[`GET =~^https://github\.com/edgelesssys/marblerun/releases/download/v[0-9\.]*/premain-graphene[\.so]{0}|[\.so]{3}`])
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,7 +8,7 @@ var globalUsage = `The marblerun CLI enables you to install and manage the Marbl
 confidential computing service mesh in your Kubernetes cluster
 
 To install and configure Marblerun, run:
-   
+
     $ marblerun install
 `
 
@@ -32,4 +32,5 @@ func init() {
 	rootCmd.AddCommand(newRecoverCmd())
 	rootCmd.AddCommand(newUninstallCmd())
 	rootCmd.AddCommand(newVersionCmd())
+	rootCmd.AddCommand(newGraphenePrepareCmd())
 }

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -124,7 +124,6 @@ func PromptYesNo(stdin io.Reader, question string) (bool, error) {
 	response = strings.ToLower(strings.TrimSpace(response))
 
 	if response != "y" && response != "yes" {
-		fmt.Println("Aborting.")
 		return false, nil
 	}
 

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/edgelesssys/era/era"
 	"k8s.io/client-go/kubernetes"
@@ -16,6 +18,8 @@ import (
 )
 
 const webhookName = "marble-injector.marblerun"
+
+const promptForChanges = "Do you want to automatically apply the suggested changes [y/n]? "
 
 var eraConfig string
 var insecureEra bool
@@ -107,4 +111,22 @@ func getKubernetesInterface() (*kubernetes.Clientset, error) {
 	}
 
 	return kubeClient, nil
+}
+
+func PromptYesNo(stdin io.Reader, question string) (bool, error) {
+	fmt.Print(question)
+	reader := bufio.NewReader(stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+
+	if response != "y" && response != "yes" {
+		fmt.Println("Aborting.")
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/cli/cmd/util_test.go
+++ b/cli/cmd/util_test.go
@@ -1,12 +1,53 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestServer(handler http.Handler) (server *httptest.Server, addr string, cert *pem.Block) {
 	s := httptest.NewTLSServer(handler)
 	return s, s.Listener.Addr().String(), &pem.Block{Type: "CERTIFICATE", Bytes: s.Certificate().Raw}
+}
+
+func TestPromptYesNo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var stdin bytes.Buffer
+
+	stdin.Write([]byte("y\n"))
+	approved, err := PromptYesNo(&stdin, promptForChanges)
+	require.NoError(err)
+	assert.True(approved)
+
+	// Typos are intentional to test if strings are lowercased later correctly
+	stdin.Reset()
+	stdin.Write([]byte("yEs\n"))
+	approved, err = PromptYesNo(&stdin, promptForChanges)
+	require.NoError(err)
+	assert.True(approved)
+
+	stdin.Reset()
+	stdin.Write([]byte("n\n"))
+	approved, err = PromptYesNo(&stdin, promptForChanges)
+	require.NoError(err)
+	assert.False(approved)
+
+	stdin.Reset()
+	stdin.Write([]byte("nO\n"))
+	approved, err = PromptYesNo(&stdin, promptForChanges)
+	require.NoError(err)
+	assert.False(approved)
+
+	stdin.Reset()
+	stdin.Write([]byte("ja\n"))
+	approved, err = PromptYesNo(&stdin, promptForChanges)
+	require.NoError(err)
+	assert.False(approved)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/edgelesssys/marblerun
 go 1.14
 
 require (
+	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/edgelesssys/ego v0.1.2
 	github.com/edgelesssys/era v0.3.0
 	github.com/gofrs/flock v0.8.0
@@ -12,6 +13,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/pelletier/go-toml v1.8.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/spf13/afero v1.5.1
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/pelletier/go-toml v1.8.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/spf13/afero v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/edgelesssys/ego v0.1.2
 	github.com/edgelesssys/era v0.3.0
+	github.com/fatih/color v1.10.0
 	github.com/gofrs/flock v0.8.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembj
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2 h1:t8KYCwSKsOEZBFELI4Pn/phbp38iJ1RRAkDFNin1aak=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -196,7 +198,6 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edgelesssys/ego v0.1.2 h1:ypDC5r+6+SHuIy+ArBPlnUhSH8bkUsnUHerNUP3xUc8=
 github.com/edgelesssys/ego v0.1.2/go.mod h1:2w3REN6B9YUdc98PF8d5jh6cmGNHORbKaJxTlLl5vxM=
-github.com/edgelesssys/era v0.1.1-0.20210209072546-fb6c08a3562c h1:tHXDurmMedmO1dWopD6qR24T93hnBd6Jf0tuIyHTXm8=
 github.com/edgelesssys/era v0.1.1-0.20210209072546-fb6c08a3562c/go.mod h1:rEv/EPEWTUpu8gGOUWp97Bk1kFFvgYwcJY0yA4cKG8U=
 github.com/edgelesssys/era v0.3.0 h1:YX2K+S24J1F0eP/T1eEHo0wDYBOWZbEOk2VWjZPby5M=
 github.com/edgelesssys/era v0.3.0/go.mod h1:5OB1KAIEjbCqrs+5VOK5Im28wbcNiyc/RD3AQtuw/sM=
@@ -283,7 +284,6 @@ github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14j
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -326,7 +326,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -436,7 +435,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -478,7 +476,6 @@ github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.12.0 h1:u/x3mp++qUxvYfulZ4HKOvVO0JWhk7HtE8lWhbGz/Do=
 github.com/mattn/go-sqlite3 v1.12.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -564,6 +561,8 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -653,7 +652,6 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
 github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.5.1 h1:VHu76Lk0LSP1x254maIu2bplkWpfBWI+B+6fdoZprcg=
 github.com/spf13/afero v1.5.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
@@ -684,17 +682,14 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
 github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/gjson v1.6.8 h1:CTmXMClGYPAmln7652e69B7OLXfTi5ABcPPwjIWUv7w=
 github.com/tidwall/gjson v1.6.8/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
-github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
@@ -789,7 +784,6 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -800,7 +794,6 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b h1:GgiSbuUyC0BlbUmHQBgFqu32eiRR/CEYdjOjOd4zE6Y=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
@@ -834,7 +827,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -893,7 +885,6 @@ golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -901,7 +892,6 @@ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -948,7 +938,6 @@ golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200122220014-bf1340f18c4a/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa h1:5E4dL8+NgFOgjwbTKz+OOEGGhP+ectTmF842l6KjupQ=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
@@ -958,7 +947,6 @@ golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 h1:HHeAlu5H9b71C+Fx0K+1dGg
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1002,7 +990,6 @@ google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a h1:pOwg4OoaRYScjmR4LlLgdtnyoHYTSAVhhqe5uPdpII8=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1021,7 +1008,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
-google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
@@ -1080,17 +1066,14 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/api v0.20.1 h1:ud1c3W3YNzGd6ABJlbFfKXBKXO+1KdGfcgGGNgFR03E=
 k8s.io/api v0.20.1/go.mod h1:KqwcCVogGxQY3nBlRpwt+wpAMF/KjaCc7RpywacvqUo=
 k8s.io/api v0.20.2 h1:y/HR22XDZY3pniu9hIFDLpUCPq2w5eQ6aV/VFQ7uJMw=
 k8s.io/api v0.20.2/go.mod h1:d7n6Ehyzx+S+cE3VhTGfVNNqtGc/oL9DCdYYahlurV8=
 k8s.io/apiextensions-apiserver v0.20.1 h1:ZrXQeslal+6zKM/HjDXLzThlz/vPSxrfK3OqL8txgVQ=
 k8s.io/apiextensions-apiserver v0.20.1/go.mod h1:ntnrZV+6a3dB504qwC5PN/Yg9PBiDNt1EVqbW2kORVk=
-k8s.io/apimachinery v0.20.1 h1:LAhz8pKbgR8tUwn7boK+b2HZdt7MiTu2mkYtFMUjTRQ=
 k8s.io/apimachinery v0.20.1/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/apimachinery v0.20.2 h1:hFx6Sbt1oG0n6DZ+g4bFt5f6BoMkOjKWsQFu077M3Vg=
 k8s.io/apimachinery v0.20.2/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
@@ -1098,7 +1081,6 @@ k8s.io/apiserver v0.20.1 h1:yEqdkxlnQbxi/3e74cp0X16h140fpvPrNnNRAJBDuBk=
 k8s.io/apiserver v0.20.1/go.mod h1:ro5QHeQkgMS7ZGpvf4tSMx6bBOgPfE+f52KwvXfScaU=
 k8s.io/cli-runtime v0.20.1 h1:fJhRQ9EfTpJpCqSFOAqnYLuu5aAM7yyORWZ26qW1jJc=
 k8s.io/cli-runtime v0.20.1/go.mod h1:6wkMM16ZXTi7Ow3JLYPe10bS+XBnIkL6V9dmEz0mbuY=
-k8s.io/client-go v0.20.1 h1:Qquik0xNFbK9aUG92pxHYsyfea5/RPO9o9bSywNor+M=
 k8s.io/client-go v0.20.1/go.mod h1:/zcHdt1TeWSd5HoUe6elJmHSQ6uLLgp4bIJHVEuy+/Y=
 k8s.io/client-go v0.20.2 h1:uuf+iIAbfnCSw8IGAv/Rg0giM+2bOzHLOsbbrwrdhNQ=
 k8s.io/client-go v0.20.2/go.mod h1:kH5brqWqp7HDxUFKoEgiI4v8G1xzbe9giaCenUWJzgE=

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,9 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -465,11 +466,13 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-oci8 v0.0.7/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
@@ -877,6 +880,7 @@ golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
So, this became quite the project.

This PR adds a feature to the Marblerun CLI in which Marblerun automatically tries to adapt an existing Graphene manifest to use Marblerun's premain & make the required changes.

For use with Graphene's examples, this seems to work mostly fine for the `preload` case with a minimal Marblerun manifest (basically only declaring the Package with MRENCLAVE and a Marble using this package), and also seems to work mostly fine for the `spawn` case when an adequate Marblerun manifest with correct argv provisioning was supplied to the coordinator.

Usage (`spawn`):
```bash
./marblerun graphene-prepare spawn <path>
```
Usage (`preload`):
```bash
./marblerun graphene-prepare preload <path>
```

Whereas <path> = path to the Graphene project manifest.template file

Screenshot of how it looks like:
![Screenshot of graphene-prepare](https://user-images.githubusercontent.com/26608194/113300363-20870480-92fe-11eb-91a8-d2b25cfcf658.png)

Feedback appreciated :) Especially ideas to simplify the code, it's quite nested unfortunately...