### PR TITLE
AB#987 Allow setting of secrets by users

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -358,7 +358,7 @@ func (c *Core) GetSecrets(ctx context.Context, requestedSecrets []string, client
 	return secrets, nil
 }
 
-// SetSecrets allows a user to set certain user defined secrets
+// WriteSecrets allows a user to set certain user defined secrets
 func (c *Core) WriteSecrets(ctx context.Context, rawSecretManifest []byte, updater *user.User) error {
 	defer c.mux.Unlock()
 

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -441,7 +441,7 @@ func TestGetSecret(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestSetSecret(t *testing.T) {
+func TestWriteSecret(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, _ := mustSetup()
@@ -460,7 +460,7 @@ func TestSetSecret(t *testing.T) {
 	assert.Error(err)
 
 	// set a secret
-	err = c.WriteSecrets(context.TODO(), []byte(test.SecretsManifest), admin)
+	err = c.WriteSecrets(context.TODO(), []byte(test.UserSecrets), admin)
 	assert.NoError(err)
 	secret, err := c.data.getSecret(symmetricSecret)
 	assert.NoError(err)

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -434,6 +435,51 @@ func TestGetSecret(t *testing.T) {
 	// request should fail for non shared secrets since they dont get put in store
 	_, err = c.GetSecrets(context.TODO(), []string{"symmetric_key_private", "cert_private"}, admin)
 	assert.Error(err)
+
+	// requesting an unset secret should fail
+	_, err = c.GetSecrets(context.TODO(), []string{"symmetric_key_unset"}, admin)
+	assert.Error(err)
+}
+
+func TestSetSecret(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	c, _ := mustSetup()
+	_, err := c.SetManifest(context.TODO(), []byte(test.ManifestJSONWithRecoveryKey))
+	require.NoError(err)
+
+	admin, err := c.data.getUser("admin")
+	assert.NoError(err)
+	symmetricSecret := "symmetric_key_unset"
+	certSecret := "cert_unset"
+
+	// there should be no secret yet
+	_, err = c.data.getSecret(symmetricSecret)
+	assert.Error(err)
+	_, err = c.data.getSecret(certSecret)
+	assert.Error(err)
+
+	// set a secret
+	err = c.WriteSecrets(context.TODO(), []byte(test.SecretsManifest), admin)
+	assert.NoError(err)
+	secret, err := c.data.getSecret(symmetricSecret)
+	assert.NoError(err)
+	assert.Equal(16, len(secret.Public))
+	secret, err = c.data.getSecret(certSecret)
+	assert.NoError(err)
+	assert.Equal("Marblerun Coordinator - Intermediate CA", secret.Cert.Issuer.CommonName)
+
+	// try to set a secret in plain format
+	genericSecret := []byte(`{
+		"generic_secret": {
+			"Key": "` + base64.StdEncoding.EncodeToString([]byte("Marblerun Unit Test")) + `"
+		}
+	}`)
+	err = c.WriteSecrets(context.TODO(), genericSecret, admin)
+	assert.NoError(err)
+	secret, err = c.data.getSecret("generic_secret")
+	assert.NoError(err)
+	assert.Equal("Marblerun Unit Test", string(secret.Public))
 }
 
 func testManifestInvalidDebugCase(c *Core, manifest *manifest.Manifest, marblePackage quote.PackageProperties, assert *assert.Assertions, require *require.Assertions) *Core {

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -370,6 +370,10 @@ func (c *Core) generateSecrets(ctx context.Context, secrets map[string]manifest.
 
 	// Generate secrets
 	for name, secret := range secrets {
+		// Skip user defined secrets, these will be uploaded by a user
+		if secret.UserDefined {
+			continue
+		}
 
 		// Skip secrets from wrong context
 		if secret.Shared != (id == uuid.Nil) {
@@ -403,7 +407,7 @@ func (c *Core) generateSecrets(ctx context.Context, secrets map[string]manifest.
 				}
 			}
 
-			// Get secret object from manifest, create a copy, modify it and put in in the new map so we do not overwrite the manifest entires
+			// Get secret object from manifest, create a copy, modify it and put in in the new map so we do not overwrite the manifest entries
 			secret.Private = generatedValue
 			secret.Public = generatedValue
 

--- a/coordinator/core/storewrapper.go
+++ b/coordinator/core/storewrapper.go
@@ -156,7 +156,7 @@ func (s storeWrapper) putSecret(secretType string, secret manifest.Secret) error
 	return s.store.Put(request, rawSecret)
 }
 
-// getSecretMap returns a map of all Marblerun secrets
+// getSecretMap returns a map of all shared Marblerun secrets
 func (s storeWrapper) getSecretMap() (map[string]manifest.Secret, error) {
 	secretMap := map[string]manifest.Secret{}
 
@@ -165,9 +165,9 @@ func (s storeWrapper) getSecretMap() (map[string]manifest.Secret, error) {
 		return nil, err
 	}
 
-	for key := range manifest.Secrets {
-		if manifest.Secrets[key].Shared {
-			secretMap[key], err = s.getSecret(key)
+	for k, v := range manifest.Secrets {
+		if v.Shared && !v.UserDefined {
+			secretMap[k], err = s.getSecret(k)
 			if err != nil {
 				return nil, err
 			}

--- a/coordinator/core/storewrapper.go
+++ b/coordinator/core/storewrapper.go
@@ -156,7 +156,7 @@ func (s storeWrapper) putSecret(secretType string, secret manifest.Secret) error
 	return s.store.Put(request, rawSecret)
 }
 
-// getSecretMap returns a map of all shared Marblerun secrets
+// getSecretMap returns a map of all shared and user-defined Marblerun secrets
 func (s storeWrapper) getSecretMap() (map[string]manifest.Secret, error) {
 	secretMap := map[string]manifest.Secret{}
 
@@ -166,10 +166,13 @@ func (s storeWrapper) getSecretMap() (map[string]manifest.Secret, error) {
 	}
 
 	for k, v := range manifest.Secrets {
-		if v.Shared && !v.UserDefined {
+		if v.Shared || v.UserDefined {
+			// if a secret is not set, then this will add an empty secret
 			secretMap[k], err = s.getSecret(k)
 			if err != nil {
-				return nil, err
+				if !store.IsStoreValueUnsetError(err) {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -191,13 +191,13 @@ type PublicKey []byte
 // Secret defines a structure for storing certificates & encryption keys
 type Secret struct {
 	Type        string
-	Size        uint `json:",omitempty"`
-	Shared      bool `json:",omitempty"`
+	Size        uint
+	Shared      bool
 	UserDefined bool
 	Cert        Certificate
-	ValidFor    uint       `json:",omitempty"`
-	Private     PrivateKey `json:",omitempty"`
-	Public      PublicKey  `json:",omitempty"`
+	ValidFor    uint
+	Private     PrivateKey
+	Public      PublicKey
 }
 
 // Certificate is an x509.Certificate

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -191,13 +191,13 @@ type PublicKey []byte
 // Secret defines a structure for storing certificates & encryption keys
 type Secret struct {
 	Type        string
-	Size        uint
-	Shared      bool
+	Size        uint `json:",omitempty"`
+	Shared      bool `json:",omitempty"`
 	UserDefined bool
 	Cert        Certificate
-	ValidFor    uint
-	Private     PrivateKey
-	Public      PublicKey
+	ValidFor    uint       `json:",omitempty"`
+	Private     PrivateKey `json:",omitempty"`
+	Public      PublicKey  `json:",omitempty"`
 }
 
 // Certificate is an x509.Certificate

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -235,16 +235,22 @@ func (c *Certificate) UnmarshalJSON(data []byte) error {
 func EncodeSecretDataToPem(data interface{}) (string, error) {
 	var pemData []byte
 
-	switch x := data.(type) {
+	switch secret := data.(type) {
 	case Certificate:
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x.Raw})
-	case PublicKey:
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x})
-	case PrivateKey:
-		if x == nil {
-			return "", errors.New("private key not set for secret")
+		if len(secret.Raw) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
 		}
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x})
+		pemData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: secret.Raw})
+	case PublicKey:
+		if len(secret) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
+		}
+		pemData = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: secret})
+	case PrivateKey:
+		if len(secret) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
+		}
+		pemData = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: secret})
 	default:
 		return "", errors.New("invalid secret type")
 	}
@@ -265,17 +271,29 @@ func EncodeSecretDataToHex(data interface{}) (string, error) {
 func EncodeSecretDataToRaw(data interface{}) (string, error) {
 	switch secret := data.(type) {
 	case []byte:
+		if len(secret) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
+		}
 		return string(secret), nil
 	case PrivateKey:
-		if secret == nil {
-			return "", errors.New("private key not set for secret")
+		if len(secret) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
 		}
 		return string(secret), nil
 	case PublicKey:
+		if len(secret) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
+		}
 		return string(secret), nil
 	case Secret:
+		if len(secret.Public) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
+		}
 		return string(secret.Public), nil
 	case Certificate:
+		if len(secret.Raw) <= 0 {
+			return "", errors.New("tried to parse secret with empty value")
+		}
 		return string(secret.Raw), nil
 	default:
 		return "", errors.New("invalid secret type")

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -233,29 +233,24 @@ func (c *Certificate) UnmarshalJSON(data []byte) error {
 
 // EncodeSecretDataToPem encodes a secret to an appropriate PEM block
 func EncodeSecretDataToPem(data interface{}) (string, error) {
-	var pemData []byte
+	var typ string
+	var bytes []byte
 
 	switch secret := data.(type) {
 	case Certificate:
-		if len(secret.Raw) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: secret.Raw})
+		typ, bytes = "CERTIFICATE", secret.Raw
 	case PublicKey:
-		if len(secret) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: secret})
+		typ, bytes = "PUBLIC KEY", secret
 	case PrivateKey:
-		if len(secret) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		pemData = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: secret})
+		typ, bytes = "PRIVATE KEY", secret
 	default:
 		return "", errors.New("invalid secret type")
 	}
 
-	return string(pemData), nil
+	if len(bytes) <= 0 {
+		return "", errors.New("tried to parse secret with empty value")
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: typ, Bytes: bytes})), nil
 }
 
 // EncodeSecretDataToHex encodes a secret to a hex string
