### PR TITLE
Fix CLI install for Intel device plugin

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -416,6 +416,11 @@ func setSGXValues(resourceKey string, values, chartValues map[string]interface{}
 	if needNewLimit {
 		values["coordinator"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{})[resourceKey] = 10
 	}
+
+	// Make sure provision bit is set if the Intel plugin is used
+	if resourceKey == intelEpc.String() {
+		values["coordinator"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{})[intelProvision.String()] = 1
+	}
 }
 
 // errorAndCleanup returns the given error and deletes resources which might have been created previously

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -390,6 +390,12 @@ func setSGXValues(resourceKey string, values, chartValues map[string]interface{}
 
 	toRemove := fmt.Sprintf("%s %s", intelEpc.String(), azureEpc.String())
 	var needNewLimit bool
+	var limit string
+	if resourceKey == azureEpc.String() {
+		limit = "10"
+	} else {
+		limit = "10Mi"
+	}
 
 	// remove all previously set sgx resource limits
 	if presetLimits, ok := chartValues["coordinator"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{}); ok {
@@ -414,7 +420,7 @@ func setSGXValues(resourceKey string, values, chartValues map[string]interface{}
 
 	// Set the new sgx resource limit, kubernetes will automatically set a resource request equal to the limit
 	if needNewLimit {
-		values["coordinator"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{})[resourceKey] = 10
+		values["coordinator"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{})[resourceKey] = limit
 	}
 
 	// Make sure provision bit is set if the Intel plugin is used

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/edgelesssys/marblerun/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	certv1 "k8s.io/api/certificates/v1"
@@ -115,9 +116,9 @@ func TestGetSGXResourceKey(t *testing.T) {
 		},
 		Status: corev1.NodeStatus{
 			Capacity: corev1.ResourceList{
-				intelEnclave:   resource.MustParse("10"),
-				intelEpc:       resource.MustParse("500"),
-				intelProvision: resource.MustParse("10"),
+				util.IntelEnclave:   resource.MustParse("10"),
+				util.IntelEpc:       resource.MustParse("500"),
+				util.IntelProvision: resource.MustParse("10"),
 			},
 		},
 	}
@@ -126,7 +127,7 @@ func TestGetSGXResourceKey(t *testing.T) {
 
 	resourceKey, err := getSGXResourceKey(testClient)
 	assert.NoError(err)
-	assert.Equal(intelEpc.String(), resourceKey)
+	assert.Equal(util.IntelEpc.String(), resourceKey)
 }
 
 func TestErrorAndCleanup(t *testing.T) {

--- a/cli/cmd/precheck.go
+++ b/cli/cmd/precheck.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/edgelesssys/marblerun/util"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-)
-
-const (
-	intelEpc       corev1.ResourceName = "sgx.intel.com/epc"
-	intelEnclave   corev1.ResourceName = "sgx.intel.com/enclave"
-	intelProvision corev1.ResourceName = "sgx.intel.com/provision"
-	azureEpc       corev1.ResourceName = "kubernetes.azure.com/sgx_epc_mem_in_MiB"
 )
 
 func newPrecheckCmd() *cobra.Command {
@@ -74,14 +68,14 @@ func nodeSupportsSGX(capacityInfo corev1.ResourceList) bool {
 
 // nodeHasAzureDevPlugin checks if a node has the Azures SGX device plugin installed
 func nodeHasAzureDevPlugin(capacityInfo corev1.ResourceList) bool {
-	epcQuant := capacityInfo[azureEpc]
+	epcQuant := capacityInfo[util.AzureEpc]
 	return epcQuant.Value() != 0
 }
 
 // nodeHasIntelDevPlugin checks if a node has the Intel SGX device plugin installed
 func nodeHasIntelDevPlugin(capacityInfo corev1.ResourceList) bool {
-	epcQuant := capacityInfo[intelEpc]
-	enclaveQuant := capacityInfo[intelEnclave]
-	provisionQuant := capacityInfo[intelProvision]
+	epcQuant := capacityInfo[util.IntelEpc]
+	enclaveQuant := capacityInfo[util.IntelEnclave]
+	provisionQuant := capacityInfo[util.IntelProvision]
 	return !(epcQuant.Value() == 0 || enclaveQuant.Value() == 0 || provisionQuant.Value() == 0)
 }

--- a/cli/cmd/precheck_test.go
+++ b/cli/cmd/precheck_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/edgelesssys/marblerun/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -42,9 +43,9 @@ func TestNodeSupportsSGX(t *testing.T) {
 		},
 		Status: corev1.NodeStatus{
 			Capacity: corev1.ResourceList{
-				intelEnclave:   resource.MustParse("10"),
-				intelEpc:       resource.MustParse("500"),
-				intelProvision: resource.MustParse("10"),
+				util.IntelEnclave:   resource.MustParse("10"),
+				util.IntelEpc:       resource.MustParse("500"),
+				util.IntelProvision: resource.MustParse("10"),
 			},
 		},
 	}
@@ -67,7 +68,7 @@ func TestNodeSupportsSGX(t *testing.T) {
 		},
 		Status: corev1.NodeStatus{
 			Capacity: corev1.ResourceList{
-				azureEpc: resource.MustParse("500"),
+				util.AzureEpc: resource.MustParse("500"),
 			},
 		},
 	}
@@ -107,9 +108,9 @@ func TestCliCheckSGXSupport(t *testing.T) {
 		},
 		Status: corev1.NodeStatus{
 			Capacity: corev1.ResourceList{
-				intelEnclave:   resource.MustParse("10"),
-				intelEpc:       resource.MustParse("500"),
-				intelProvision: resource.MustParse("10"),
+				util.IntelEnclave:   resource.MustParse("10"),
+				util.IntelEpc:       resource.MustParse("500"),
+				util.IntelProvision: resource.MustParse("10"),
 			},
 		},
 	}

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -14,6 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const azureEPC = "kubernetes.azure.com/sgx_epc_mem_in_MiB"
+
 // Mutator struct
 type Mutator struct {
 	// CoordAddr contains the address of the marblerun coordinator
@@ -277,14 +279,20 @@ func addEnvVar(setVars, newVars []corev1.EnvVar, basePath string) []map[string]i
 
 // createResourcePatch creates a json patch for sgx resource limits
 func createResourcePatch(container corev1.Container, idx int, resourceKey string) map[string]interface{} {
+	var limit string
+	if resourceKey == azureEPC {
+		limit = "10"
+	} else {
+		limit = "10Mi"
+	}
 	// first check if neither limits nor requests have been set for the container -> we need to create the complete path
 	if len(container.Resources.Limits) <= 0 && len(container.Resources.Requests) <= 0 {
 		return map[string]interface{}{
 			"op":   "add",
 			"path": fmt.Sprintf("/spec/containers/%d/resources", idx),
 			"value": map[string]interface{}{
-				"limits": map[string]int{
-					resourceKey: 10,
+				"limits": map[string]string{
+					resourceKey: limit,
 				},
 			},
 		}
@@ -294,8 +302,8 @@ func createResourcePatch(container corev1.Container, idx int, resourceKey string
 		return map[string]interface{}{
 			"op":   "add",
 			"path": fmt.Sprintf("/spec/containers/%d/resources/limits", idx),
-			"value": map[string]int{
-				resourceKey: 10,
+			"value": map[string]string{
+				resourceKey: limit,
 			},
 		}
 	}
@@ -306,7 +314,7 @@ func createResourcePatch(container corev1.Container, idx int, resourceKey string
 	return map[string]interface{}{
 		"op":    "add",
 		"path":  fmt.Sprintf("/spec/containers/%d/resources/limits/%s", idx, newKey),
-		"value": 10,
+		"value": limit,
 	}
 }
 

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -9,12 +9,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/edgelesssys/marblerun/util"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const azureEPC = "kubernetes.azure.com/sgx_epc_mem_in_MiB"
 
 // Mutator struct
 type Mutator struct {
@@ -279,12 +278,7 @@ func addEnvVar(setVars, newVars []corev1.EnvVar, basePath string) []map[string]i
 
 // createResourcePatch creates a json patch for sgx resource limits
 func createResourcePatch(container corev1.Container, idx int, resourceKey string) map[string]interface{} {
-	var limit string
-	if resourceKey == azureEPC {
-		limit = "10"
-	} else {
-		limit = "10Mi"
-	}
+	limit := util.GetEPCResourceLimit(resourceKey)
 	// first check if neither limits nor requests have been set for the container -> we need to create the complete path
 	if len(container.Resources.Limits) <= 0 && len(container.Resources.Requests) <= 0 {
 		return map[string]interface{}{

--- a/injector/injector_test.go
+++ b/injector/injector_test.go
@@ -64,7 +64,7 @@ func TestMutatesValidRequest(t *testing.T) {
 	r := v1.AdmissionReview{}
 	require.NoError(json.Unmarshal(response, &r), "failed to unmarshal response with error %s", err)
 
-	assert.Contains(string(r.Response.Patch), `{"op":"add","path":"/spec/containers/0/resources","value":{"limits":{"kubernetes.azure.com/sgx_epc_mem_in_MiB":10}}}`, "applied incorrect resource patch")
+	assert.Contains(string(r.Response.Patch), `{"op":"add","path":"/spec/containers/0/resources","value":{"limits":{"kubernetes.azure.com/sgx_epc_mem_in_MiB":"10"}}}`, "applied incorrect resource patch")
 	assert.Contains(string(r.Response.Patch), `"op":"add","path":"/spec/containers/0/env","value":[{"name":"EDG_MARBLE_COORDINATOR_ADDR","value":"coordinator-mesh-api.marblerun:2001"}]`, "failed to apply coordinator env variable patch")
 	assert.Contains(string(r.Response.Patch), `"op":"add","path":"/spec/containers/0/env/-","value":{"name":"EDG_MARBLE_TYPE","value":"test"}`, "failed to apply marble type env variable patch")
 	assert.Contains(string(r.Response.Patch), `"op":"add","path":"/spec/containers/0/env/-","value":{"name":"EDG_MARBLE_DNS_NAMES","value":"test,test.injectable,test.injectable.svc.cluster.local"}`, "failed to apply DNS name env varibale patch")
@@ -160,7 +160,7 @@ func TestPreSetValues(t *testing.T) {
 	r := v1.AdmissionReview{}
 	require.NoError(json.Unmarshal(response, &r), "failed to unmarshal response with error %s", err)
 
-	assert.Contains(string(r.Response.Patch), `{"op":"add","path":"/spec/containers/0/resources/limits/kubernetes.azure.com~1sgx_epc_mem_in_MiB","value":10}`, "applied incorrect resource patch")
+	assert.Contains(string(r.Response.Patch), `{"op":"add","path":"/spec/containers/0/resources/limits/kubernetes.azure.com~1sgx_epc_mem_in_MiB","value":"10"}`, "applied incorrect resource patch")
 	assert.NotContains(string(r.Response.Patch), `"op":"add","path":"/spec/containers/0/env"`, "applied coordinator env variable patch when it shouldnt have")
 	assert.NotContains(string(r.Response.Patch), `"op":"add","path":"/spec/containers/0/env/-"`, "applied marble type env variable patch when it shouldnt have")
 	assert.NotContains(string(r.Response.Patch), `"op":"add","path":"/spec/containers/0/env/-"`, "applied DNS name env varibale patch when it shouldnt have")

--- a/util/util.go
+++ b/util/util.go
@@ -17,6 +17,14 @@ import (
 	"os"
 
 	"golang.org/x/crypto/hkdf"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	IntelEpc       corev1.ResourceName = "sgx.intel.com/epc"
+	IntelEnclave   corev1.ResourceName = "sgx.intel.com/enclave"
+	IntelProvision corev1.ResourceName = "sgx.intel.com/provision"
+	AzureEpc       corev1.ResourceName = "kubernetes.azure.com/sgx_epc_mem_in_MiB"
 )
 
 // DefaultCertificateIPAddresses defines a placeholder value used for automated x509 certificate generation
@@ -104,4 +112,18 @@ func MustGetwd() string {
 		return wd
 	}
 	panic(err)
+}
+
+// GetEPCResorceLimit returns the amount of EPC to set for k8s deployments depending on the used sgx device plugin
+func GetEPCResourceLimit(resourceKey string) string {
+	// azure device plugin expects epc in MiB
+	if resourceKey == AzureEpc.String() {
+		return "10"
+	}
+	// intels device plugin expects epc
+	if resourceKey == IntelEpc.String() {
+		return "10Mi"
+	}
+
+	return "10Mi"
 }


### PR DESCRIPTION
This PR addresses an issue encountered when using the Intel SGX device plugin. (See https://github.com/edgelesssys/marblerun/issues/179#issue-915092193)
Since the coordinator uses in-process attestation we need to set `sgx.intel.com/provision` in the pods resource limits so the pod is allowed to access `/dev/sgx_provision`.

Additionally the EPC limits for the coordinator, as well as the injected EPC limits by the marble-injector, have been increased from 10 to 10Mi when using the Intel plugin.
This was an oversight when switching from the azure plugin which by default defined its limits in MiB.

[A PR for the helm chart](https://github.com/edgelesssys/helm/pull/10#issue-666031711) has also been created.