### PR TITLE
AB#804 Add CLI complete command

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	example := `
+  	For bash:
+  	source <(marblerun completion bash)
+
+	For zsh:
+	If shell completion is not already enabled in your environment you will need to enable it:
+	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+	To load completions for each session, execute once:
+	marblerun completion zsh > "${fpath[1]}/_marblerun"
+
+	For fish:
+	marblerun completion fish | source
+
+	To load fish shell completions for each session, execute once:
+	marblerun completion fish > ~/.config/fish/completions/marblerun.fish
+	`
+	cmd := &cobra.Command{
+		Use:                   "completion",
+		Short:                 "Output script for specified shell to enable autocompletion",
+		Long:                  `Output script for specified shell to enable autocompletion`,
+		Example:               example,
+		Args:                  cobra.ExactArgs(1),
+		ValidArgs:             []string{"bash", "fish", "zsh"},
+		DisableFlagsInUseLine: true,
+		SilenceErrors:         true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			shell := args[0]
+			out, err := cliCompletion(shell, cmd.Root())
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// cliCompletion returns the autocompletion script for the specified shell
+func cliCompletion(shell string, parent *cobra.Command) (string, error) {
+	var buf bytes.Buffer
+	var err error
+
+	switch shell {
+	case "bash":
+		err = parent.GenBashCompletion(&buf)
+	case "fish":
+		err = parent.GenFishCompletion(&buf, false)
+	case "zsh":
+		err = parent.GenZshCompletion(&buf)
+	default:
+		err = fmt.Errorf("unsopported shell type [%s]", shell)
+	}
+
+	return buf.String(), err
+}

--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -18,12 +18,6 @@ func newCompletionCmd() *cobra.Command {
 
 	To load completions for each session, execute once:
 	marblerun completion zsh > "${fpath[1]}/_marblerun"
-
-	For fish:
-	marblerun completion fish | source
-
-	To load fish shell completions for each session, execute once:
-	marblerun completion fish > ~/.config/fish/completions/marblerun.fish
 	`
 	cmd := &cobra.Command{
 		Use:                   "completion",
@@ -31,7 +25,7 @@ func newCompletionCmd() *cobra.Command {
 		Long:                  `Output script for specified shell to enable autocompletion`,
 		Example:               example,
 		Args:                  cobra.ExactArgs(1),
-		ValidArgs:             []string{"bash", "fish", "zsh"},
+		ValidArgs:             []string{"bash", "zsh"},
 		DisableFlagsInUseLine: true,
 		SilenceErrors:         true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,8 +50,8 @@ func cliCompletion(shell string, parent *cobra.Command) (string, error) {
 	switch shell {
 	case "bash":
 		err = parent.GenBashCompletion(&buf)
-	case "fish":
-		err = parent.GenFishCompletion(&buf, false)
+	//case "fish":
+	//	err = parent.GenFishCompletion(&buf, false)
 	case "zsh":
 		err = parent.GenZshCompletion(&buf)
 	default:

--- a/cli/cmd/completion_test.go
+++ b/cli/cmd/completion_test.go
@@ -13,9 +13,9 @@ func TestCliCompletion(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(bashCompletion, "# bash completion for marblerun")
 
-	fishCompletion, err := cliCompletion("fish", rootCmd)
-	assert.NoError(err)
-	assert.Contains(fishCompletion, "# fish completion for marblerun")
+	//fishCompletion, err := cliCompletion("fish", rootCmd)
+	//assert.NoError(err)
+	//assert.Contains(fishCompletion, "# fish completion for marblerun")
 
 	zshCompletion, err := cliCompletion("zsh", rootCmd)
 	assert.NoError(err)

--- a/cli/cmd/completion_test.go
+++ b/cli/cmd/completion_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCliCompletion(t *testing.T) {
+	assert := assert.New(t)
+
+	bashCompletion, err := cliCompletion("bash", rootCmd)
+	assert.NoError(err)
+	assert.Contains(bashCompletion, "# bash completion for marblerun")
+
+	fishCompletion, err := cliCompletion("fish", rootCmd)
+	assert.NoError(err)
+	assert.Contains(fishCompletion, "# fish completion for marblerun")
+
+	zshCompletion, err := cliCompletion("zsh", rootCmd)
+	assert.NoError(err)
+	assert.Contains(zshCompletion, "# zsh completion for marblerun")
+
+	_, err = cliCompletion("unsupproted-shell", rootCmd)
+	assert.Error(err)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -26,13 +26,14 @@ func Execute() error {
 func init() {
 	rootCmd.AddCommand(newCertificateCmd())
 	rootCmd.AddCommand(newCheckCmd())
-	rootCmd.AddCommand(newPrecheckCmd())
+	rootCmd.AddCommand(newCompletionCmd())
+	rootCmd.AddCommand(newGraphenePrepareCmd())
 	rootCmd.AddCommand(newInstallCmd())
 	rootCmd.AddCommand(newManifestCmd())
-	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newNamespaceCmd())
+	rootCmd.AddCommand(newPrecheckCmd())
 	rootCmd.AddCommand(newRecoverCmd())
+	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newUninstallCmd())
 	rootCmd.AddCommand(newVersionCmd())
-	rootCmd.AddCommand(newGraphenePrepareCmd())
 }


### PR DESCRIPTION
This PR adds a new command `completion`.
This new command generates a shell script which enables autocompletion for the cli.

I tested this with `bash` and `zsh` without encountering errors.
`fish` completion works but i received some errors when using the completion. If anyone uses the `fish` shell and would like to test it i would be glad to hear your feedback. If not i will remove support for `fish` before merging.