### PR TITLE
AB#988 Allow reading of secrets by users

### DIFF
--- a/test/manifests.go
+++ b/test/manifests.go
@@ -202,6 +202,20 @@ var ManifestJSONWithRecoveryKey string = `{
 		}
 	},
 	"Secrets": {
+		"restricted_secret": {
+			"Size": 128,
+			"Shared": true,
+			"Type": "symmetric-key"
+		},
+		"symmetric_key_shared": {
+			"Size": 128,
+			"Shared": true,
+			"Type": "symmetric-key"
+		},
+		"symmetric_key_private": {
+			"Size": 256,
+			"Type": "symmetric-key"
+		},
 		"cert_private": {
 			"Size": 2048,
 			"Type": "cert-rsa",
@@ -235,6 +249,10 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Certificate": "` + pemToJSONString(AdminCert) + `",
 			"UpdatePackages": [
 				"frontend"
+			],
+			"ReadSecrets": [
+				"symmetric_key_shared",
+				"cert_shared"
 			]
 		}
 	},

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -330,12 +330,22 @@ var IntegrationManifestJSON string = `{
 	"Clients": {
 		"owner": [9,9,9]
 	},
+	"Secrets" :{
+		"symmetric_key_shared": {
+			"Size": 128,
+			"Shared": true,
+			"Type": "symmetric-key"
+		}
+	},
 	"Users": {
 		"admin": {
 			"Certificate": "` + pemToJSONString(AdminCert) + `",
 			"UpdatePackages": [
 				"frontend",
 				"backend"
+			],
+			"ReadSecrets": [
+				"symmetric_key_shared"
 			]
 		}
 	},


### PR DESCRIPTION
### Proposed changes
Allow users to read out secrets using the `/secrets` endpoint.
The manifest defines which secrets a user is allowed to read. The following shows an example of a user allowed to read the secrets `symmetric_key_shared` and `cert_shared`:
```javascript
{
//...
  "Users": {
    "marblerunUser": {
      "Certificate": "<certificate>",
      "ReadSecrets": [
        "symmetric_key_shared",
        "cert_shared" 
      ]
    }
  }
//...
}
```

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- A user can not read private secrets (secrets without the `shared=true` property), because those are only accessible to the respective Marble
- The `/secrets` endpoint expects requests in the form of a query string in the following format:
```
https://<IP>:<PORT>/secrets?s=<secret_name_one>&s=<secret_name_two>&...
```
- Requests may specify one or more secrets, but will fail if the user is not allowed to read one of the secrets
- Requests where the query string contains empty fields for `s` will fail, e.g. `?s=key_shared&s=&s=cert_shared`
- Requests where the query string contains fields different than `s` will fail, e.g. `?s=key_shared&c=test` 
- Successful requests will contain the secrets as `map[string]manifest.Secret` marshaled to JSON in the `data` field of the JSON response


<!-- (uncomment if applicable)
### Screenshots

-->
