### PR TITLE
AB#914 cli exit code 1 on error

### DIFF
--- a/cli/cmd/manifestVerify.go
+++ b/cli/cmd/manifestVerify.go
@@ -33,6 +33,7 @@ func newManifestVerify() *cobra.Command {
 
 			return cliManifestVerify(localSignature, hostName, cert)
 		},
+		SilenceUsage: true,
 	}
 
 	return cmd

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/edgelesssys/marblerun/cli/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
While currently the CLI returns errors to the users, this is not reflected in the exit code of the program. This makes using the CLI as part of a shell script annoying since we dont have a reliable way to check for errors.

This PR fixes that problem by returning `1` on error and `0` on success

