### PR TITLE
AB#999 Use cross-signed intermediate certificate

### DIFF
--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -28,7 +28,7 @@ func TestCore(t *testing.T) {
 	curState, err := c.store.getState()
 	assert.NoError(err)
 	assert.Equal(stateAcceptingManifest, curState)
-	rootCert, err := c.store.getCertificate("root")
+	rootCert, err := c.store.getCertificate(sKCoordinatorRootCert)
 	assert.NoError(err)
 	assert.Equal(coordinatorName, rootCert.Subject.CommonName)
 
@@ -189,9 +189,9 @@ func TestGenerateSecrets(t *testing.T) {
 
 	c := NewCoreWithMocks()
 
-	rootCert, err := c.store.getCertificate("root")
+	rootCert, err := c.store.getCertificate(sKCoordinatorRootCert)
 	assert.NoError(err)
-	rootPrivK, err := c.store.getPrivK("root")
+	rootPrivK, err := c.store.getPrivK(sKCoordinatorRootKey)
 	assert.NoError(err)
 
 	// This should return valid secrets

--- a/coordinator/core/openssl_test.go
+++ b/coordinator/core/openssl_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build openssl_test
+
+package core
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net"
+	"testing"
+
+	libMarble "github.com/edgelesssys/ego/marble"
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
+	"github.com/edgelesssys/marblerun/coordinator/quote"
+	"github.com/edgelesssys/marblerun/coordinator/recovery"
+	"github.com/edgelesssys/marblerun/coordinator/rpc"
+	"github.com/edgelesssys/marblerun/coordinator/seal"
+	"github.com/edgelesssys/marblerun/test"
+	"github.com/edgelesssys/marblerun/util"
+	"github.com/google/uuid"
+	"github.com/spacemonkeygo/openssl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+func TestOpenSSLVerify(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// parse manifest
+	var manifest manifest.Manifest
+	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
+
+	// setup mock zaplogger which can be passed to Core
+	zapLogger, err := zap.NewDevelopment()
+	require.NoError(err)
+	defer zapLogger.Sync()
+
+	// create core
+	validator := quote.NewMockValidator()
+	issuer := quote.NewMockIssuer()
+	sealer := &seal.MockSealer{}
+	recovery := recovery.NewSinglePartyRecovery()
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, sealer, recovery, zapLogger)
+	require.NoError(err)
+	require.NotNil(coreServer)
+
+	// set manifest
+	_, err = coreServer.SetManifest(context.TODO(), []byte(test.ManifestJSON))
+	require.NoError(err)
+
+	// create marble
+	marbleType := "backend_first"
+	infraName := "Azure"
+	cert, csr, _ := util.MustGenerateTestMarbleCredentials()
+	// create mock quote using values from the manifest
+	quote, err := issuer.Issue(cert.Raw)
+	assert.NotNil(quote)
+	assert.Nil(err)
+	marble, ok := manifest.Marbles[marbleType]
+	assert.True(ok)
+	pkg, ok := manifest.Packages[marble.Package]
+	assert.True(ok)
+	infra, ok := manifest.Infrastructures[infraName]
+	assert.True(ok)
+	validator.AddValidQuote(quote, cert.Raw, pkg, infra)
+
+	tlsInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{cert},
+		},
+	}
+
+	ctx := peer.NewContext(context.TODO(), &peer.Peer{
+		AuthInfo: tlsInfo,
+	})
+
+	resp, err := coreServer.Activate(ctx, &rpc.ActivationReq{
+		CSR:        csr,
+		MarbleType: marbleType,
+		Quote:      quote,
+		UUID:       uuid.New().String(),
+	})
+
+	assert.NoError(err, "Activate failed: %v", err)
+	assert.NotNil(resp)
+
+	// Get marble credentials
+	params := resp.GetParameters()
+	pMarbleKey, _ := pem.Decode([]byte(params.Env[libMarble.MarbleEnvironmentPrivateKey]))
+	require.NotNil(pMarbleKey)
+	pLeaf, rest := pem.Decode([]byte(params.Env[libMarble.MarbleEnvironmentCertificateChain]))
+	require.NotNil(pLeaf)
+	require.NotEmpty(rest)
+	pMarbleRoot, rest := pem.Decode(rest)
+	require.NotNil(pMarbleRoot)
+	require.Empty(rest)
+
+	// Verify cert-chain with OpenSSL
+	openSSLCtx, err := openssl.NewCtx()
+	require.NoError(err)
+	certStore := openSSLCtx.GetCertificateStore()
+	rootCert, err := openssl.LoadCertificateFromPEM(pem.EncodeToMemory(pMarbleRoot))
+	require.NoError(err)
+	leafCert, err := openssl.LoadCertificateFromPEM(pem.EncodeToMemory(pLeaf))
+	require.NoError(err)
+	privKey, err := openssl.LoadPrivateKeyFromPEM(pem.EncodeToMemory(pMarbleKey))
+	require.NoError(err)
+	require.NoError(certStore.AddCertificate(rootCert))
+	require.NoError(openSSLCtx.AddChainCertificate(rootCert))
+	require.NoError(openSSLCtx.UseCertificate(leafCert))
+	require.NoError(openSSLCtx.UsePrivateKey(privKey))
+	openSSLCtx.SetVerifyMode(openssl.VerifyPeer)
+
+	server, client := net.Pipe()
+	go func() {
+		sslServer, err := openssl.Server(server, openSSLCtx)
+		require.NoError(err)
+		assert.NoError(sslServer.Handshake())
+		server.Close()
+	}()
+	sslClient, err := openssl.Client(client, openSSLCtx)
+	require.NoError(err)
+	assert.NoError(sslClient.Handshake())
+	verifyResult := sslClient.VerifyResult()
+	assert.Equal(openssl.Ok, verifyResult, "failed to verify certificate with openssl: %v", verifyResult)
+}

