### PR TITLE
AB#976 Add RBAC

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -28,7 +28,7 @@ type ClientCore interface {
 	GetManifestSignature(ctx context.Context) (manifestSignature []byte)
 	GetStatus(ctx context.Context) (statusCode int, status string, err error)
 	Recover(ctx context.Context, encryptionKey []byte) (int, error)
-	VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.MarblerunUser, error)
+	VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.User, error)
 	UpdateManifest(ctx context.Context, rawUpdateManifest []byte) error
 }
 
@@ -79,7 +79,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	c.sealer.SetEncryptionKey(encryptionKey)
 
 	// Parse X.509 user certificates and permissions from manifest
-	users, err := user.GenerateUsersFromManifest(manifest.Users)
+	users, err := GenerateUsersFromManifest(manifest.Users)
 	if err != nil {
 		c.zaplogger.Error("Could not parse specified user certificate from supplied manifest", zap.Error(err))
 		return nil, err
@@ -192,7 +192,7 @@ func (c *Core) GetStatus(ctx context.Context) (statusCode int, status string, er
 }
 
 // VerifyUser checks if a given client certificate matches the admin certificates specified in the manifest
-func (c *Core) VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.MarblerunUser, error) {
+func (c *Core) VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.User, error) {
 	manifest, err := c.data.getManifest("main")
 	if err != nil {
 		return nil, err

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -79,7 +79,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	c.sealer.SetEncryptionKey(encryptionKey)
 
 	// Parse X.509 user certificates and permissions from manifest
-	users, err := GenerateUsersFromManifest(manifest.Users)
+	users, err := generateUsersFromManifest(manifest.Users)
 	if err != nil {
 		c.zaplogger.Error("Could not parse specified user certificate from supplied manifest", zap.Error(err))
 		return nil, err

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/store"
+	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
@@ -27,7 +28,7 @@ type ClientCore interface {
 	GetManifestSignature(ctx context.Context) (manifestSignature []byte)
 	GetStatus(ctx context.Context) (statusCode int, status string, err error)
 	Recover(ctx context.Context, encryptionKey []byte) (int, error)
-	VerifyAdmin(ctx context.Context, clientCerts []*x509.Certificate) bool
+	VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.MarblerunUser, error)
 	UpdateManifest(ctx context.Context, rawUpdateManifest []byte) error
 }
 
@@ -77,10 +78,10 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	}
 	c.sealer.SetEncryptionKey(encryptionKey)
 
-	// Parse X.509 admin certificates from manifest
-	users, err := generateUsersFromManifest(manifest.Admins)
+	// Parse X.509 user certificates and permissions from manifest
+	users, err := user.GenerateUsersFromManifest(manifest.Users)
 	if err != nil {
-		c.zaplogger.Error("Could not parse specified admin client certificate from supplied manifest", zap.Error(err))
+		c.zaplogger.Error("Could not parse specified user certificate from supplied manifest", zap.Error(err))
 		return nil, err
 	}
 
@@ -190,25 +191,28 @@ func (c *Core) GetStatus(ctx context.Context) (statusCode int, status string, er
 	return c.getStatus(ctx)
 }
 
-// VerifyAdmin checks if a given client certificate matches the admin certificates specified in the manifest
-func (c *Core) VerifyAdmin(ctx context.Context, clientCerts []*x509.Certificate) bool {
+// VerifyUser checks if a given client certificate matches the admin certificates specified in the manifest
+func (c *Core) VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.MarblerunUser, error) {
 	manifest, err := c.data.getManifest("main")
 	if err != nil {
-		return false
+		return nil, err
 	}
 
 	// Check if a supplied client cert matches the supplied ones from the manifest stored in the core
 	// NOTE: We do not use the "correct" X.509 verify here since we do not really care about expiration and chain verification here.
 	for _, suppliedCert := range clientCerts {
-		for user := range manifest.Admins {
-			userData, _ := c.data.getUser(user)
-			if suppliedCert.Equal(userData.certificate) {
-				return true
+		for userName := range manifest.Users {
+			user, err := c.data.getUser(userName)
+			if err != nil {
+				return nil, err
+			}
+			if suppliedCert.Equal(user.Certificate()) {
+				return user, nil
 			}
 		}
 	}
 
-	return false
+	return nil, errors.New("client certificate did not match any Marblerun users")
 }
 
 // UpdateManifest allows to update certain package parameters, supplied via a JSON manifest

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -206,7 +206,7 @@ func TestGetStatus(t *testing.T) {
 	assert.NotEmpty(status, "Status string was empty, but should not.")
 }
 
-func TestVerifyAdmin(t *testing.T) {
+func TestVerifyUser(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, _ := mustSetup()
@@ -221,10 +221,14 @@ func TestVerifyAdmin(t *testing.T) {
 	adminTestCertSlice := []*x509.Certificate{adminTestCert}
 	otherTestCertSlice := []*x509.Certificate{otherTestCert}
 
-	// Check if the adminTest certificatge is deemed valid (stored in core), and the freshly generated one is deemed false
-	assert.True(c.VerifyAdmin(context.TODO(), adminTestCertSlice))
-	assert.False(c.VerifyAdmin(context.TODO(), otherTestCertSlice))
-	assert.False(c.VerifyAdmin(context.TODO(), nil))
+	// Check if the adminTest certificate is deemed valid (stored in core), and the freshly generated one is deemed false
+	user, err := c.VerifyUser(context.TODO(), adminTestCertSlice)
+	assert.NoError(err)
+	assert.Equal(*user.Certificate(), *adminTestCert)
+	_, err = c.VerifyUser(context.TODO(), otherTestCertSlice)
+	assert.Error(err)
+	_, err = c.VerifyUser(context.TODO(), nil)
+	assert.Error(err)
 }
 
 func TestUpdateManifest(t *testing.T) {

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -570,7 +570,7 @@ func GenerateUsersFromManifest(rawUsers map[string]manifest.User) ([]*user.User,
 		newUser := user.NewUser(name, cert)
 		newUser.Assign(user.NewPermission(user.PermissionSetSecret, userData.WriteSecrets))
 		newUser.Assign(user.NewPermission(user.PermissionReadSecret, userData.ReadSecrets))
-		newUser.Assign(user.NewPermission(user.PermissionAllowedUpdate, userData.UpdatePackages))
+		newUser.Assign(user.NewPermission(user.PermissionUpdatePackage, userData.UpdatePackages))
 		users = append(users, newUser)
 	}
 	return users, nil

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -554,8 +554,8 @@ func (c *Core) generateCertificateForSecret(secret manifest.Secret, parentCertif
 	return secret, nil
 }
 
-// GenerateUsersFromManifest creates users and permissions from a map of manifest.User
-func GenerateUsersFromManifest(rawUsers map[string]manifest.User) ([]*user.User, error) {
+// generateUsersFromManifest creates users and permissions from a map of manifest.User
+func generateUsersFromManifest(rawUsers map[string]manifest.User) ([]*user.User, error) {
 	// Parse & write X.509 user data from manifest
 	users := make([]*user.User, 0, len(rawUsers))
 	for name, userData := range rawUsers {
@@ -568,7 +568,7 @@ func GenerateUsersFromManifest(rawUsers map[string]manifest.User) ([]*user.User,
 			return nil, err
 		}
 		newUser := user.NewUser(name, cert)
-		newUser.Assign(user.NewPermission(user.PermissionSetSecret, userData.WriteSecrets))
+		newUser.Assign(user.NewPermission(user.PermissionWriteSecret, userData.WriteSecrets))
 		newUser.Assign(user.NewPermission(user.PermissionReadSecret, userData.ReadSecrets))
 		newUser.Assign(user.NewPermission(user.PermissionUpdatePackage, userData.UpdatePackages))
 		users = append(users, newUser)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -128,7 +128,7 @@ func TestRecover(t *testing.T) {
 	assert.Error(err)
 
 	// Set manifest. This will seal the state.
-	_, err = c.SetManifest(context.TODO(), []byte(test.ManifestJSON))
+	_, err = c.SetManifest(context.TODO(), []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
 	// core does not allow recover after manifest has been set

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -177,7 +177,7 @@ func TestGenerateUsersFromManifest(t *testing.T) {
 			},
 		},
 	}
-	newUsers, err := GenerateUsersFromManifest(Users)
+	newUsers, err := generateUsersFromManifest(Users)
 	assert.NoError(err)
 	assert.Equal(len(Users), len(newUsers))
 
@@ -196,7 +196,7 @@ func TestGenerateUsersFromManifest(t *testing.T) {
 			},
 		},
 	}
-	_, err = GenerateUsersFromManifest(invalidUsers)
+	_, err = generateUsersFromManifest(invalidUsers)
 	assert.Error(err)
 }
 

--- a/coordinator/core/storewrapper_test.go
+++ b/coordinator/core/storewrapper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/store"
+	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func TestStoreWrapper(t *testing.T) {
 	require.NoError(err)
 	testUserCert, _, err := generateCert([]string{"example.com"}, "test-user", nil, nil, nil)
 	require.NoError(err)
-	testUser := &marblerunUser{name: "test-user", certificate: testUserCert}
+	testUser := user.NewMarblerunUser("test-user", testUserCert)
 
 	// save values to store
 	tx, err := c.store.BeginTransaction()

--- a/coordinator/core/storewrapper_test.go
+++ b/coordinator/core/storewrapper_test.go
@@ -41,7 +41,7 @@ func TestStoreWrapper(t *testing.T) {
 	require.NoError(err)
 	testUserCert, _, err := generateCert([]string{"example.com"}, "test-user", nil, nil, nil)
 	require.NoError(err)
-	testUser := user.NewMarblerunUser("test-user", testUserCert)
+	testUser := user.NewUser("test-user", testUserCert)
 
 	// save values to store
 	tx, err := c.store.BeginTransaction()

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -30,7 +30,7 @@ type Manifest struct {
 	Infrastructures map[string]quote.InfrastructureProperties
 	// Marbles contains the allowed services with their corresponding enclave and configuration parameters.
 	Marbles map[string]Marble
-	// Users contains user-generated TLS client certificates to be used for an administrator to perform manifest updates
+	// Users contains user definitions, including certificates used for authentication and permissions.
 	Users map[string]User
 	// Clients contains TLS certificates for authenticating clients that use the ClientAPI.
 	Clients map[string][]byte

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -203,8 +203,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 			writeJSONError(w, "no client certificate provided", http.StatusUnauthorized)
 			return
 		}
-		_, err := cc.VerifyUser(r.Context(), r.TLS.PeerCertificates)
-		if err != nil {
+		if _, err := cc.VerifyUser(r.Context(), r.TLS.PeerCertificates); err != nil {
 			writeJSONError(w, "unauthorized user", http.StatusUnauthorized)
 			return
 		}

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -198,8 +198,13 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 	})
 
 	mux.HandleFunc("/update", func(w http.ResponseWriter, r *http.Request) {
-		// Abort if no admin client certificate was provided
-		if r.TLS == nil || !cc.VerifyAdmin(r.Context(), r.TLS.PeerCertificates) {
+		// Abort if no user client certificate was provided
+		if r.TLS == nil {
+			writeJSONError(w, "no client certificate provided", http.StatusUnauthorized)
+			return
+		}
+		_, err := cc.VerifyUser(r.Context(), r.TLS.PeerCertificates)
+		if err != nil {
 			writeJSONError(w, "unauthorized user", http.StatusUnauthorized)
 			return
 		}

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	PermissionSetSecret     = "SetSecret"
+	PermissionWriteSecret   = "WriteSecret"
 	PermissionReadSecret    = "ReadSecret"
 	PermissionUpdatePackage = "UpdatePackage"
 )

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -1,0 +1,123 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package user
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
+)
+
+const (
+	permissionSetSecret     = "SetSecret"
+	permissionReadSecret    = "ReadSecret"
+	permissionAllowedUpdate = "Update"
+)
+
+// MarblerunUser represents a privileged user of Marblerun
+type MarblerunUser struct {
+	name string
+	// certificate is the users certificate, used for authentication
+	certificate *x509.Certificate
+	// permissions of the user
+	permissions map[string]MarblerunPermission
+}
+
+// NewMarblerunUser creates a new user based on data from manifest.User
+func NewMarblerunUser(name string, certificate *x509.Certificate) *MarblerunUser {
+	newUser := &MarblerunUser{
+		name:        name,
+		certificate: certificate,
+		permissions: make(map[string]MarblerunPermission),
+	}
+	return newUser
+}
+
+// Assign adds a new permission to the user
+func (u *MarblerunUser) Assign(p MarblerunPermission) {
+	u.permissions[p.ID()] = p
+}
+
+// IsGranted returns true if the user has the requested permission
+func (u MarblerunUser) IsGranted(p MarblerunPermission) bool {
+	q, ok := u.permissions[p.ID()]
+	if !ok {
+		return false
+	}
+	return q.match(p)
+}
+
+// Name returns the name of a user
+func (u MarblerunUser) Name() string {
+	return u.name
+}
+
+// Permissions returns a users permissions
+func (u MarblerunUser) Permissions() map[string]MarblerunPermission {
+	return u.permissions
+}
+
+// Certificate returns a users certificate
+func (u MarblerunUser) Certificate() *x509.Certificate {
+	return u.certificate
+}
+
+// MarblerunPermission represents the permissions of a Marblerun user
+type MarblerunPermission struct {
+	permissionID string
+	resourceID   map[string]bool
+}
+
+// NewMarblerunPermission creates a new permission, granting access to resources grouped by permissionID
+func NewMarblerunPermission(permissionID string, resourceIDs []string) MarblerunPermission {
+	newPermission := MarblerunPermission{
+		permissionID: permissionID,
+		resourceID:   make(map[string]bool),
+	}
+	for _, v := range resourceIDs {
+		newPermission.resourceID[v] = true
+	}
+	return newPermission
+}
+
+// ID returns the permissionID
+func (p MarblerunPermission) ID() string {
+	return p.permissionID
+}
+
+// Match returns true if a is a subgroup of p
+func (p MarblerunPermission) match(q MarblerunPermission) bool {
+	if p.permissionID != q.ID() {
+		return false
+	}
+	for k := range q.resourceID {
+		if !p.resourceID[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// GenerateUsersFromManifest creates users and permissions from a map of manifest.User
+func GenerateUsersFromManifest(rawUsers map[string]manifest.User) ([]*MarblerunUser, error) {
+	// Parse & write X.509 user data from manifest
+	users := make([]*MarblerunUser, 0, len(rawUsers))
+	for name, userData := range rawUsers {
+		block, _ := pem.Decode([]byte(userData.Certificate))
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		newUser := NewMarblerunUser(name, cert)
+		newUser.Assign(NewMarblerunPermission(permissionSetSecret, userData.SetSecrets))
+		newUser.Assign(NewMarblerunPermission(permissionReadSecret, userData.ReadSecrets))
+		newUser.Assign(NewMarblerunPermission(permissionAllowedUpdate, userData.AllowedUpdates))
+		users = append(users, newUser)
+	}
+	return users, nil
+}

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -14,7 +14,7 @@ import (
 const (
 	PermissionSetSecret     = "SetSecret"
 	PermissionReadSecret    = "ReadSecret"
-	PermissionAllowedUpdate = "Update"
+	PermissionUpdatePackage = "UpdatePackage"
 )
 
 // User represents a privileged user of Marblerun

--- a/coordinator/user/user_test.go
+++ b/coordinator/user/user_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package user
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
+	"github.com/edgelesssys/marblerun/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserPermissions(t *testing.T) {
+	assert := assert.New(t)
+
+	adminTestCert, _ := test.MustSetupTestCerts(test.RecoveryPrivateKey)
+	userName := "test-user"
+	testResource := "testResource"
+	testPermission := NewMarblerunPermission(testResource, []string{"perm-1", "perm-2"})
+
+	testUser := NewMarblerunUser(userName, adminTestCert)
+	testUser.Assign(testPermission)
+
+	assert.Equal(*adminTestCert, *testUser.Certificate())
+	assert.Equal(userName, testUser.Name())
+	assert.Equal(testUser.Permissions()[testResource], testPermission)
+
+	ok := testUser.IsGranted(NewMarblerunPermission(testResource, []string{"perm-1"}))
+	assert.True(ok)
+	ok = testUser.IsGranted(NewMarblerunPermission(testResource, []string{"perm-1", "perm-2"}))
+	assert.True(ok)
+	ok = testUser.IsGranted(NewMarblerunPermission(testResource, []string{"perm-1", "perm-2", "perm-3"}))
+	assert.False(ok)
+	ok = testUser.IsGranted(NewMarblerunPermission(testResource, []string{"perm-3"}))
+	assert.False(ok)
+	ok = testUser.IsGranted(NewMarblerunPermission("unkownResource", []string{"perm-2"}))
+	assert.False(ok)
+}
+
+func TestGenerateUsersFromManifest(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var manifest manifest.Manifest
+	err := json.Unmarshal([]byte(test.ManifestJSONWithRecoveryKey), &manifest)
+	require.NoError(err)
+
+	newUsers, err := GenerateUsersFromManifest(manifest.Users)
+	assert.NoError(err)
+	assert.Equal(len(manifest.Users), len(newUsers))
+}

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -204,8 +204,10 @@ var ManifestJSONWithRecoveryKey string = `{
 	"Clients": {
 		"owner": [9,9,9]
 	},
-	"Admins": {
-		"admin": "` + pemToJSONString(AdminCert) + `"
+	"Users": {
+		"admin": {
+			"Certificate": "` + pemToJSONString(AdminCert) + `"
+		}
 	},
 	"RecoveryKeys": {
 		"testRecKey1": "` + pemToJSONString(RecoveryPublicKey) + `"
@@ -281,8 +283,10 @@ var IntegrationManifestJSON string = `{
 	"Clients": {
 		"owner": [9,9,9]
 	},
-	"Admins": {
-		"admin": "` + pemToJSONString(AdminCert) + `"
+	"Users": {
+		"admin": {
+			"Certificate": "` + pemToJSONString(AdminCert) + `"
+		}
 	},
 	"RecoveryKeys": {
 		"testRecKey1": "` + pemToJSONString(RecoveryPublicKey) + `"


### PR DESCRIPTION
This PR changes how permissions work for users when interacting with the coordinator:

First up instead of `Admins` the manifest now defines `Users`. 
Users are ordered by their name and each define a `Certificate`, which is the same as before for `Admins`, as well as permissions to read/write secrets and update packages.
Functionality for these permissions will be added at a later date.

Functions related to users are in a new module `coordinator/user`.
From the user definition in a manifest, a `MarblerunUser` is created.
This type holds information about:
* the users name
* the users certificate
* the users permissions

The main difference for now is the change from `VerifyAdmin` to `VerifyUser` in the `ClientCore` interface. Which, instead of returning true or false, return the user matching the supplied certificate.

Using `marblerunUser.IsGranted(somePermission)` we can check if a user has been granted a requested permission.
This allows us to gate specific functions of the core to only privileged users.
For example allowing only user `A` and `B` to update a manifest, while the update by user `C` gets rejected.