### PR TITLE
AB#730 Add cli check and precheck commands

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func newCheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check the status of Marbleruns control plane",
+		Long:  `Check the status of Marbleruns control plane`,
+		Args:  cobra.NoArgs,
+		RunE: func(cobracmd *cobra.Command, args []string) error {
+			kubeClient, err := getKubernetesInterface()
+			if err != nil {
+				return err
+			}
+			return cliCheck(kubeClient)
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+// check if marblerun control-plane deployments are ready to use
+func cliCheck(kubeClient kubernetes.Interface) error {
+	err := checkDeploymentStatus(kubeClient, "marble-injector", "marblerun")
+	if err != nil {
+		return err
+	}
+
+	err = checkDeploymentStatus(kubeClient, "marblerun-coordinator", "marblerun")
+	if err != nil {
+		return err
+	}
+
+	// Add checks for other control plane deployments here
+	//
+	// err = checkDeploymentStatus(kubeClient, "some-control-plane-component", "marblerun")
+	//
+
+	return nil
+}
+
+// checkDeploymentStatus checks if a deployment is installed on the cluster
+// If it is, this function will wait until all replicas have the "available" status (ready for at least minReadySeconds)
+// Current status is continuously printed on screen
+func checkDeploymentStatus(kubeClient kubernetes.Interface, deploymentName string, namespace string) error {
+	_, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		fmt.Printf("%s is not installed on this cluster\n", deploymentName)
+	} else {
+		var podsReady string
+		deploymentReady := false
+		for !deploymentReady {
+			deploymentReady, podsReady, err = deploymentIsReady(kubeClient, deploymentName, namespace)
+			if err != nil {
+				return err
+			}
+
+			updateString := fmt.Sprintf("%s pods ready: %s", deploymentName, podsReady)
+			for i := 0; i < len(updateString); i++ {
+				fmt.Printf(" ")
+			}
+
+			fmt.Printf("\r%s", updateString)
+			time.Sleep(1)
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// deploymentIsReady checks on the status of a single deployment and returns the number of available pods in the form "available/total"
+func deploymentIsReady(kubeClient kubernetes.Interface, deploymentName string, namespace string) (bool, string, error) {
+	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return false, "", err
+	}
+
+	status := fmt.Sprintf("%d/%d", deployment.Status.AvailableReplicas, deployment.Status.Replicas)
+	if deployment.Status.Replicas == deployment.Status.AvailableReplicas {
+		return true, status, nil
+	}
+
+	return false, status, nil
+}

--- a/cli/cmd/check_test.go
+++ b/cli/cmd/check_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDeploymentIsReady(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testClient := fake.NewSimpleClientset()
+
+	deploymentName := "marblerun-coordinator"
+	namespace := "marblerun"
+
+	_, _, err := deploymentIsReady(testClient, deploymentName, namespace)
+	require.Error(err)
+
+	// create fake deployment with one non ready replica
+	// create a fake deployment with 1/1 available replicas
+	testDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: deploymentName,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            1,
+			UnavailableReplicas: 1,
+		},
+	}
+
+	_, err = testClient.AppsV1().Deployments(namespace).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	require.NoError(err)
+
+	ready, status, err := deploymentIsReady(testClient, deploymentName, namespace)
+	require.NoError(err)
+	assert.False(ready, "function returned true when deployment was not ready")
+	assert.Equal("0/1", status, fmt.Sprintf("Expected 0/1 ready pods but got %s", status))
+
+	testDeployment.Status.UnavailableReplicas = 0
+	testDeployment.Status.AvailableReplicas = 1
+	_, err = testClient.AppsV1().Deployments(namespace).UpdateStatus(context.TODO(), testDeployment, metav1.UpdateOptions{})
+	require.NoError(err)
+
+	ready, status, err = deploymentIsReady(testClient, deploymentName, namespace)
+	require.NoError(err)
+	assert.True(ready, "function returned false when deployment was ready")
+	assert.Equal("1/1", status, fmt.Sprintf("Expected 1/1 ready pods but got %s", status))
+}
+
+func TestCheckDeploymentStatus(t *testing.T) {
+	require := require.New(t)
+	testClient := fake.NewSimpleClientset()
+
+	deploymentName := "marblerun-coordinator"
+	namespace := "marblerun"
+
+	// try without any deployments
+	err := checkDeploymentStatus(testClient, deploymentName, namespace)
+	require.NoError(err)
+
+	// create a fake deployment with 1/1 available replicas
+	testDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: deploymentName,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			AvailableReplicas: 1,
+		},
+	}
+	_, err = testClient.AppsV1().Deployments(namespace).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	require.NoError(err)
+
+	err = checkDeploymentStatus(testClient, deploymentName, namespace)
+	require.NoError(err)
+}
+
+func TestCliCheck(t *testing.T) {
+	require := require.New(t)
+	testClient := fake.NewSimpleClientset()
+
+	// try without any deployments
+	err := cliCheck(testClient)
+	require.NoError(err)
+
+	// create a fake deployment with 1/1 available replicas
+	testDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "marblerun-coordinator",
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:          1,
+			AvailableReplicas: 1,
+		},
+	}
+	_, err = testClient.AppsV1().Deployments("marblerun").Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	require.NoError(err)
+
+	err = cliCheck(testClient)
+	require.NoError(err)
+}

