### PR TITLE
Ref/improve samples

### DIFF
--- a/samples/graphene-hello/README.md
+++ b/samples/graphene-hello/README.md
@@ -20,7 +20,7 @@ Then get `mr_enclave` from the build output and set it as `UniqueID` in `manifes
 ## Run
 Next, use the `erthost` command to start the Coordinator in a local enclave:
 ```sh
-erthost ../../../build/coordinator-enclave.signed
+erthost ../../build/coordinator-enclave.signed
 ```
 
 The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (port 2001). While the Coordinator and your Marble communicate via the mesh API, you can administrate the Coordinator via the REST API.

--- a/samples/graphene-hello/manifest.json
+++ b/samples/graphene-hello/manifest.json
@@ -13,7 +13,7 @@
                     "HELLO_WORLD": "Hello World from Marblerun!"
                 },
                 "Argv": [
-                    "Welcome!",
+                    "./hello",
                     "Hello World from Marblerun!"
                 ]
             }

--- a/samples/graphene-nginx/README.md
+++ b/samples/graphene-nginx/README.md
@@ -16,7 +16,7 @@ make SGX=1
 
 Start the Coordinator in a SGX enclave:
 ```sh
-erthost ../../../build/coordinator-enclave.signed
+erthost ../../build/coordinator-enclave.signed
 ```
 
 The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (port 2001). While the Coordinator and your Marble communicate via the mesh API, you can administrate the Coordinator via the REST API.

--- a/samples/graphene-redis/README.md
+++ b/samples/graphene-redis/README.md
@@ -30,8 +30,8 @@ First, we are installing Marblerun on your cluster.
 * Port-forward the client API service to localhost
 
     ```bash
-    kubectl -n marblerun port-forward svc/coordinator-client-api 25555:25555 --address localhost >/dev/null &
-    export MARBLERUN=localhost:25555
+    kubectl -n marblerun port-forward svc/coordinator-client-api 4433:4433 --address localhost >/dev/null &
+    export MARBLERUN=localhost:4433
     ```
 
 * Check Coordinator's status, this should return status `2: ready to accept manifest`.

--- a/samples/helloc++/README.md
+++ b/samples/helloc++/README.md
@@ -34,7 +34,7 @@ The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (
 
 Once the Coordinator instance is running, you can upload the manifest to the Coordinator's client API:
 ```sh
-curl -k --data-binary @manifest.json https://localhost:4433/manifest
+curl -k --data-binary @../manifest.json https://localhost:4433/manifest
 ```
 
 To run the application, you need to set some environment variables. The type of the Marble is defined in the `manifest.json`. In this example, the manifest defines a single Marble, which is called "hello". The Marble's DNS name and the Coordinator's address are used to establish a connection between the Coordinator's mesh API and the Marble. Further, the UUID file stores a unique ID that enables a restart of the application.
@@ -43,6 +43,6 @@ EDG_MARBLE_TYPE=hello \
 EDG_MARBLE_COORDINATOR_ADDR=localhost:2001 \
 EDG_MARBLE_UUID_FILE=$PWD/uuid \
 EDG_MARBLE_DNS_NAMES=localhost \
-erthost build/enclave.signed
+erthost enclave.signed
 ```
 The app prints a "Hello world!" followed by the command line arguments that are defined in the `manifest.json`.

--- a/samples/helloc++/manifest.json
+++ b/samples/helloc++/manifest.json
@@ -2,7 +2,7 @@
     "Packages": {
         "world": {
             "Debug": true,
-            "UniqueID": "<replace with mrenclave obtained by `ego uniqueid hello`>"
+            "UniqueID": "<replace with mrenclave obtained by `oesign dump -e enclave.signed`>"
         }
     },
     "Marbles": {

--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -29,7 +29,7 @@ curl -k --data-binary @manifest.json https://localhost:4433/manifest
 
 Finaly, you can run the helloworld Marble (or whatever Marble you just created) with the `ego marblerun` command. You just need to set `EDG_MARBLE_TYPE` to a Marble that was defined in the `manifest.json`. In this example, the manifest defines a single Marble, which is called "hello".
 ```sh
-EDG_MARBLE_TYPE=hello ego marblerun helloworld
+EDG_MARBLE_TYPE=hello ego marblerun hello
 ```
 EGo starts the Marble, which will then connect itself to the mesh API of the Coordinator.
 

--- a/samples/occlum-hello/README.md
+++ b/samples/occlum-hello/README.md
@@ -27,7 +27,7 @@ cd marblerun/samples/occlum-hello
 make
 ```
 
-After you build the Occlum image, you need to retrieve the for `UniqueID` or `SignerID`/`ProductID`/`SecurityVersion` values for Marblerun's [`manifest.json`](manifest.json). You can get the values using the Marblerun CLI tool:
+After you build the Occlum image, you need to retrieve either the `UniqueID` or the `SignerID`/`ProductID`/`SecurityVersion` triple for Marblerun's [`manifest.json`](manifest.json). You can get the values using the Marblerun CLI tool:
 
 ```sh
 wget https://github.com/edgelesssys/marblerun/releases/latest/download/marblerun


### PR DESCRIPTION
Fixes some wording to make running samples smoother.
Also changes the graphene-hello sample to use the program name as argv0 in the Marblerun manifest.