@@ -269,35 +264,27 @@ func EncodeSecretDataToHex(data interface{}) (string, error) {
 
 // EncodeSecretDataToRaw encodes a secret to a raw byte string
 func EncodeSecretDataToRaw(data interface{}) (string, error) {
+	var raw []byte
+
 	switch secret := data.(type) {
 	case []byte:
-		if len(secret) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		return string(secret), nil
+		raw = secret
 	case PrivateKey:
-		if len(secret) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		return string(secret), nil
+		raw = secret
 	case PublicKey:
-		if len(secret) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		return string(secret), nil
+		raw = secret
 	case Secret:
-		if len(secret.Public) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		return string(secret.Public), nil
+		raw = secret.Public
 	case Certificate:
-		if len(secret.Raw) <= 0 {
-			return "", errors.New("tried to parse secret with empty value")
-		}
-		return string(secret.Raw), nil
+		raw = secret.Raw
 	default:
 		return "", errors.New("invalid secret type")
 	}
+
+	if len(raw) <= 0 {
+		return "", errors.New("tried to parse secret with empty value")
+	}
+	return string(raw), nil
 }
 
 // EncodeSecretDataToBase64 encodes the byte value of a secret to a Base64 string

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -230,8 +230,17 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 
 		switch r.Method {
 		case http.MethodPost:
-			writeJSONError(w, "not implemented", http.StatusBadRequest)
-			return
+			secretManifest, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				writeJSONError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			err = cc.WriteSecrets(r.Context(), secretManifest, user)
+			if err != nil {
+				writeJSONError(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			writeJSON(w, nil)
 		case http.MethodGet:
 			// Secrets are requested via the query string in the form of ?s=<secret_one>&s=<secret_two>&s=...
 			requestedSecrets := r.URL.Query()["s"]

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -235,8 +235,7 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 				writeJSONError(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			err = cc.WriteSecrets(r.Context(), secretManifest, user)
-			if err != nil {
+			if err := cc.WriteSecrets(r.Context(), secretManifest, user); err != nil {
 				writeJSONError(w, err.Error(), http.StatusBadRequest)
 				return
 			}

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -144,7 +144,7 @@ func TestSetSecret(t *testing.T) {
 	mux := CreateServeMux(c)
 
 	// Make HTTP secret request with no TLS at all, should be unauthenticated
-	req := httptest.NewRequest(http.MethodPost, "/secrets", strings.NewReader(test.SecretsManifest))
+	req := httptest.NewRequest(http.MethodPost, "/secrets", strings.NewReader(test.UserSecrets))
 	resp := httptest.NewRecorder()
 	err = testRequestWithCert(req, resp, mux)
 	assert.NoError(err)

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -111,26 +112,8 @@ func TestUpdate(t *testing.T) {
 	// Make HTTP update request with no TLS at all, should be unauthenticated
 	req := httptest.NewRequest(http.MethodPost, "/update", strings.NewReader(test.UpdateManifest))
 	resp := httptest.NewRecorder()
-	mux.ServeHTTP(resp, req)
-	assert.Equal(http.StatusUnauthorized, resp.Code)
-
-	// Get certificates to test
-	adminTestCert, otherTestCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
-	adminTestCertSlice := []*x509.Certificate{adminTestCert}
-	otherTestCertSlice := []*x509.Certificate{otherTestCert}
-
-	// Create mock TLS object and with wrong certificate, should fail
-	req.TLS = &tls.ConnectionState{}
-	req.TLS.PeerCertificates = otherTestCertSlice
-	resp = httptest.NewRecorder()
-	mux.ServeHTTP(resp, req)
-	assert.Equal(http.StatusUnauthorized, resp.Code)
-
-	// Create mock TLS connection with right certificate, should pass
-	req.TLS.PeerCertificates = adminTestCertSlice
-	resp = httptest.NewRecorder()
-	mux.ServeHTTP(resp, req)
-	assert.Equal(http.StatusOK, resp.Code)
+	err = testRequestWithCert(req, resp, mux)
+	assert.NoError(err)
 }
 
 func TestReadSecret(t *testing.T) {
@@ -146,8 +129,32 @@ func TestReadSecret(t *testing.T) {
 	// Make HTTP secret request with no TLS at all, should be unauthenticated
 	req := httptest.NewRequest(http.MethodGet, "/secrets?s=symmetric_key_shared", nil)
 	resp := httptest.NewRecorder()
+	err = testRequestWithCert(req, resp, mux)
+	assert.NoError(err)
+}
+
+func TestSetSecret(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Setup mock core and set a manifest
+	c := core.NewCoreWithMocks()
+	_, err := c.SetManifest(context.TODO(), []byte(test.ManifestJSONWithRecoveryKey))
+	require.NoError(err)
+	mux := CreateServeMux(c)
+
+	// Make HTTP secret request with no TLS at all, should be unauthenticated
+	req := httptest.NewRequest(http.MethodPost, "/secrets", strings.NewReader(test.SecretsManifest))
+	resp := httptest.NewRecorder()
+	err = testRequestWithCert(req, resp, mux)
+	assert.NoError(err)
+}
+
+func testRequestWithCert(req *http.Request, resp *httptest.ResponseRecorder, mux *http.ServeMux) error {
 	mux.ServeHTTP(resp, req)
-	assert.Equal(http.StatusUnauthorized, resp.Code)
+	if resp.Code != http.StatusUnauthorized {
+		return errors.New("request without certificate was not rejected")
+	}
 
 	// Get certificates to test
 	adminTestCert, otherTestCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
@@ -159,13 +166,18 @@ func TestReadSecret(t *testing.T) {
 	req.TLS.PeerCertificates = otherTestCertSlice
 	resp = httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
-	assert.Equal(http.StatusUnauthorized, resp.Code)
+	if resp.Code != http.StatusUnauthorized {
+		return errors.New("request with wrong certificate was not rejected")
+	}
 
 	// Create mock TLS connection with right certificate, should pass
 	req.TLS.PeerCertificates = adminTestCertSlice
 	resp = httptest.NewRecorder()
 	mux.ServeHTTP(resp, req)
-	assert.Equal(http.StatusOK, resp.Code)
+	if resp.Code != http.StatusOK {
+		return errors.New("correct request was not accepted")
+	}
+	return nil
 }
 
 func TestConcurrent(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -319,7 +318,7 @@ func TestSettingSecrets(t *testing.T) {
 	// test setting a secret
 	log.Println("Setting a custom secret")
 	clientAPIURL := url.URL{Scheme: "https", Host: clientServerAddr, Path: "secrets"}
-	_, err = client.Post(clientAPIURL.String(), "application/json", strings.NewReader(UserSecrets))
+	_, err = client.Post(clientAPIURL.String(), "application/json", bytes.NewReader([]byte(UserSecrets)))
 	require.NoError(err)
 
 	// start the marble again

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -318,7 +319,7 @@ func TestSettingSecrets(t *testing.T) {
 	// test setting a secret
 	log.Println("Setting a custom secret")
 	clientAPIURL := url.URL{Scheme: "https", Host: clientServerAddr, Path: "secrets"}
-	_, err = client.Post(clientAPIURL.String(), "application/json", bytes.NewReader([]byte(UserSecrets)))
+	_, err = client.Post(clientAPIURL.String(), "application/json", strings.NewReader(UserSecrets))
 	require.NoError(err)
 
 	// start the marble again

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -239,6 +239,17 @@ var ManifestJSONWithRecoveryKey string = `{
 				}
 			},
 			"ValidFor": 7
+		},
+		"symmetric_key_unset": {
+			"Shared": true,
+			"Type": "symmetric-key",
+			"Size": 128,
+			"UserDefined": true
+		},
+		"cert_unset": {
+			"Shared": true,
+			"Type": "cert-ed25519",
+			"UserDefined": true
 		}
 	},
 	"Clients": {
@@ -252,7 +263,12 @@ var ManifestJSONWithRecoveryKey string = `{
 			],
 			"ReadSecrets": [
 				"symmetric_key_shared",
+				"symmteric_key_unset",
 				"cert_shared"
+			],
+			"WriteSecrets": [
+				"symmetric_key_unset",
+				"cert_unset"
 			]
 		}
 	},
@@ -403,6 +419,26 @@ const UpdateManifest = `{
 	"Packages": {
 		"frontend": {
 			"SecurityVersion": 5
+		}
+	}
+}`
+
+// SecretsManifest is a test secrets manifest to update secrets
+const SecretsManifest = `{
+	"Secrets": {
+		"symmetric_key_unset": {
+			"Type": "symmetric-key",
+			"Size": 128,
+			"Shared": true,
+			"Public": "AAECAwQFBgcICQoLDA0ODw=="
+		},
+		"cert_unset": {
+			"Type": "cert-ed25519", 
+			"Shared": true,
+			"Cert": "MIIBjDCCATOgAwIBAgICBTkwCgYIKoZIzj0EAwIwMjEwMC4GA1UEAxMnTWFyYmxlcnVuIENvb3JkaW5hdG9yIC0gSW50ZXJtZWRpYXRlIENBMB4XDTIxMDYxNTA4NTY0M1oXDTIxMDYyMjA4NTY0M1owLTEcMBoGA1UEAxMTTWFyYmxlcnVuIFVuaXQgVGVzdDENMAsGA1UEBRMEMTMzNzAqMAUGAytlcAMhAEPOc066G5XmvLizOKTENSR+U9lv3geZ0/a2+XkhJRvDo20wazAOBgNVHQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwLAYDVR0RBCUwI4IJbG9jYWxob3N0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAABMAoGCCqGSM49BAMCA0cAMEQCIGOlRcynaPaj/flSr2ZEvmTmhuvtmTb4QkwPFtxFz3EJAiB77ijxAcJNxPKcKmgMB+c8NORC+6N/St2iP/oX/vqQvg==",
+			"ValidFor": 7,
+			"Private": "MC4CAQAwBQYDK2VwBCIEIPlmAOOhAStk8ytxzvekPr8zLaQa9+lxnHK+CizDrMds",
+			"Public": "MCowBQYDK2VwAyEAQ85zTroblea8uLM4pMQ1JH5T2W/eB5nT9rb5eSElG8M="
 		}
 	}
 }`

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -455,8 +455,8 @@ const UpdateManifest = `{
 	}
 }`
 
-// SecretsManifest is a test secrets manifest to update secrets
-const SecretsManifest = `{
+// UserSecrets is a test JSON string to update secrets
+const UserSecrets = `{
 	"symmetric_key_unset": {
 		"Key": "AAECAwQFBgcICQoLDA0ODw=="
 	},

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -339,7 +339,7 @@ var IntegrationManifestJSON string = `{
 				"Files": {
 					"/tmp/coordinator_test/defg.txt": "foo",
 					"/tmp/coordinator_test/jkl.mno": "bar",
-					"/tmp/coordinator_test/pqr.txt": "user-defined secret: {{ raw .Secrets.symmetric_key_unset }} {{ pem .Secrets.cert_unset.Private }}"
+					"/tmp/coordinator_test/pqr.txt": "user-defined secret: {{ hex .Secrets.symmetric_key_unset }} {{ pem .Secrets.cert_unset.Private }}"
 				},
 				"Env": {
 					"IS_FIRST": "true",


### PR DESCRIPTION
### Proposed changes
- Allow users to set secrets after the coordinator has been started and initialised with a manifest.

This is done using the `/secrets` endpoint of the client API and a special "secrets" manifest.
This manifest contains the data for one or more secrets marked as `UserDefined` in the original manifest and looks similar to the following:
```javascript
{
  "symmetric_key_unset": {
    "Key": "<base64 encoded key>"
  },
  "cert_unset": {
    "Cert": "<base64 encoded certificate>",
    "Private": "<optional base64 encoded private key of the cert>"
  },
  "generic_secret": {
    "Key": "<generic base64 encoded data>"
  }
}
```

In the original manifest `symmetric-key` and `cert` secrets are defined as before, apart from the extra `UserDefined` flag.
Plain secrets only require the type to be `plain` and the `UserDefined` flag.

A user trying to set a secret using the API has to have permissions for every secret they try to set.

A secret in the "secrets" manifest consist of 4 parts:
* The name of the secret
* `Key`: a base64 encoded symmetric key or arbitrary base64 encoded data
* `Cert`: a x509 certificate
* `Private`: a private key of a certificate, this can be left empty when uploading a certificate

When uploaded, the names of the secrets defined in the "secrets" manifest are matched against the ones defined in the original Manifest.
If no match is found, or the secret is not marked as `UserDefined` an error occurs, otherwise one of three cases happens:
* The secret is of type `symmetric-key`: 
  * the length of the data in `Key` is verified against the size defined in the original manifest
  * if `Key` or `Private` are set an error occurs
  * a new `manifest.Secret` of type `symmetric-key` is created using the metadata from the original manifest and key from the "secrets" manifest, and uploaded to the store
* The secret is of type `cert-*`:
  * if `Key` is set an error occurs
  * a new `manifest.Secret` of type `cert-*` is created using the metadata from the original manifest and cert, public and private key from the "secrets" manifest, and uploaded to the store
* The secret is of type `plain`:
  *  if `Key` or `Private` are set an error occurs
  * a new `manifest.Secret` of type `plain` is created using the metadata from the original manifest and key from the "secrets" manifest, and uploaded to the store

### Additional info
If a Marble requiring a secret marked as `UserDefined` tries to start before said secret is uploaded, the activation request fails.
The same thing happens when a Marble requiring the private key of a certificate marked as `UserDefined` tries to start, but the private key was not uploaded along the certificate.

<!-- (uncomment if applicable)
### Screenshots

-->
