### PR TITLE
make ttls clientAuth configurable

### DIFF
--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -357,7 +357,7 @@ func (c *Core) setTTLSConfig(marble manifest.Marble, specialSecrets reservedSecr
 
 				connConf["clicrt"] = stringUserClientCert
 				connConf["clikey"] = stringUserClientKey
-				connConf["clientAuth"] = false
+				connConf["clientAuth"] = !entry.DisableClientAuth
 				connConf["cacrt"] = stringCaCert
 
 			} else {

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -65,9 +65,10 @@ type TLStag struct {
 
 // TLSTagEntry describes one connection which should be elevated to ttls
 type TLSTagEntry struct {
-	Port string
-	Addr string
-	Cert string
+	Port              string
+	Addr              string
+	Cert              string
+	DisableClientAuth bool
 }
 
 // Check checks if the manifest is consistent.
@@ -129,6 +130,13 @@ func (m Manifest) Check(ctx context.Context, zaplogger *zap.Logger) error {
 			if entry.Cert != "" {
 				if _, ok := m.Secrets[entry.Cert]; !ok {
 					return fmt.Errorf("TLS.Incoming.%s references undefined secret %s", key, entry.Cert)
+				}
+				if !entry.DisableClientAuth {
+					return fmt.Errorf("TLS.Incoming.%s defines Cert but does not disable client authentication", key)
+				}
+			} else {
+				if entry.DisableClientAuth {
+					return fmt.Errorf("TLS.Incoming.%s disables client authentication", key)
 				}
 			}
 		}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -165,7 +165,8 @@ const ManifestJSON string = `{
 			"Incoming": [
 				{
 					"Port": "8080",
-					"Cert": "cert_shared"
+					"Cert": "cert_shared",
+					"DisableClientAuth": true
 				}
 			]
 		}


### PR DESCRIPTION
Previously whenever "Cert" was specified, we disabled ttls clientAuth.
Now the user can set clientAuth on incoming connections where a custom certificate is set. The client then needs to have a valid certificate signed by the coordinator's root CA. 
Also see https://github.com/edgelesssys/marblerun.sh/pull/49#discussion_r642926105