### PR TITLE
Check http status before saving era config to file

### DIFF
--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -46,6 +46,9 @@ func verifyCoordinator(host string, configFilename string, insecure bool) ([]*pe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("downloading era config failed with error %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
 	out, err := os.Create("era-config.json")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As requested here: https://github.com/edgelesssys/marblerun/pull/128#discussion_r611415094

This PR adds a check to `verifyCoordinator` in `cli/cmd/util.go` which makes sure we received an `OK` status when downloading the specified era-config.

Previously any problems during the http get request which would not result in an error from the function (e.g. `404`) were not caught  and would result in errors later on. This should be fixed now.