### PR TITLE
Use execve for Occlum + minor bug fix

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -76,3 +76,27 @@ jobs:
                                 "file": "dockerfiles/Dockerfile.marble-injector",
                                 "target":"release"}}' \
           https://api.github.com/repos/edgelesssys/deployment/dispatches
+
+  occlum:
+    runs-on: ubuntu-18.04
+    container:
+      image: occlum/occlum:0.23.0-ubuntu18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup
+        run: mkdir build
+
+      - name: Build
+        run: |
+          occlum-go build -o premain-occlum ../cmd/premain-occlum
+        working-directory: build
+
+      - name: Build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: marblerun
+          path: |
+            build/premain-occlum

--- a/samples/occlum-hello/Dockerfile
+++ b/samples/occlum-hello/Dockerfile
@@ -1,5 +1,5 @@
 # Replace standard Intel DCAP plugin with Azure DCAP plugin
-FROM occlum/occlum:0.22.0-ubuntu18.04
+FROM occlum/occlum:0.23.0-ubuntu18.04
 
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list && \
     wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add - && \

--- a/samples/occlum-hello/Makefile
+++ b/samples/occlum-hello/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 all: build
 .PHONY: clean all
 

--- a/samples/occlum-hello/README.md
+++ b/samples/occlum-hello/README.md
@@ -90,16 +90,9 @@ occlum run /bin/premain-occlum
     panic: "invalid entrypoint definition in argv[0]"
     ```
 
-    or:
+    Make sure you specified the correct filename of your target application.
 
-    ```
-    ERROR: Failed to spawn the target process.
-    Did you specify the correct target application in the Marblerun manifest as argv[0]?
-    Have you allocated enough memory?
-    panic: posix_spawn failed with error code -1
-    ```
-
-    Make sure you specified the correct filename of your target application. For the latter error message, also make sure enough memory is allocated. To find out the specific reason for why this error is occuring, you can set the environment variable `OCCLUM_LOG_LEVEL=error` by appending it in front of your run command like this:
+* If you are running into other issues, it might be helpful to enable Occlum's error logging. You can do that with the help of the environment variable `OCCLUM_LOG_LEVEL=error`, which can be set by appending it in front of your run command like this:
 
     ```sh
     OCCLUM_LOG_LEVEL=error make run
@@ -109,5 +102,3 @@ occlum run /bin/premain-occlum
     ```sh
     OCCLUM_LOG_LEVEL=error occlum run /bin/premain-occlum
     ```
-
-    Search for `SpawnMusl`. This entry will contain the error encountered when spawning your application from Marblerun's premain process.

--- a/samples/occlum-hello/README.md
+++ b/samples/occlum-hello/README.md
@@ -92,7 +92,7 @@ occlum run /bin/premain-occlum
 
     Make sure you specified the correct filename of your target application.
 
-* If you are running into other issues, it might be helpful to enable Occlum's error logging. You can do that with the help of the environment variable `OCCLUM_LOG_LEVEL=error`, which can be set by appending it in front of your run command like this:
+* If you are running into other issues, Occlum's error logging might help:
 
     ```sh
     OCCLUM_LOG_LEVEL=error make run

--- a/samples/occlum-hello/README.md
+++ b/samples/occlum-hello/README.md
@@ -5,7 +5,7 @@ This sample shows how to run an [Occlum](https://github.com/occlum/occlum) appli
 First, get Occlum and its build toolchain up and running. This can become quite complex if you run it on your existing environment. Therefore, we use the official Docker image and expose the SGX device to it:
 
 ```sh
-docker run -it --network host --device /dev/sgx occlum/occlum:0.22.0-ubuntu18.04
+docker run -it --network host --device /dev/sgx occlum/occlum:0.23.0-ubuntu18.04
 ```
 
 If you are trying to run this sample on Azure, you might want to use the provided [Dockerfile](Dockerfile) instead. It is based on the official Occlum image, but replaces the default Intel DCAP client with the [Azure DCAP Client](https://github.com/microsoft/Azure-DCAP-Client). This is required to get correct quotes on Azure's Confidential Computing virtual machines. You can build and use the image in the following way:


### PR DESCRIPTION
### Proposed changes
- Fix a bug where `-e` was added to the beginning of `etc/resolv.conf` due to Make using `/bin/sh` by default (which does not support `-e`)
- Use `execve` to launch the target application instead of `posix_spawn` (requires Occlum 0.23.0)
- Simplify troubleshooting steps, as we now get better error messages back from Occlum
- Add GitHub Action to build premain-occlum with Occlum's toolchain

### Related issue
- **Merge either this PR or #195.** Both are exclusive. This depends on whether we decide to support two premains (this PR) or if we want to unify them (#195). 
