### PR TITLE
Add Roles to manage Permissions

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -82,7 +82,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	c.sealer.SetEncryptionKey(encryptionKey)
 
 	// Parse X.509 user certificates and permissions from manifest
-	users, err := generateUsersFromManifest(manifest.Users)
+	users, err := generateUsersFromManifest(manifest.Users, manifest.Roles)
 	if err != nil {
 		c.zaplogger.Error("Could not parse specified user certificate from supplied manifest", zap.Error(err))
 		return nil, err

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -575,7 +576,7 @@ func generateUsersFromManifest(rawUsers map[string]manifest.User, roles map[stri
 		for _, assignedRole := range userData.Roles {
 			for _, action := range roles[assignedRole].Actions {
 				// correctness of roles has been verified by manifest.Check()
-				newUser.Assign(user.NewPermission(action, roles[assignedRole].ResourceNames))
+				newUser.Assign(user.NewPermission(strings.ToLower(action), roles[assignedRole].ResourceNames))
 			}
 		}
 		users = append(users, newUser)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -170,17 +170,17 @@ func TestGenerateUsersFromManifest(t *testing.T) {
 		"write_role": {
 			ResourceType:  "Secrets",
 			ResourceNames: []string{"secret_one"},
-			Actions:       []string{"write"},
+			Actions:       []string{"WriteSecret"},
 		},
 		"read_role": {
 			ResourceType:  "Secrets",
 			ResourceNames: []string{"secret_one", "secret_two"},
-			Actions:       []string{"read"},
+			Actions:       []string{"readsecret"},
 		},
 		"update_role": {
 			ResourceType:  "Packages",
 			ResourceNames: []string{"frontend", "backend"},
-			Actions:       []string{"updateSecurityVersion"},
+			Actions:       []string{"UpdateSecurityVersion"},
 		},
 	}
 	newUsers, err := generateUsersFromManifest(Users, Roles)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
+	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -158,45 +159,57 @@ func TestGenerateUsersFromManifest(t *testing.T) {
 	Users := map[string]manifest.User{
 		"Alice": {
 			Certificate: string(test.AdminCert),
-			WriteSecrets: []string{
-				"secret_one",
-			},
-			ReadSecrets: []string{
-				"secret_one",
-				"secret_two",
-			},
+			Roles:       []string{"write_role", "read_role"},
 		},
 		"Bob": {
 			Certificate: string(test.AdminCert),
-			WriteSecrets: []string{
-				"secret_one",
-			},
-			UpdatePackages: []string{
-				"frontend",
-				"backend",
-			},
+			Roles:       []string{"write_role", "update_role"},
 		},
 	}
-	newUsers, err := generateUsersFromManifest(Users)
+	Roles := map[string]manifest.Role{
+		"write_role": {
+			ResourceType:  "Secrets",
+			ResourceNames: []string{"secret_one"},
+			Actions:       []string{"write"},
+		},
+		"read_role": {
+			ResourceType:  "Secrets",
+			ResourceNames: []string{"secret_one", "secret_two"},
+			Actions:       []string{"read"},
+		},
+		"update_role": {
+			ResourceType:  "Packages",
+			ResourceNames: []string{"frontend", "backend"},
+			Actions:       []string{"updateSecurityVersion"},
+		},
+	}
+	newUsers, err := generateUsersFromManifest(Users, Roles)
 	assert.NoError(err)
 	assert.Equal(len(Users), len(newUsers))
+	for _, newUser := range newUsers {
+		switch newUser.Name() {
+		case "Alice":
+			assert.True(newUser.IsGranted(user.NewPermission(user.PermissionWriteSecret, []string{"secret_one"})))
+			assert.True(newUser.IsGranted(user.NewPermission(user.PermissionReadSecret, []string{"secret_one", "secret_two"})))
+			assert.False(newUser.IsGranted(user.NewPermission(user.PermissionUpdatePackage, []string{"frontend", "backend"})))
+		case "Bob":
+			assert.True(newUser.IsGranted(user.NewPermission(user.PermissionWriteSecret, []string{"secret_one"})))
+			assert.False(newUser.IsGranted(user.NewPermission(user.PermissionReadSecret, []string{"secret_one", "secret_two"})))
+			assert.True(newUser.IsGranted(user.NewPermission(user.PermissionUpdatePackage, []string{"frontend", "backend"})))
+		}
+	}
 
 	// try to generate new users with missing certificate, this should always error
 	invalidUsers := map[string]manifest.User{
 		"Alice": {
-			WriteSecrets: []string{
-				"secret_one",
-			},
+			Roles: []string{"write_role"},
 		},
 		"Bob": {
 			Certificate: string(test.AdminCert),
-			UpdatePackages: []string{
-				"frontend",
-				"backend",
-			},
+			Roles:       []string{"update_role"},
 		},
 	}
-	_, err = generateUsersFromManifest(invalidUsers)
+	_, err = generateUsersFromManifest(invalidUsers, Roles)
 	assert.Error(err)
 }
 

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -15,6 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/edgelesssys/marblerun/coordinator/quote"
@@ -187,21 +188,21 @@ func (m Manifest) Check(ctx context.Context, zaplogger *zap.Logger) error {
 				}
 			}
 			for _, action := range role.Actions {
-				if !(action == user.PermissionUpdatePackage) {
-					return fmt.Errorf("unkown action: %s for type Secrets in role: %s", action, roleName)
+				if !(strings.ToLower(action) == user.PermissionUpdatePackage) {
+					return fmt.Errorf("unkown action: %s for type Packages in role: %s", action, roleName)
 				}
 			}
 		case "Secrets":
 			var writeRole bool
 			var readRole bool
 			for _, action := range role.Actions {
-				if !(action == user.PermissionWriteSecret || action == user.PermissionReadSecret) {
+				if !(strings.ToLower(action) == user.PermissionWriteSecret || strings.ToLower(action) == user.PermissionReadSecret) {
 					return fmt.Errorf("unkown action: %s for type Secrets in role: %s", action, roleName)
 				}
-				if action == user.PermissionWriteSecret {
+				if strings.ToLower(action) == user.PermissionWriteSecret {
 					writeRole = true
 				}
-				if action == user.PermissionReadSecret {
+				if strings.ToLower(action) == user.PermissionReadSecret {
 					readRole = true
 				}
 			}

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -195,7 +195,7 @@ func (m Manifest) Check(ctx context.Context, zaplogger *zap.Logger) error {
 			var writeRole bool
 			var readRole bool
 			for _, action := range role.Actions {
-				if !(action == user.PermissionWriteSecret) || !(action == user.PermissionReadSecret) {
+				if !(action == user.PermissionWriteSecret || action == user.PermissionReadSecret) {
 					return fmt.Errorf("unkown action: %s for type Secrets in role: %s", action, roleName)
 				}
 				if action == user.PermissionWriteSecret {

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	PermissionWriteSecret   = "WriteSecret"
-	PermissionReadSecret    = "ReadSecret"
-	PermissionUpdatePackage = "UpdatePackage"
+	PermissionWriteSecret   = "write"
+	PermissionReadSecret    = "read"
+	PermissionUpdatePackage = "updateSecurityVersion"
 )
 
 // User represents a privileged user of Marblerun
@@ -38,7 +38,13 @@ func NewUser(name string, certificate *x509.Certificate) *User {
 
 // Assign adds a new permission to the user
 func (u *User) Assign(p Permission) {
-	u.permissions[p.ID()] = p
+	if _, ok := u.permissions[p.ID()]; !ok {
+		u.permissions[p.ID()] = p
+	} else {
+		for k, v := range p.ResourceID {
+			u.permissions[p.ID()].ResourceID[k] = u.permissions[p.ID()].ResourceID[k] || v
+		}
+	}
 }
 
 // IsGranted returns true if the user has the requested permission

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	PermissionWriteSecret   = "write"
-	PermissionReadSecret    = "read"
-	PermissionUpdatePackage = "updateSecurityVersion"
+	PermissionWriteSecret   = "writesecret"
+	PermissionReadSecret    = "readsecret"
+	PermissionUpdatePackage = "updatesecurityversion"
 )
 
 // User represents a privileged user of Marblerun

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -1,0 +1,181 @@
+{
+    "Packages": {
+		"backend": {
+			"SignerID": "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+			"ProductID": 45,
+			"SecurityVersion": 2,
+			"Debug": false
+		},
+		"frontend": {
+			"SignerID": "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+			"ProductID": 44,
+			"SecurityVersion": 3,
+			"Debug": false
+		}
+	},
+
+    "Marbles": {
+		"backend_first": {
+			"Package": "backend",
+			"MaxActivations": 1,
+			"Parameters": {
+				"Files": {
+					"/tmp/defg.txt": "foo",
+					"/tmp/jkl.mno": "bar"
+				},
+				"Env": {
+					"IS_FIRST": "true",
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
+					"TEST_SECRET_SYMMETRIC_KEY": "{{ raw .Secrets.symmetric_key_shared }}",
+					"TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
+					"TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
+				},
+				"Argv": [
+					"--first",
+					"serve"
+				]
+			},
+			"TLS": [
+				"web"
+			],
+            "Roles": [
+                "cert-reader",
+                "key-reader"
+            ]
+		},
+		"backend_other": {
+			"Package": "backend",
+			"Parameters": {
+				"Env": {
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
+					"TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
+					"TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
+				},
+				"Argv": [
+					"serve"
+				]
+			},
+			"TLS": [
+				"web", "anotherWeb"
+			],
+            "Roles": [
+                "cert-reader"
+            ]
+		},
+		"frontend": {
+			"Package": "frontend",
+			"Parameters": {
+				"Env": {
+					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}"
+				}
+			}
+		}
+	},
+
+    "Secrets": {
+        "symmetric_key_shared": {
+            "Type": "symmetric-key",
+            "Size": 128,
+            "Shared": true
+        },
+		"symmetric_key_private": {
+			"Size": 256,
+			"Type": "symmetric-key"
+		},
+		"cert_private": {
+			"Size": 2048,
+			"Type": "cert-rsa",
+			"Cert": {
+				"SerialNumber": 42,
+				"Subject": {
+					"SerialNumber": "42",
+					"CommonName": "Marblerun Unit Test"
+				}
+			},
+			"ValidFor": 7
+		},
+        "cert_shared": {
+			"Shared": true,
+			"Type": "cert-ed25519",
+			"Cert": {
+				"SerialNumber": 1337,
+				"Subject": {
+					"SerialNumber": "1337",
+					"CommonName": "Marblerun Unit Test"
+				}
+			},
+			"ValidFor": 7
+		},
+        "rsa_shared": {
+			"Shared": true,
+			"Type": "cert-rsa",
+            "Size": 2048,
+			"Cert": {
+				"SerialNumber": 4433,
+				"Subject": {
+					"SerialNumber": "4433",
+					"CommonName": "Marblerun Unit Test"
+				}
+			},
+			"ValidFor": 7
+		}
+    },
+
+    "Users": {
+        "Alice": {
+            "Certificate": "cert-alice",
+            "Roles": [
+                "frontend-updates",
+                "cert-reader",
+                "key-reader"
+            ]
+        },
+        "Bob": {
+            "Certificate": "cert-bob",
+            "Roles": [
+                "backend-updates",
+                "key-reader"
+            ]
+        },
+        "Admin": {
+            "Certificate": "cert-admin",
+            "Roles": [
+                "updates-admin",
+                "secrets-admin"
+            ]
+        }
+    },
+
+    "Roles": {
+        "frontend-updates": {
+            "Resource": "Packages",
+            "ResourceNames": ["frontend"],
+            "Actions": ["increment"]
+        },
+        "backend-updates": {
+            "Resource": "Packages",
+            "ResourceNames": ["backend"],
+            "Actions": ["increment"]
+        },
+        "updates-admin": {
+            "Resource": "Packages",
+            "ResourceNames": ["frontend", "backend"],
+            "Actions": ["increment"]
+        },
+        "cert-reader": {
+            "Resource": "Secrets",
+            "ResourceNames": ["cert_shared", "rsa_shared"],
+            "Actions": ["read"]
+        },
+        "key-reader": {
+            "Resource": "Secrets",
+            "ResourceNames": ["symmetric_key_shared"],
+            "Actions": ["read"]
+        },
+        "secrets-admin": {
+            "Resource": "Secrets",
+            "ResourceNames": ["symmetric_key_shared", "cert_shared", "rsa_shared"],
+            "Actions": ["read", "write"]
+        }
+    }
+}

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -148,34 +148,34 @@
 
     "Roles": {
         "frontend-updates": {
-            "Resource": "Packages",
+            "ResourceType": "Packages",
             "ResourceNames": ["frontend"],
-            "Actions": ["increment"]
+            "Actions": ["UpdateSecurityVersion"]
         },
         "backend-updates": {
-            "Resource": "Packages",
+            "ResourceType": "Packages",
             "ResourceNames": ["backend"],
-            "Actions": ["increment"]
+            "Actions": ["UpdateSecurityVersion"]
         },
         "updates-admin": {
-            "Resource": "Packages",
+            "ResourceType": "Packages",
             "ResourceNames": ["frontend", "backend"],
-            "Actions": ["increment"]
+            "Actions": ["UpdateSecurityVersion"]
         },
         "cert-reader": {
-            "Resource": "Secrets",
+            "ResourceType": "Secrets",
             "ResourceNames": ["cert_shared", "rsa_shared"],
-            "Actions": ["read"]
+            "Actions": ["ReadSecret"]
         },
         "key-reader": {
-            "Resource": "Secrets",
+            "ResourceType": "Secrets",
             "ResourceNames": ["symmetric_key_shared"],
-            "Actions": ["read"]
+            "Actions": ["ReadSecret"]
         },
         "secrets-admin": {
             "Resource": "Secrets",
             "ResourceNames": ["symmetric_key_shared", "cert_shared", "rsa_shared"],
-            "Actions": ["read", "write"]
+            "Actions": ["ReadSecret", "WriteSecret"]
         }
     }
 }

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -260,23 +260,48 @@ var ManifestJSONWithRecoveryKey string = `{
 	"Users": {
 		"admin": {
 			"Certificate": "` + pemToJSONString(AdminCert) + `",
-			"UpdatePackages": [
-				"frontend"
-			],
-			"ReadSecrets": [
-				"symmetric_key_shared",
-				"symmteric_key_unset",
-				"cert_shared"
-			],
-			"WriteSecrets": [
-				"symmetric_key_unset",
-				"cert_unset",
-				"generic_secret"
+			"Roles": [
+				"secret_manager",
+				"read_only",
+				"update_manager"
 			]
 		}
 	},
 	"RecoveryKeys": {
 		"testRecKey1": "` + pemToJSONString(RecoveryPublicKey) + `"
+	},
+	"Roles": {
+		"secret_manager": {
+			"ResourceType": "Secrets",
+			"ResourceNames": [
+				"symmetric_key_unset",
+				"cert_unset",
+				"generic_secret"
+			],
+			"Actions": [
+				"read",
+				"write"
+			]
+		},
+		"read_only": {
+			"ResourceType": "Secrets",
+			"ResourceNames": [
+				"symmetric_key_shared",
+				"cert_shared"
+			],
+			"Actions": [
+				"read"
+			]
+		},
+		"update_manager": {
+			"ResourceType": "Packages",
+			"ResourceNames": [
+				"frontend"
+			],
+			"Actions": [
+				"updateSecurityVersion"
+			]
+		}
 	}
 }`
 
@@ -384,21 +409,46 @@ var IntegrationManifestJSON string = `{
 	"Users": {
 		"admin": {
 			"Certificate": "` + pemToJSONString(AdminCert) + `",
-			"UpdatePackages": [
-				"frontend",
-				"backend"
-			],
-			"ReadSecrets": [
-				"symmetric_key_shared"
-			],
-			"WriteSecrets": [
-				"symmetric_key_unset",
-				"cert_unset"
+			"Roles": [
+				"write_role",
+				"read_role",
+				"update_role"
 			]
 		}
 	},
 	"RecoveryKeys": {
 		"testRecKey1": "` + pemToJSONString(RecoveryPublicKey) + `"
+	},
+	"Roles": {
+		"write_role": {
+			"ResourceType": "Secrets",
+			"ResourceNames": [
+				"symmetric_key_unset",
+				"cert_unset"
+			],
+			"Actions": [
+				"write"
+			]
+		},
+		"read_role": {
+			"ResourceType": "Secrets",
+			"ResourceNames": [
+				"symmetric_key_shared"
+			],
+			"Actions": [
+				"read"
+			]
+		},
+		"update_role": {
+			"ResourceType": "Packages",
+			"ResourceNames": [
+				"frontend",
+				"backend"
+			],
+			"Actions": [
+				"updateSecurityVersion"
+			]
+		}
 	}
 }`
 

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -279,8 +279,8 @@ var ManifestJSONWithRecoveryKey string = `{
 				"generic_secret"
 			],
 			"Actions": [
-				"read",
-				"write"
+				"ReadSecret",
+				"WriteSecret"
 			]
 		},
 		"read_only": {
@@ -290,7 +290,7 @@ var ManifestJSONWithRecoveryKey string = `{
 				"cert_shared"
 			],
 			"Actions": [
-				"read"
+				"ReadSecret"
 			]
 		},
 		"update_manager": {
@@ -299,7 +299,7 @@ var ManifestJSONWithRecoveryKey string = `{
 				"frontend"
 			],
 			"Actions": [
-				"updateSecurityVersion"
+				"UpdateSecurityVersion"
 			]
 		}
 	}
@@ -427,7 +427,7 @@ var IntegrationManifestJSON string = `{
 				"cert_unset"
 			],
 			"Actions": [
-				"write"
+				"WriteSecret"
 			]
 		},
 		"read_role": {
@@ -436,7 +436,7 @@ var IntegrationManifestJSON string = `{
 				"symmetric_key_shared"
 			],
 			"Actions": [
-				"read"
+				"ReadSecret"
 			]
 		},
 		"update_role": {
@@ -446,7 +446,7 @@ var IntegrationManifestJSON string = `{
 				"backend"
 			],
 			"Actions": [
-				"updateSecurityVersion"
+				"UpdateSecurityVersion"
 			]
 		}
 	}


### PR DESCRIPTION
As mentioned here: https://github.com/edgelesssys/marblerun/pull/188#issuecomment-861421271, having a centralised role system will make managing permissions easier when creating a manifest.

This PR serves to discuss the best format to do so.

For now I have created a sample manifest (`samples/sample-manifest.json`) to showcase a potential format.

For now a role defines 4 things:
* The name of the role
* The type of resource being affected (Secrets, Packages, etc.)
* The name of the resource (e.g. `symmetric_key_shared`)
* The actions allowed to perform on the resource (increment svn, read secret, write secret, etc.)


Things that remain a bit confusing and will need to be discussed:
* Not all resources allow the same actions: only `Packages` will allow incrementing, and for now only secrets allow reading the values
  * Should we use the same name for updating a package and setting a secret? e.g. the action `write` allows updates to packages and setting of secrets

