### PR TITLE
AB#700: Add PreMainEgo and let EGo handle filesystem mounting

### DIFF
--- a/marble/premain/premain.go
+++ b/marble/premain/premain.go
@@ -102,6 +102,13 @@ func PreMain() error {
 	return PreMainEx(ertvalidator.NewERTIssuer(), ActivateRPC, hostfs, enclavefs)
 }
 
+// PreMainEgo works similar to PreMain, but let's EGo's premain handle the in-enclave memory filesystem mounting
+func PreMainEgo() error {
+	hostfs := afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(filepath.FromSlash("/edg"), "hostfs"))
+	enclavefs := afero.NewOsFs()
+	return PreMainEx(ertvalidator.NewERTIssuer(), ActivateRPC, hostfs, enclavefs)
+}
+
 // PreMainMock mocks the quoting and file system handling in the PreMain routine for testing.
 func PreMainMock() error {
 	hostfs := afero.NewOsFs()


### PR DESCRIPTION
Additional PR for https://github.com/edgelesssys/ego/pull/49

With EGo soon handling filesystem mounts, I think it's better that we have a separate Premain which does not handle filesystem mounting but expects it to be already prepared. Saves some if/else blocks in EGo.