### PR TITLE
AB#1061 Virtual manifest

### DIFF
--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -50,19 +50,19 @@ Optionally get the manifests signature or merge updates into the displayed manif
 	}
 
 	cmd.Flags().BoolVarP(&signature, "signature", "s", false, "Set to additionally display the manifests signature")
-	cmd.Flags().BoolVarP(&consolidate, "consolidate", "c", false, "Set to merge updates into the displayed manifest")
+	cmd.Flags().BoolVarP(&consolidate, "display-update", "u", false, "Set to merge updates into the displayed manifest")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Save output to file instead of printing to stdout")
 	return cmd
 }
 
 // decodeManifest parses a base64 encoded manifest and optionally merges updates
-func decodeManifest(wantUpdate bool, encodedManifest, hostName string, cert []*pem.Block) (string, error) {
+func decodeManifest(consolidate bool, encodedManifest, hostName string, cert []*pem.Block) (string, error) {
 	manifest, err := base64.StdEncoding.DecodeString(encodedManifest)
 	if err != nil {
 		return "", err
 	}
 
-	if !wantUpdate {
+	if !consolidate {
 		return string(manifest), nil
 	}
 

--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -14,7 +14,7 @@ import (
 
 func newManifestGet() *cobra.Command {
 	var output string
-	var consolidate bool
+	var displayUpdate bool
 	var signature bool
 
 	cmd := &cobra.Command{
@@ -34,7 +34,7 @@ Optionally get the manifests signature or merge updates into the displayed manif
 			if err != nil {
 				return err
 			}
-			manifest, err := decodeManifest(consolidate, gjson.GetBytes(response, "Manifest").String(), hostName, cert)
+			manifest, err := decodeManifest(displayUpdate, gjson.GetBytes(response, "Manifest").String(), hostName, cert)
 			if signature {
 				// wrap the signature and manifest into one json object
 				manifest = fmt.Sprintf("{\n\"ManifestSignature\": \"%s\",\n\"Manifest\": %s}", gjson.GetBytes(response, "ManifestSignature"), manifest)
@@ -50,19 +50,19 @@ Optionally get the manifests signature or merge updates into the displayed manif
 	}
 
 	cmd.Flags().BoolVarP(&signature, "signature", "s", false, "Set to additionally display the manifests signature")
-	cmd.Flags().BoolVarP(&consolidate, "display-update", "u", false, "Set to merge updates into the displayed manifest")
+	cmd.Flags().BoolVarP(&displayUpdate, "display-update", "u", false, "Set to merge updates into the displayed manifest")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Save output to file instead of printing to stdout")
 	return cmd
 }
 
 // decodeManifest parses a base64 encoded manifest and optionally merges updates
-func decodeManifest(consolidate bool, encodedManifest, hostName string, cert []*pem.Block) (string, error) {
+func decodeManifest(displayUpdate bool, encodedManifest, hostName string, cert []*pem.Block) (string, error) {
 	manifest, err := base64.StdEncoding.DecodeString(encodedManifest)
 	if err != nil {
 		return "", err
 	}
 
-	if !consolidate {
+	if !displayUpdate {
 		return string(manifest), nil
 	}
 

--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -1,39 +1,121 @@
 package cmd
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
 )
 
 func newManifestGet() *cobra.Command {
 	var output string
+	var consolidate bool
+	var signature bool
 
 	cmd := &cobra.Command{
 		Use:   "get <IP:PORT>",
-		Short: "Get the manifest signature from the Marblerun coordinator",
-		Long:  `Get the manifest signature from the Marblerun coordinator`,
-		Args:  cobra.ExactArgs(1),
+		Short: "Get the manifest from the Marblerun coordinator",
+		Long: `Get the manifest from the Marblerun coordinator.
+Optionally get the manifests signature or merge updates into the displayed manifest.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
 			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Successfully verified coordinator, now requesting manifest signature")
-			response, err := cliDataGet(hostName, "manifest", "data.ManifestSignature", cert)
+			fmt.Println("Successfully verified coordinator, now requesting manifest")
+			response, err := cliDataGet(hostName, "manifest", "data", cert)
 			if err != nil {
 				return err
 			}
-			if len(output) > 0 {
-				return ioutil.WriteFile(output, response, 0644)
+			manifest, err := decodeManifest(consolidate, gjson.GetBytes(response, "Manifest").String(), hostName, cert)
+			if signature {
+				// wrap the signature and manifest into one json object
+				manifest = fmt.Sprintf("{\n\"ManifestSignature\": \"%s\",\n\"Manifest\": %s}", gjson.GetBytes(response, "ManifestSignature"), manifest)
 			}
-			fmt.Printf("Manifest signature: %s\n", string(response))
+
+			if len(output) > 0 {
+				return ioutil.WriteFile(output, []byte(manifest), 0644)
+			}
+			fmt.Println(manifest)
 			return nil
 		},
 		SilenceUsage: true,
 	}
+
+	cmd.Flags().BoolVarP(&signature, "signature", "s", false, "Set to additionally display the manifests signature")
+	cmd.Flags().BoolVarP(&consolidate, "consolidate", "c", false, "Set to merge updates into the displayed manifest")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Save singature to file instead of printing to stdout")
 	return cmd
+}
+
+// decodeManifest parses a base64 encoded manifest and optionally merges updates
+func decodeManifest(wantUpdate bool, encodedManifest, hostName string, cert []*pem.Block) (string, error) {
+	manifest, err := base64.StdEncoding.DecodeString(encodedManifest)
+	if err != nil {
+		return "", err
+	}
+
+	if !wantUpdate {
+		return string(manifest), nil
+	}
+
+	log, err := cliDataGet(hostName, "update", "data", cert)
+	if err != nil {
+		return "", err
+	}
+
+	return consolidateManifest(manifest, log)
+}
+
+// consolidateManifest updates a base manifest with values from an update log
+func consolidateManifest(rawManifest, log []byte) (string, error) {
+	var baseManifest manifest.Manifest
+	if err := json.Unmarshal(rawManifest, &baseManifest); err != nil {
+		return "", err
+	}
+
+	pkg := gjson.GetBytes(log, "..#.package").Array()
+	svn := gjson.GetBytes(log, "..#.new version").Array()
+	for idx, sPkg := range pkg {
+		*baseManifest.Packages[sPkg.String()].SecurityVersion = uint(svn[idx].Uint())
+	}
+
+	updated, err := json.Marshal(baseManifest)
+	if err != nil {
+		return "", err
+	}
+	var removeTarget map[string]interface{}
+	if err := json.Unmarshal(updated, &removeTarget); err != nil {
+		return "", err
+	}
+	removeNil(removeTarget)
+	updated, err = json.Marshal(removeTarget)
+	if err != nil {
+		return "", err
+	}
+
+	return gjson.Parse(string(updated)).Get(`@pretty:{"indent":"    "}`).String(), nil
+}
+
+func removeNil(m map[string]interface{}) {
+	partial := reflect.ValueOf(m)
+	for _, entry := range partial.MapKeys() {
+		val := partial.MapIndex(entry)
+		if val.IsNil() {
+			delete(m, entry.String())
+			continue
+		}
+		switch t := val.Interface().(type) {
+		case map[string]interface{}:
+			removeNil(t)
+		}
+	}
 }

--- a/cli/cmd/manifest_test.go
+++ b/cli/cmd/manifest_test.go
@@ -82,6 +82,40 @@ func TestDecodeManifest(t *testing.T) {
 	assert.Equal(test.ManifestJSON, manifest)
 }
 
+func TestRemoveNil(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	testMap := map[string]interface{}{
+		"1": "TestValue",
+		"2": map[string]interface{}{
+			"2.1": "TestValue",
+			"2.2": nil,
+		},
+		"3": nil,
+		"4": map[string]interface{}{
+			"4.1": map[string]interface{}{
+				"4.1.1": nil,
+				"4.1.2": map[string]interface{}{},
+			},
+		},
+	}
+
+	rawMap, err := json.Marshal(testMap)
+	require.NoError(err)
+
+	removeNil(testMap)
+
+	removedMap, err := json.Marshal(testMap)
+	require.NoError(err)
+	assert.NotEqual(rawMap, removedMap)
+	// three should be removed since its nil
+	assert.NotContains(removedMap, `"3"`)
+	// 2.2 should be removed since its nil, but 2 stays since 2.1 is not nil
+	assert.NotContains(removedMap, `"2.2"`)
+	// 4 should be removed completly since it only contains empty maps
+	assert.NotContains(removedMap, `"4"`)
+}
+
 func TestCliManifestSet(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cli/cmd/manifest_test.go
+++ b/cli/cmd/manifest_test.go
@@ -13,8 +13,10 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/marblerun/coordinator/server"
+	"github.com/edgelesssys/marblerun/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestCliManifestGet(t *testing.T) {
@@ -49,6 +51,35 @@ func TestCliManifestGet(t *testing.T) {
 	})
 	_, err = cliDataGet(host, "manifest", "data.ManifestSignature", []*pem.Block{cert})
 	require.Error(err)
+}
+
+func TestConsolidateManifest(t *testing.T) {
+	assert := assert.New(t)
+	log := []byte(`{"time":"1970-01-01T01:00:00.0","update":"initial manifest set"}
+{"time":"1970-01-01T02:00:00.0","update":"SecurityVersion increased","user":"admin","package":"frontend","new version":5}
+{"time":"1970-01-01T03:00:00.0","update":"SecurityVersion increased","user":"admin","package":"frontend","new version":5}
+{"time":"1970-01-01T04:00:00.0","update":"SecurityVersion increased","user":"admin","package":"frontend","new version":8}
+{"time":"1970-01-01T05:00:00.0","update":"SecurityVersion increased","user":"admin","package":"frontend","new version":12}`)
+
+	manifest, err := consolidateManifest([]byte(test.ManifestJSON), log)
+	assert.NoError(err)
+	assert.Contains(manifest, `"SecurityVersion": 12`)
+	assert.NotContains(manifest, `"RecoveryKeys"`)
+}
+
+func TestDecodeManifest(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	type responseStruct struct {
+		Manifest []byte
+	}
+
+	wrapped, err := json.Marshal(responseStruct{[]byte(test.ManifestJSON)})
+	require.NoError(err)
+
+	manifest, err := decodeManifest(false, gjson.GetBytes(wrapped, "Manifest").String(), "", nil)
+	assert.NoError(err)
+	assert.Equal(test.ManifestJSON, manifest)
 }
 
 func TestCliManifestSet(t *testing.T) {

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -27,7 +27,7 @@ import (
 type ClientCore interface {
 	SetManifest(ctx context.Context, rawManifest []byte) (recoverySecretMap map[string][]byte, err error)
 	GetCertQuote(ctx context.Context) (cert string, certQuote []byte, err error)
-	GetManifestSignature(ctx context.Context) (manifestSignature []byte)
+	GetManifestSignature(ctx context.Context) (manifestSignature []byte, manifest []byte)
 	GetSecrets(ctx context.Context, requestedSecrets []string, requestUser *user.User) (map[string]manifest.Secret, error)
 	GetStatus(ctx context.Context) (statusCode int, status string, err error)
 	GetUpdateLog(ctx context.Context) (updateLog string, err error)
@@ -192,13 +192,13 @@ func (c *Core) GetCertQuote(ctx context.Context) (string, []byte, error) {
 // GetManifestSignature returns the hash of the manifest
 //
 // Returns a SHA256 hash of the active manifest.
-func (c *Core) GetManifestSignature(ctx context.Context) []byte {
+func (c *Core) GetManifestSignature(ctx context.Context) ([]byte, []byte) {
 	rawManifest, err := c.data.getRawManifest()
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	hash := sha256.Sum256(rawManifest)
-	return hash[:]
+	return hash[:], rawManifest
 }
 
 // Recover sets an encryption key (ideally decrypted from the recovery data) and tries to unseal and load a saved state again.

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -39,9 +39,10 @@ func TestGetManifestSignature(t *testing.T) {
 
 	assert.NoError(err)
 
-	sig := c.GetManifestSignature(context.TODO())
+	sig, manifest := c.GetManifestSignature(context.TODO())
 	expectedHash := sha256.Sum256([]byte(test.ManifestJSON))
 	assert.Equal(expectedHash[:], sig)
+	assert.Equal([]byte(test.ManifestJSON), manifest)
 }
 
 func TestSetManifest(t *testing.T) {

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -83,7 +83,7 @@ func TestSeal(t *testing.T) {
 	// Get certificate and signature.
 	cert, err := c.GetTLSRootCertificate(nil)
 	assert.NoError(err)
-	signature := c.GetManifestSignature(context.TODO())
+	signature, _ := c.GetManifestSignature(context.TODO())
 
 	// Get secrets
 	cSecrets, err := c.data.getSecretMap(c.cmp.sharedSecrets)
@@ -108,7 +108,7 @@ func TestSeal(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(cSecrets, c2Secrets)
 
-	signature2 := c2.GetManifestSignature(context.TODO())
+	signature2, _ := c2.GetManifestSignature(context.TODO())
 	assert.Equal(signature, signature2, "manifest signature differs after restart")
 }
 

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -48,6 +48,7 @@ type statusResp struct {
 }
 type manifestSignatureResp struct {
 	ManifestSignature string
+	Manifest          []byte
 }
 
 // Contains RSA-encrypted AES state sealing key with public key specified by user in manifest
@@ -121,8 +122,11 @@ func CreateServeMux(cc core.ClientCore) *http.ServeMux {
 	mux.HandleFunc("/manifest", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			signature := cc.GetManifestSignature(r.Context())
-			writeJSON(w, manifestSignatureResp{hex.EncodeToString(signature)})
+			signature, manifest := cc.GetManifestSignature(r.Context())
+			writeJSON(w, manifestSignatureResp{
+				ManifestSignature: hex.EncodeToString(signature),
+				Manifest:          manifest,
+			})
 		case http.MethodPost:
 			manifest, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -58,8 +58,8 @@ func TestManifest(t *testing.T) {
 	mux.ServeHTTP(resp, req)
 	require.Equal(http.StatusOK, resp.Code)
 
-	sig := hex.EncodeToString(c.GetManifestSignature(context.TODO()))
-	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":"`+sig+`"}}`, resp.Body.String())
+	sig, manifest := c.GetManifestSignature(context.TODO())
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
 
 	// try setting manifest again, should fail
 	req = httptest.NewRequest(http.MethodPost, "/manifest", strings.NewReader(test.ManifestJSON))

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -258,7 +258,7 @@ func TestClientAPI(t *testing.T) {
 	manifest, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	require.NoError(err)
-	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":""}}`, string(manifest))
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":"","Manifest":null}}`, string(manifest))
 
 	log.Println("Setting the Manifest")
 	_, err = setManifest(testManifest)


### PR DESCRIPTION
### Proposed changes
- Return the initial manifest over the coordinators REST API on GET requests to `/manifest`
  - Coordinator still send the signature and the general structure of the responds stays the same:
    ```go
    type manifestSignatureResp struct {
      ManifestSignature string
      Manifest          []byte
    }
    ```
  - This allows users who dont have access to the manifest at the start, to request the manifest at their own time directly from the coordinator.
- Change the `manifest get` command to mainly display the manifest instead of its signature
  - Using flags users can additionally display the signature, or create a virtual updated manifest by merging changes from the update log into the manifest.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Not totally happy with the flag names. For now I am using `consolidate` / `c` to merge the updates into the manifest. Other options might be more intuitive.
- It could be possible to not return the manifest over the coordinators rest api, and instead move the virtual / consolidated manifest feature into another command. This would require users to supply the manifest themselves. The cli in this case only updates the manifest using an update log. This option does not seem the most user friendly in my opinion.

<!-- (uncomment if applicable)
### Screenshots

-->