--- a/coordinator/core/storewrapper_test.go
+++ b/coordinator/core/storewrapper_test.go
@@ -24,9 +24,9 @@ func TestStoreWrapper(t *testing.T) {
 	c := NewCoreWithMocks()
 
 	// creating a new core should have set root and intermediate certs/keys
-	_, err := c.store.getCertificate("root")
+	_, err := c.store.getCertificate(sKCoordinatorRootCert)
 	assert.NoError(err)
-	_, err = c.store.getPrivK("root")
+	_, err = c.store.getPrivK(sKCoordinatorRootKey)
 	assert.NoError(err)
 
 	rawManifest := []byte(test.ManifestJSON)
@@ -37,9 +37,9 @@ func TestStoreWrapper(t *testing.T) {
 		Size:   16,
 		Shared: true,
 	}
-	someCert, somePrivK, err := generateCert([]string{"example.com"}, coordinatorName, nil, nil)
+	someCert, somePrivK, err := generateCert([]string{"example.com"}, coordinatorName, nil, nil, nil)
 	require.NoError(err)
-	testUserCert, _, err := generateCert([]string{"example.com"}, "test-user", nil, nil)
+	testUserCert, _, err := generateCert([]string{"example.com"}, "test-user", nil, nil, nil)
 	require.NoError(err)
 	testUser := &marblerunUser{name: "test-user", certificate: testUserCert}
 
@@ -89,13 +89,13 @@ func TestStoreWrapperDefaults(t *testing.T) {
 	c := NewCoreWithMocks()
 
 	// values for root / intermediate and state should be set by core init function
-	_, err := c.store.getCertificate("root")
+	_, err := c.store.getCertificate(sKCoordinatorRootCert)
 	assert.NoError(err)
-	_, err = c.store.getCertificate("intermediate")
+	_, err = c.store.getCertificate(skCoordinatorIntermediateCert)
 	assert.NoError(err)
-	_, err = c.store.getPrivK("root")
+	_, err = c.store.getPrivK(sKCoordinatorRootKey)
 	assert.NoError(err)
-	_, err = c.store.getPrivK("intermediate")
+	_, err = c.store.getPrivK(sKCoordinatorIntermediateKey)
 	assert.NoError(err)
 	state, err := c.store.getState()
 	assert.NoError(err)

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -63,7 +63,7 @@ type recoveryStatusResp struct {
 // The effective TCP address is returned via `addrChan`.
 func RunMarbleServer(core *core.Core, addr string, addrChan chan string, errChan chan error, zapLogger *zap.Logger) {
 	tlsConfig := tls.Config{
-		GetCertificate: core.GetTLSIntermediateCertificate,
+		GetCertificate: core.GetTLSMarbleRootCertificate,
 		// NOTE: we'll verify the cert later using the given quote
 		ClientAuth: tls.RequireAnyClientCert,
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,13 @@ go 1.14
 
 require (
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
-	github.com/edgelesssys/ego v0.1.2
+	github.com/edgelesssys/ego v0.2.4-0.20210609075311-d09986cbed77
 	github.com/edgelesssys/era v0.3.0
+	github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855 // indirect
 	github.com/fatih/color v1.10.0
 	github.com/gofrs/flock v0.8.0
 	github.com/golang/protobuf v1.4.3
-	github.com/google/go-cmp v0.5.5
+	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
@@ -17,12 +18,13 @@ require (
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/pelletier/go-toml v1.8.1
 	github.com/prometheus/client_golang v1.8.0
+	github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a
 	github.com/spf13/afero v1.5.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.6.8
 	go.uber.org/zap v1.16.0
-	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0
@@ -30,5 +32,6 @@ require (
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
+	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edgelesssys/ego v0.1.2 h1:ypDC5r+6+SHuIy+ArBPlnUhSH8bkUsnUHerNUP3xUc8=
 github.com/edgelesssys/ego v0.1.2/go.mod h1:2w3REN6B9YUdc98PF8d5jh6cmGNHORbKaJxTlLl5vxM=
+github.com/edgelesssys/ego v0.2.4-0.20210609075311-d09986cbed77 h1:PZjjdPlJPeU192bz5gST+4wNEY5Y2JvuwFMCT6S9j70=
+github.com/edgelesssys/ego v0.2.4-0.20210609075311-d09986cbed77/go.mod h1:bJ5ZgOZs8EymTLb7ga0bqipr/J6Hp7Xg+ITwGFnou58=
 github.com/edgelesssys/era v0.1.1-0.20210209072546-fb6c08a3562c/go.mod h1:rEv/EPEWTUpu8gGOUWp97Bk1kFFvgYwcJY0yA4cKG8U=
 github.com/edgelesssys/era v0.3.0 h1:YX2K+S24J1F0eP/T1eEHo0wDYBOWZbEOk2VWjZPby5M=
 github.com/edgelesssys/era v0.3.0/go.mod h1:5OB1KAIEjbCqrs+5VOK5Im28wbcNiyc/RD3AQtuw/sM=
@@ -330,6 +332,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -654,6 +658,10 @@ github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:s
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a h1:/eS3yfGjQKG+9kayBkj0ip1BGhq6zJ3eaVksphxAaek=
+github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
+github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
+github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -770,6 +778,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -835,6 +845,8 @@ golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -894,6 +906,10 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1049,6 +1065,8 @@ gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
+gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=


### PR DESCRIPTION
Cross-sign the intermediate certificate.
The Marbles see a self-signed root certificate.
The "outside world" sees an intermediate certificate signed by the Coordinator's root CA.
Verifies the certificate chain with OpenSSL in the Marble API test.
Fixes #175 