### PR TITLE
AB#975 RBAC for manifest update

### DIFF
--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -440,7 +440,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 
 	// parse manifest
 	var manifest manifest.Manifest
-	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
+	require.NoError(json.Unmarshal([]byte(test.ManifestJSONWithRecoveryKey), &manifest))
 
 	// setup mock zaplogger which can be passed to Core
 	zapLogger, err := zap.NewDevelopment()
@@ -465,14 +465,17 @@ func TestSecurityLevelUpdate(t *testing.T) {
 		coreServer: coreServer,
 	}
 	// set manifest
-	_, err = coreServer.SetManifest(context.TODO(), []byte(test.ManifestJSON))
+	_, err = coreServer.SetManifest(context.TODO(), []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
+
+	admin, err := coreServer.data.getUser("admin")
+	assert.NoError(err)
 
 	// try to activate another first backend, should succeed as SecurityLevel matches the definition in the manifest
 	spawner.newMarble("frontend", "Azure", true)
 
 	// update manifest
-	err = coreServer.UpdateManifest(context.TODO(), []byte(test.UpdateManifest))
+	err = coreServer.UpdateManifest(context.TODO(), []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	// try to activate another first backend, should fail as required SecurityLevel is now higher after manifest update

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -203,7 +203,8 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 			writeJSONError(w, "no client certificate provided", http.StatusUnauthorized)
 			return
 		}
-		if _, err := cc.VerifyUser(r.Context(), r.TLS.PeerCertificates); err != nil {
+		user, err := cc.VerifyUser(r.Context(), r.TLS.PeerCertificates)
+		if err != nil {
 			writeJSONError(w, "unauthorized user", http.StatusUnauthorized)
 			return
 		}
@@ -215,7 +216,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 				writeJSONError(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			err = cc.UpdateManifest(r.Context(), updateManifest)
+			err = cc.UpdateManifest(r.Context(), updateManifest, user)
 			if err != nil {
 				writeJSONError(w, err.Error(), http.StatusBadRequest)
 				return

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -201,12 +201,41 @@ var ManifestJSONWithRecoveryKey string = `{
 			}
 		}
 	},
+	"Secrets": {
+		"cert_private": {
+			"Size": 2048,
+			"Type": "cert-rsa",
+			"Cert": {
+				"SerialNumber": 42,
+				"Subject": {
+					"SerialNumber": "42",
+					"CommonName": "Marblerun Unit Test"
+				}
+			},
+			"ValidFor": 7
+		},
+		"cert_shared": {
+			"Shared": true,
+			"Type": "cert-ed25519",
+			"Cert": {
+				"SerialNumber": 1337,
+				"Subject": {
+					"SerialNumber": "1337",
+					"CommonName": "Marblerun Unit Test"
+				}
+			},
+			"ValidFor": 7
+		}
+	},
 	"Clients": {
 		"owner": [9,9,9]
 	},
 	"Users": {
 		"admin": {
-			"Certificate": "` + pemToJSONString(AdminCert) + `"
+			"Certificate": "` + pemToJSONString(AdminCert) + `",
+			"UpdatePackages": [
+				"frontend"
+			]
 		}
 	},
 	"RecoveryKeys": {
@@ -285,7 +314,11 @@ var IntegrationManifestJSON string = `{
 	},
 	"Users": {
 		"admin": {
-			"Certificate": "` + pemToJSONString(AdminCert) + `"
+			"Certificate": "` + pemToJSONString(AdminCert) + `",
+			"UpdatePackages": [
+				"frontend",
+				"backend"
+			]
 		}
 	},
 	"RecoveryKeys": {


### PR DESCRIPTION
### Proposed change
Verify user permissions in `UpdateManifest` of the `ClientCore` interface to make sure the user updating the manifest is allowed to do so

This should happen for each package the user is trying to update.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Since there are now a couple more reasons for a failed update attempt, I made some changes to the error handling of `manifest update` in the CLI to provide better information in that case.
Instead of printing a generic error message the CLI now also prints the error returned by the Coordinator along with a short message of what failed (unable to authorize or error during the manifest update).

<!-- (uncomment if applicable)
### Screenshots

-->
