### PR TITLE
AB#993 CLI secret get/set

### DIFF
--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -49,7 +49,7 @@ func newManifestGet() *cobra.Command {
 
 // cliManifestGet gets the manifest from the coordinatros rest api
 func cliManifestGet(host string, cert []*pem.Block) ([]byte, error) {
-	client, err := restClient(cert)
+	client, err := restClient(cert, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/manifestSet.go
+++ b/cli/cmd/manifestSet.go
@@ -53,7 +53,7 @@ func newManifestSet() *cobra.Command {
 
 // cliManifestSet sets the coordinators manifest using its rest api
 func cliManifestSet(manifest []byte, host string, cert []*pem.Block, recover string) error {
-	client, err := restClient(cert)
+	client, err := restClient(cert, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -48,7 +48,7 @@ func newRecoverCmd() *cobra.Command {
 
 // cliRecover tries to unseal the coordinator by uploading the recovery key
 func cliRecover(host string, key []byte, cert []*pem.Block) error {
-	client, err := restClient(cert)
+	client, err := restClient(cert, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 	rootCmd.AddCommand(newNamespaceCmd())
 	rootCmd.AddCommand(newPrecheckCmd())
 	rootCmd.AddCommand(newRecoverCmd())
+	rootCmd.AddCommand(newSecretCmd())
 	rootCmd.AddCommand(newSGXSDKPackageInfoCmd())
 	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newUninstallCmd())

--- a/cli/cmd/secret.go
+++ b/cli/cmd/secret.go
@@ -15,7 +15,7 @@ func newSecretCmd() *cobra.Command {
 		Short: "Manages secrets for the Marblerun coordinator",
 		Long: `
 Manages secrets for the Marblerun coordinator.
-Used to either set a secret, or retrieve a secret used by the coordinator.`,
+Set or retrieve a secret defined in the manifest.`,
 	}
 
 	cmd.PersistentFlags().StringVar(&eraConfig, "era-config", "", "Path to remote attestation config file in json format, if none provided the newest configuration will be loaded from github")

--- a/cli/cmd/secret.go
+++ b/cli/cmd/secret.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	userCertFile string
+	userKeyFile  string
+)
+
+func newSecretCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: "Manages secrets for the Marblerun coordinator",
+		Long: `
+Manages secrets for the Marblerun coordinator.
+Used to either set a secret, or retrieve a secret used by the coordinator.`,
+	}
+
+	cmd.PersistentFlags().StringVar(&eraConfig, "era-config", "", "Path to remote attestation config file in json format, if none provided the newest configuration will be loaded from github")
+	cmd.PersistentFlags().StringVarP(&userCertFile, "cert", "c", "", "PEM encoded Marblerun user certificate file (required)")
+	cmd.PersistentFlags().StringVarP(&userKeyFile, "key", "k", "", "PEM encoded Marblerun user key file (required)")
+	cmd.PersistentFlags().BoolVarP(&insecureEra, "insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
+	cmd.MarkPersistentFlagRequired("key")
+	cmd.MarkPersistentFlagRequired("cert")
+	cmd.AddCommand(newSecretSet())
+	cmd.AddCommand(newSecretGet())
+
+	return cmd
+}

--- a/cli/cmd/secretGet.go
+++ b/cli/cmd/secretGet.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
+)
+
+type secretGetOptions struct {
+	host      string
+	secretIDs []string
+	output    string
+	clCert    tls.Certificate
+	caCert    []*pem.Block
+}
+
+func newSecretGet() *cobra.Command {
+	options := &secretGetOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "get SECRETNAME ... <IP:PORT>",
+		Short: "Retrieve secrets from the Marblerun coordinator",
+		Long: `
+Retrieve one or more secrets from the Marblerun coordinator.
+A user has to authenticate themselves using a certificate and private key,
+and has to be permitted to read the requested secrets.
+`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostName := args[len(args)-1]
+			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			if err != nil {
+				return err
+			}
+
+			// Load client certificate and key
+			clCert, err := tls.LoadX509KeyPair(userCertFile, userKeyFile)
+			if err != nil {
+				return err
+			}
+
+			options.secretIDs = args[0 : len(args)-1]
+			options.host = hostName
+			options.caCert = caCert
+			options.clCert = clCert
+
+			return cliSecretGet(options)
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVarP(&options.output, "output", "o", "", "File to save the secret to")
+
+	return cmd
+}
+
+// cliSecretGet requests one or more secrets from the Marblerun coordinator
+func cliSecretGet(o *secretGetOptions) error {
+	client, err := restClient(o.caCert, &o.clCert)
+	if err != nil {
+		return err
+	}
+
+	secretQuery := fmt.Sprintf("s=%s", o.secretIDs[0])
+	for _, secret := range o.secretIDs[1:] {
+		secretQuery = fmt.Sprintf("%s&s=%s", secretQuery, secret)
+	}
+	url := url.URL{Scheme: "https", Host: o.host, Path: "secrets", RawQuery: secretQuery}
+	resp, err := client.Get(url.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Everything went fine, print the secret or save to file
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		response := gjson.GetBytes(respBody, "data")
+		if len(response.String()) <= 0 {
+			return fmt.Errorf("received empty secret response")
+		}
+
+		if len(response.Map()) != len(o.secretIDs) {
+			return fmt.Errorf("Did not receive the same number of secrets as requested")
+		}
+
+		if o.output == "" {
+			return printSecrets(response)
+		}
+		if err := ioutil.WriteFile(o.output, []byte(response.String()), 0644); err != nil {
+			return err
+		}
+		fmt.Printf("Saved secret to: %s\n", o.output)
+	case http.StatusBadRequest:
+		// Something went wrong
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		response := gjson.GetBytes(respBody, "message")
+		return fmt.Errorf("unable to retrieve secret: %s", response)
+	case http.StatusUnauthorized:
+		// User was not authorized
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		response := gjson.GetBytes(respBody, "message")
+		return fmt.Errorf("unable to authorize user: %s", response)
+	default:
+		return fmt.Errorf("error connecting to server: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	return nil
+}
+
+// printSecrets prints secrets formated in a readable way
+func printSecrets(response gjson.Result) error {
+	for secretName, singleResponse := range response.Map() {
+		secretType := singleResponse.Get("Type")
+		userDefined := singleResponse.Get("UserDefined")
+		secretSize := singleResponse.Get("Size")
+		validFor := singleResponse.Get("ValidFor")
+		cert := singleResponse.Get("Cert")
+		public := singleResponse.Get("Public")
+		private := singleResponse.Get("Private")
+
+		fmt.Printf("%s:\n", secretName)
+		var output string
+		output = prettyFormat(output, "Type:", secretType.String())
+
+		switch secretType.String() {
+		case "cert-rsa", "cert-ecdsa", "cert-ed25519":
+			output = prettyFormat(output, "UserDefined:", userDefined.String())
+			if secretType.String() == "cert-rsa" || secretType.String() == "cert-ecdsa" {
+				output = prettyFormat(output, "Size:", secretSize.String())
+			}
+			output = prettyFormat(output, "Valid For:", validFor.String())
+			output = prettyFormat(output, "Certificate:", cert.String())
+			output = prettyFormat(output, "Public Key:", public.String())
+			output = prettyFormat(output, "Private Key:", private.String())
+		case "symmetric-key":
+			output = prettyFormat(output, "UserDefined:", userDefined.String())
+			output = prettyFormat(output, "Size:", secretSize.String())
+			output = prettyFormat(output, "Key:", public.String())
+		case "plain":
+			output = prettyFormat(output, "Data:", public.String())
+		default:
+			return fmt.Errorf("unkown secret type")
+		}
+		fmt.Printf("%s\n", output)
+	}
+
+	return nil
+}
+
+func prettyFormat(previous, label, value string) string {
+	return fmt.Sprintf("%s\t%-14s %s\n", previous, label, value)
+}

--- a/cli/cmd/secretGet.go
+++ b/cli/cmd/secretGet.go
@@ -93,7 +93,7 @@ func cliSecretGet(o *secretGetOptions) error {
 		}
 
 		if len(response.Map()) != len(o.secretIDs) {
-			return fmt.Errorf("Did not receive the same number of secrets as requested")
+			return fmt.Errorf("did not receive the same number of secrets as requested")
 		}
 
 		if o.output == "" {

--- a/cli/cmd/secretGet.go
+++ b/cli/cmd/secretGet.go
@@ -28,8 +28,8 @@ func newSecretGet() *cobra.Command {
 		Short: "Retrieve secrets from the Marblerun coordinator",
 		Long: `
 Retrieve one or more secrets from the Marblerun coordinator.
-A user has to authenticate themselves using a certificate and private key,
-and has to be permitted to read the requested secrets.
+Users have to authenticate themselves using a certificate and private key,
+and need permissions in the manifest to read the requested secrets.
 `,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,11 +67,12 @@ func cliSecretGet(o *secretGetOptions) error {
 		return err
 	}
 
-	secretQuery := fmt.Sprintf("s=%s", o.secretIDs[0])
-	for _, secret := range o.secretIDs[1:] {
-		secretQuery = fmt.Sprintf("%s&s=%s", secretQuery, secret)
+	secretQuery := url.Values{}
+
+	for _, secret := range o.secretIDs {
+		secretQuery.Add("s", secret)
 	}
-	url := url.URL{Scheme: "https", Host: o.host, Path: "secrets", RawQuery: secretQuery}
+	url := url.URL{Scheme: "https", Host: o.host, Path: "secrets", RawQuery: secretQuery.Encode()}
 	resp, err := client.Get(url.String())
 	if err != nil {
 		return err

--- a/cli/cmd/secretSet.go
+++ b/cli/cmd/secretSet.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
+)
+
+func newSecretSet() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <secret_name> <IP:PORT>",
+		Short: "Set a secret for the Marblerun coordinator",
+		Long: `
+Set a secret for the Marblerun coordinator.
+A user has to authenticate themselves using a certificate and private key,
+and has to be permitted to write the requested secrets.
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			secretFile := args[0]
+			hostName := args[1]
+
+			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			if err != nil {
+				return err
+			}
+
+			// Load client certificate and key
+			clCert, err := tls.LoadX509KeyPair(userCertFile, userKeyFile)
+			if err != nil {
+				return err
+			}
+
+			newSecrets, err := ioutil.ReadFile(secretFile)
+			if err != nil {
+				return err
+			}
+
+			return cliSecretSet(hostName, newSecrets, clCert, caCert)
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+// cliSecretSet sets one or more secrets using a secrets manifest
+func cliSecretSet(host string, newSecrets []byte, clCert tls.Certificate, caCert []*pem.Block) error {
+	client, err := restClient(caCert, &clCert)
+	if err != nil {
+		return err
+	}
+
+	url := url.URL{Scheme: "https", Host: host, Path: "secrets"}
+	resp, err := client.Post(url.String(), "application/json", bytes.NewReader(newSecrets))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Everything went fine, just print the sucess message
+		fmt.Println("Secret successfully set")
+	case http.StatusBadRequest:
+		// Something went wrong
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		response := gjson.GetBytes(respBody, "message")
+		return fmt.Errorf("unable to set secret: %s", response)
+	case http.StatusUnauthorized:
+		// User was not authorized
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		response := gjson.GetBytes(respBody, "message")
+		return fmt.Errorf("unable to authorize user: %s", response)
+	default:
+		return fmt.Errorf("error connecting to server: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	return nil
+}

--- a/cli/cmd/secretSet.go
+++ b/cli/cmd/secretSet.go
@@ -19,8 +19,8 @@ func newSecretSet() *cobra.Command {
 		Short: "Set a secret for the Marblerun coordinator",
 		Long: `
 Set a secret for the Marblerun coordinator.
-A user has to authenticate themselves using a certificate and private key,
-and has to be permitted to write the requested secrets.
+Users have to authenticate themselves using a certificate and private key
+and need permissions in the manifest to write the requested secrets.
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,7 +67,7 @@ func cliSecretSet(host string, newSecrets []byte, clCert tls.Certificate, caCert
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// Everything went fine, just print the sucess message
+		// Everything went fine, just print the success message
 		fmt.Println("Secret successfully set")
 	case http.StatusBadRequest:
 		// Something went wrong

--- a/cli/cmd/secret_test.go
+++ b/cli/cmd/secret_test.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetSecrets(t *testing.T) {
@@ -118,5 +120,68 @@ func TestGetSecrets(t *testing.T) {
 
 	options.secretIDs = []string{"this should cause an error"}
 	err = cliSecretGet(options)
+	assert.Error(err)
+}
+
+func TestSecretFromPEM(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const testCert = `
+-----BEGIN CERTIFICATE-----
+MIICpjCCAg+gAwIBAgIUS5FDU/DJnN3hDISm2eAu7hVWqSUwDQYJKoZIhvcNAQEL
+BQAwZTELMAkGA1UEBhMCREUxEzARBgNVBAgMClNvbWUtU3RhdGUxGTAXBgNVBAoM
+EEVkZ2VsZXNzIFN5c3RlbXMxEjAQBgNVBAsMCVVuaXQgVGVzdDESMBAGA1UEAwwJ
+VW5pdCBUZXN0MB4XDTIxMDYyMzA3NTAxMVoXDTIyMDYyMzA3NTAxMVowZTELMAkG
+A1UEBhMCREUxEzARBgNVBAgMClNvbWUtU3RhdGUxGTAXBgNVBAoMEEVkZ2VsZXNz
+IFN5c3RlbXMxEjAQBgNVBAsMCVVuaXQgVGVzdDESMBAGA1UEAwwJVW5pdCBUZXN0
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDO+ZG7pGx+/poBhr5Zt2lX0+Nh
+kcWpYbWdbt69tJXhSWYlZmLeo6FJbeV11bX8zEwVPaDxhYSmlDq2tu9t8o1j8N01
+FAoWy4NnDyGEyx1bJGyGGcMN01mVqD+PTbmKeOuVGYchyz8YBub+k5Eft9l6MxuN
+kA7SuJGv9fU3lTpQpQIDAQABo1MwUTAdBgNVHQ4EFgQUmD/6vklf6UsdUcZvOB2x
+FeymJU0wHwYDVR0jBBgwFoAUmD/6vklf6UsdUcZvOB2xFeymJU0wDwYDVR0TAQH/
+BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOBgQCxHFf2dQ+6O/ntEQr6zbHgU4jMidM+
+foF2RSiG5icffjDcjpxttJtpIK+iGh3yguGfWaaMVo72DPFPNAVmqHutoEr80chV
+yr93zz66XkRPyMhopTeF3Ld1K3qAQ0CqtWck1kblgHCWJBGYgyngawoxSGhUMkSD
+i6zr19jszrNxzg==
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAM75kbukbH7+mgGG
+vlm3aVfT42GRxalhtZ1u3r20leFJZiVmYt6joUlt5XXVtfzMTBU9oPGFhKaUOra2
+723yjWPw3TUUChbLg2cPIYTLHVskbIYZww3TWZWoP49NuYp465UZhyHLPxgG5v6T
+kR+32XozG42QDtK4ka/19TeVOlClAgMBAAECgYEAyEX3vUEJ9wx3ixiN4hQ2q9SN
+BiFeyVqRuSfKAnjWOquiWngrHVHqRDpBuXa05UvuJvN+Y5YV2HZAJgL3xUTZh+jV
+sBgj65evWTUE3daVJBPoTDtBRmZCoEXNvonXbUNFExUwWfDaYOraZCSupP9Yg/0q
+m1To7ktkWmS84JuVukECQQDmbVibBLYqIClFsEdNVuVjAq0OHHSsN5FEyD3joQso
+JZ5EmCUnp/GvJ+yDgOyKY/gOVK9s9BYKEd7WQQBQ3Vs1AkEA5fHsHtYryPMTl3s7
+aycxjEEJyvpDr3y1Pk5tSGdj2YSTvKdkVYP3pJmA0JaCRL/2rqJx3pKuOm1/kOS8
+71xdsQJBAJAbLmC0T6CEwIr+tXjesVJ8Z/H9RdI2ZjlX6aykGLAg5pwLcqEcXP+n
+vjh3tnbOEmIUACnpdKcTigMAX8wyw0kCQBpYpro9xdSHbWY822kCm527UfjsxdaU
+jluuNr1GA13H3/mMoGVf8n7si6Laq+Besk/+EtfyrH3LUAN1AeTXC3ECQQCua5+L
+Ra6Yym8Tq+6I6YFqee2NFPKrsKw2xrExhHjx/vv+V0SMXU/zBfZudCbPUcLQoH3q
+LuL049+D8bu8Z+Fe
+-----END PRIVATE KEY-----`
+
+	secretName := "test-secret"
+	secret, err := loadSecretFromPEM(secretName, []byte(testCert))
+	assert.NoError(err)
+
+	var secretMap map[string]manifest.Secret
+	err = json.Unmarshal(secret, &secretMap)
+	require.NoError(err)
+
+	_, ok := secretMap[secretName]
+	require.True(ok)
+	assert.True(len(secretMap[secretName].Cert.Raw) > 0)
+	assert.True(len(secretMap[secretName].Private) > 0)
+	assert.True(len(secretMap[secretName].Public) == 0)
+
+	// no error here since we stop after finding the first cert-key pair
+	_, err = loadSecretFromPEM(secretName, []byte(testCert+"\n-----BEGIN MESSAGE-----\ndGVzdA==\n-----END MESSAGE-----"))
+	assert.NoError(err)
+	// error since the first pem block contains an invalid type
+	_, err = loadSecretFromPEM(secretName, []byte("-----BEGIN MESSAGE-----\ndGVzdA==\n-----END MESSAGE-----\n"+testCert))
+	assert.Error(err)
+	_, err = loadSecretFromPEM(secretName, []byte("no PEM data here"))
 	assert.Error(err)
 }

--- a/cli/cmd/secret_test.go
+++ b/cli/cmd/secret_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"encoding/pem"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/edgelesssys/marblerun/coordinator/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetSecrets(t *testing.T) {
+	assert := assert.New(t)
+	s, host, cert := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/secrets", r.RequestURI)
+		assert.Equal(http.MethodPost, r.Method)
+		request, err := ioutil.ReadAll(r.Body)
+		assert.NoError(err)
+
+		if strings.Contains(string(request), "restricted_secret") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if strings.Contains(string(request), `"Type":"invalid"`) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		serverResp := server.GeneralResponse{
+			Status: "success",
+		}
+		assert.NoError(json.NewEncoder(w).Encode(serverResp))
+	}))
+	defer s.Close()
+
+	err := cliSecretSet(host, []byte(`{"user_secret":{"Type":"plain","Key":"Q0xJIFRlc3QK"}}`), tls.Certificate{}, []*pem.Block{cert})
+	assert.NoError(err)
+
+	err = cliSecretSet(host, []byte(`{"restricted_secret":{"Type":"plain","Key":"Q0xJIFRlc3QK"}}`), tls.Certificate{}, []*pem.Block{cert})
+	assert.Error(err)
+
+	err = cliSecretSet(host, []byte(`{"user_secret":{"Type":"invalid","Key":"Q0xJIFRlc3QK"}}`), tls.Certificate{}, []*pem.Block{cert})
+	assert.Error(err)
+}
+
+func TestGetSecrets(t *testing.T) {
+	assert := assert.New(t)
+	s, host, cert := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		if "/secrets?s=plain_secret&s=cert_shared&s=secretOne" == r.RequestURI {
+			serverResp := server.GeneralResponse{
+				Status: "success",
+				Data: map[string]interface{}{
+					"plain_secret": map[string]interface{}{
+						"Type":        "plain",
+						"Size":        0,
+						"Shared":      false,
+						"UserDefined": true,
+						"Cert":        nil,
+						"ValidFor":    0,
+						"Private":     "base64-data",
+						"Public":      "base64-data",
+					},
+					"secretOne": map[string]interface{}{
+						"Type":        "symmetric-key",
+						"Size":        128,
+						"Shared":      true,
+						"UserDefined": false,
+						"Cert":        nil,
+						"ValidFor":    0,
+						"Private":     "base64-priv-data",
+						"Public":      "base64-priv-data",
+					},
+					"cert_shared": map[string]interface{}{
+						"Type":        "cert-rsa",
+						"Size":        2048,
+						"Shared":      true,
+						"UserDefined": false,
+						"Cert":        "base64-cert-data",
+						"ValidFor":    14,
+						"Private":     "base64-priv-data",
+						"Public":      "base64-pub-data",
+					},
+				},
+			}
+			assert.NoError(json.NewEncoder(w).Encode(serverResp))
+			return
+		}
+		if "/secrets?s=restricted_secret" == r.RequestURI {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer s.Close()
+	options := &secretGetOptions{
+		host: host,
+		secretIDs: []string{
+			"plain_secret",
+			"cert_shared",
+			"secretOne",
+		},
+		output: "",
+		clCert: tls.Certificate{},
+		caCert: []*pem.Block{cert},
+	}
+	err := cliSecretGet(options)
+	assert.NoError(err)
+
+	options.secretIDs = []string{"restricted_secret"}
+	err = cliSecretGet(options)
+	assert.Error(err)
+
+	options.secretIDs = []string{"this should cause an error"}
+	err = cliSecretGet(options)
+	assert.Error(err)
+}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -59,7 +59,7 @@ func newStatusCmd() *cobra.Command {
 
 // cliStatus requests the current status of the coordinator
 func cliStatus(host string, cert []*pem.Block) error {
-	client, err := restClient(cert)
+	client, err := restClient(cert, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Proposed changes
- Add a command to retrieve secrets from the coordinator using the API endpoint from https://github.com/edgelesssys/marblerun/pull/188
  - supports saving to file as json or printing to stdout in readable format
- Add a command to set secrets for the coordinator using the API endpoint from https://github.com/edgelesssys/marblerun/pull/191
  - requires a json file defining the secrets as described in the original PR

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Also updates the `restClient` function to accept an optional client tls certificate to create a http client with user certificate

<!-- (uncomment if applicable)
### Screenshots

-->