--- a/cli/cmd/precheck.go
+++ b/cli/cmd/precheck.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	intelEpc       corev1.ResourceName = "sgx.intel.com/epc"
+	intelEnclave   corev1.ResourceName = "sgx.intel.com/enclave"
+	intelProvision corev1.ResourceName = "sgx.intel.com/provision"
+)
+
+func newPrecheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "precheck",
+		Short: "Check if your kubernetes cluster supports SGX",
+		Long:  `Check if your kubernetes cluster supports SGX`,
+		Args:  cobra.NoArgs,
+		RunE: func(cobracmd *cobra.Command, args []string) error {
+			kubeClient, err := getKubernetesInterface()
+			if err != nil {
+				return err
+			}
+			return cliCheckSGXSupport(kubeClient)
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+func cliCheckSGXSupport(kubeClient kubernetes.Interface) error {
+	nodes, err := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	numNodes := len(nodes.Items)
+	supportedNodes := 0
+
+	// Iterate over all nodes in the cluster and check their SGX support
+	for i := 0; i < numNodes; i++ {
+		if nodeSupportsSGX(nodes.Items[i].Status.Capacity) {
+			supportedNodes++
+		}
+	}
+
+	nodeString := "node"
+
+	if supportedNodes == 0 {
+		fmt.Println("Cluster does not support SGX, you may still run Marblerun in simulation mode")
+		fmt.Println("To install Marblerun run [marblerun install --simulation]")
+	} else {
+		if supportedNodes > 1 {
+			nodeString = nodeString + "s"
+		}
+		fmt.Printf("Cluster supports SGX on %d %s\n", supportedNodes, nodeString)
+		fmt.Println("To install Marblerun run [marblerun install]")
+	}
+
+	return nil
+}
+
+// nodeSupportsSGX checks if a single cluster node supports SGX in some way
+// Checks for different implementations of kubernetes SGX should be put here (e.g. different resource definitions than the one used by Azure)
+func nodeSupportsSGX(capacityInfo corev1.ResourceList) bool {
+	if nodeSupportsAzureSGX(capacityInfo) {
+		return true
+	}
+
+	// if nodeSupports[SomeCloudProvider]SGX(capacityInfo) {
+	// 	return true
+	// }
+
+	return false
+}
+
+// nodeSupportsAzureSGX checks if nodes in the cluster contain Azures SGX definitions
+func nodeSupportsAzureSGX(capacityInfo corev1.ResourceList) bool {
+	epcQuant := capacityInfo[intelEpc]
+	enclaveQuant := capacityInfo[intelEnclave]
+	provisionQuant := capacityInfo[intelProvision]
+	if epcQuant.Value() == 0 || enclaveQuant.Value() == 0 || provisionQuant.Value() == 0 {
+		return false
+	}
+	return true
+}

--- a/cli/cmd/precheck_test.go
+++ b/cli/cmd/precheck_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeSupportsAzureSGX(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	testClient := fake.NewSimpleClientset()
+
+	// Test node not supporting SGX
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regular-node",
+		},
+	}
+	_, err := testClient.CoreV1().Nodes().Create(context.TODO(), testNode, metav1.CreateOptions{})
+	require.NoError(err)
+
+	nodes, err := testClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(err)
+
+	supportsSGX := nodeSupportsSGX(nodes.Items[0].Status.Capacity)
+	assert.False(supportsSGX, "Function returned true for nodes not supporting SGX")
+
+	err = testClient.CoreV1().Nodes().Delete(context.TODO(), "regular-node", metav1.DeleteOptions{})
+	require.NoError(err)
+
+	// Test node supporting SGX
+	testNodeSGX := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sgx-node",
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				intelEnclave:   resource.MustParse("10"),
+				intelEpc:       resource.MustParse("500"),
+				intelProvision: resource.MustParse("10"),
+			},
+		},
+	}
+	_, err = testClient.CoreV1().Nodes().Create(context.TODO(), testNodeSGX, metav1.CreateOptions{})
+	require.NoError(err)
+
+	nodes, err = testClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(err)
+
+	supportsSGX = nodeSupportsSGX(nodes.Items[0].Status.Capacity)
+	assert.True(supportsSGX, "Function returned false for nodes supporting SGX")
+}
+
+func TestCliCheckSGXSupport(t *testing.T) {
+	require := require.New(t)
+	testClient := fake.NewSimpleClientset()
+
+	testNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "regular-node",
+		},
+	}
+	_, err := testClient.CoreV1().Nodes().Create(context.TODO(), testNode, metav1.CreateOptions{})
+	require.NoError(err)
+
+	_, err = testClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	require.NoError(err)
+
+	err = cliCheckSGXSupport(testClient)
+	require.NoError(err)
+
+	// Test node supporting SGX
+	testNodeSGX := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sgx-node",
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				intelEnclave:   resource.MustParse("10"),
+				intelEpc:       resource.MustParse("500"),
+				intelProvision: resource.MustParse("10"),
+			},
+		},
+	}
+	_, err = testClient.CoreV1().Nodes().Create(context.TODO(), testNodeSGX, metav1.CreateOptions{})
+	require.NoError(err)
+
+	err = cliCheckSGXSupport(testClient)
+	require.NoError(err)
+
+	testNodeSGX.ObjectMeta.Name = "sgx-node-2"
+	_, err = testClient.CoreV1().Nodes().Create(context.TODO(), testNodeSGX, metav1.CreateOptions{})
+	require.NoError(err)
+
+	err = cliCheckSGXSupport(testClient)
+	require.NoError(err)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -25,6 +25,8 @@ func Execute() error {
 
 func init() {
 	rootCmd.AddCommand(newCertificateCmd())
+	rootCmd.AddCommand(newCheckCmd())
+	rootCmd.AddCommand(newPrecheckCmd())
 	rootCmd.AddCommand(newInstallCmd())
 	rootCmd.AddCommand(newManifestCmd())
 	rootCmd.AddCommand(newStatusCmd())


### PR DESCRIPTION
This PR adds two new commands to the CLI:

* `precheck`: checks if a cluster supports SGX
  * If no node of the cluster has SGX supports the command suggests installing in simulation mode
  * If a cluster supports SGX it will show how many nodes do so
  * Currently this checks only if the nodes provide these resources (which all have to be non zero for the node to be considered having SGX support) :
    * `sgx.intel.com/epc`
    * `sgx.intel.com/enclave`
    * `sgx.intel.com/provision`
  * If more implementations come up the code is structured in a way to easily add checks for them

* `check`: checks if the marblerun-coordinator and/or the marble-injector have been deployed on the cluster
  * If either the coordinator or the injector exists the command checks how many replicas the deployment is supposed to have and waits until all replicas have the `available` status

