### PR TITLE
Miscellaneous fixes for CLI

### DIFF
--- a/cli/cmd/manifestSet.go
+++ b/cli/cmd/manifestSet.go
@@ -91,7 +91,7 @@ func cliManifestSet(manifest []byte, host string, cert []*pem.Block, recover str
 			if err := ioutil.WriteFile(recover, []byte(response.String()), 0644); err != nil {
 				return err
 			}
-			fmt.Printf("Manifest successfully set, recovery data saved to: %s.\n", recover)
+			fmt.Printf("Recovery data saved to: %s.\n", recover)
 		}
 	case http.StatusBadRequest:
 		respBody, err := ioutil.ReadAll(resp.Body)

--- a/cli/cmd/manifestUpdate.go
+++ b/cli/cmd/manifestUpdate.go
@@ -70,7 +70,7 @@ func cliManifestUpdate(manifest []byte, host string, clCert tls.Certificate, caC
 	}
 	// Add intermediate cert if applicable
 	if len(caCert) > 1 {
-		if ok := certPool.AppendCertsFromPEM([]byte(caCert[0].Bytes)); !ok {
+		if ok := certPool.AppendCertsFromPEM(pem.EncodeToMemory(caCert[0])); !ok {
 			return errors.New("Failed to parse certificate")
 		}
 	}

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -13,19 +12,15 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type coordinatorResponse struct {
-	StatusMessage string `json:"StatusMessage"`
-}
-
 func newRecoverCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "recover <IP:PORT> <recovery_key_decrypted>",
+		Use:   "recover <recovery_key_decrypted> <IP:PORT>",
 		Short: "Recovers the Marblerun coordinator from a sealed state",
 		Long:  `Recovers the Marblerun coordinator from a sealed state`,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hostName := args[0]
-			keyFile := args[1]
+			keyFile := args[0]
+			hostName := args[1]
 
 			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
 			if err != nil {
@@ -70,12 +65,8 @@ func cliRecover(host string, key []byte, cert []*pem.Block) error {
 		if err != nil {
 			return err
 		}
-		jsonResponse := gjson.GetBytes(respBody, "data")
-		var response coordinatorResponse
-		if err := json.Unmarshal([]byte(jsonResponse.String()), &response); err != nil {
-			return err
-		}
-		fmt.Printf("%s \n", response)
+		jsonResponse := gjson.GetBytes(respBody, "data.StatusMessage")
+		fmt.Printf("%s \n", jsonResponse.String())
 	default:
 		return fmt.Errorf("error connecting to server: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}


### PR DESCRIPTION
This PR fixes a few small things with the CLI:

* Parsing of intermediate certificate for the update command lead to an error
* Success message was printed twice when a recovery secret was returned and saved to file using `manifest set`
* `recover` was printing brackets when printing a returned status message


`recover` used to get its arguments in the following order:
* `marblerun recover <IP:PORT> <recovery_key>`

this was changed to be more in line with the rest of the CLI by passing IP:PORT as the second argument:
* `marblerun recover <recovery_key> <IP:PORT>`