### PR TITLE
AB#1097 Always use unique serial numbers

### DIFF
--- a/cli/cmd/csr_legay.go
+++ b/cli/cmd/csr_legay.go
@@ -8,8 +8,9 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"math/big"
 	"time"
+
+	"github.com/edgelesssys/marblerun/util"
 )
 
 // certificateLegacy acts as a handler for generating signed certificates
@@ -22,10 +23,14 @@ type certificateLegacy struct {
 
 // newCertificateLegacy creates a certificate handler for kubernetes versions <=18
 func newCertificateLegacy() (*certificateLegacy, error) {
+	serial, err := util.GenerateCertificateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
 	crt := &certificateLegacy{}
 
 	caCert := &x509.Certificate{
-		SerialNumber: big.NewInt(2021),
+		SerialNumber: serial,
 		Subject: pkix.Name{
 			Organization: []string{"edgeless.systems"},
 		},
@@ -81,8 +86,12 @@ func (crt *certificateLegacy) setCaBundle() ([]string, error) {
 
 // signRequest signs the webhook certificate using the rootCA
 func (crt *certificateLegacy) signRequest() error {
+	serial, err := util.GenerateCertificateSerialNumber()
+	if err != nil {
+		return err
+	}
 	serverCert := &x509.Certificate{
-		SerialNumber: big.NewInt(2022),
+		SerialNumber: serial,
 		Subject: pkix.Name{
 			CommonName:   "system:node:marble-injector.marblerun.svc",
 			Organization: []string{"system:nodes"},

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -513,8 +513,7 @@ func TestWriteSecret(t *testing.T) {
 	pK, _ := c.data.getPrivK(sKCoordinatorIntermediateKey)
 	priv, err = c.generateSecrets(context.TODO(), priv, uuid.New(), pC, pK)
 	assert.NoError(err)
-	assert.Equal("42", priv["cert_private"].Cert.Subject.SerialNumber)
-	assert.Equal("Marblerun Unit Test", priv["cert_private"].Cert.Subject.CommonName)
+	assert.Equal("Marblerun Unit Test Private", priv["cert_private"].Cert.Subject.CommonName)
 }
 
 func testManifestInvalidDebugCase(c *Core, manifest *manifest.Manifest, marblePackage quote.PackageProperties, assert *assert.Assertions, require *require.Assertions) *Core {

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -515,13 +515,11 @@ func (c *Core) generateCertificateForSecret(secret manifest.Secret, parentCertif
 	if template.Subject.CommonName == "" {
 		template.Subject.CommonName = "Marblerun Generated Certificate"
 	}
-	if template.SerialNumber == nil {
-		var err error
-		template.SerialNumber, err = util.GenerateCertificateSerialNumber()
-		if err != nil {
-			c.zaplogger.Error("No serial number supplied; random number generation failed.", zap.Error(err))
-			return manifest.Secret{}, err
-		}
+	var err error
+	template.SerialNumber, err = util.GenerateCertificateSerialNumber()
+	if err != nil {
+		c.zaplogger.Error("No serial number supplied; random number generation failed.", zap.Error(err))
+		return manifest.Secret{}, err
 	}
 
 	template.BasicConstraintsValid = true

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -277,6 +277,12 @@ func TestGenerateSecrets(t *testing.T) {
 	assert.NotNil(generatedSecrets["cert-rsa-specified-test"].Cert.Raw)
 	assert.NotNil(generatedSecrets["cert-ed25519-ca-test"].Cert.Raw)
 
+	// Make sure a certificate gets a new serial number if its regenerated
+	firstSerial := generatedSecrets["cert-rsa-test"].Cert.SerialNumber
+	secondGeneration, err := c.generateSecrets(context.TODO(), generatedSecrets, uuid.Nil, rootCert, rootPrivK)
+	assert.NoError(err)
+	assert.NotEqualValues(*firstSerial, *secondGeneration["cert-rsa-test"].Cert.SerialNumber)
+
 	// Check if CA certificate can generate another certificate
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(err)

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -56,7 +56,7 @@
                 ]
             },
             "TLS": [
-                "web", "anotherWeb"
+                "web", "another_web"
             ],
             "Roles": [
                 "cert-reader"
@@ -86,9 +86,7 @@
             "Size": 2048,
             "Type": "cert-rsa",
             "Cert": {
-                "SerialNumber": 42,
                 "Subject": {
-                    "SerialNumber": "42",
                     "CommonName": "Marblerun Unit Test"
                 }
             },
@@ -98,9 +96,7 @@
             "Shared": true,
             "Type": "cert-ed25519",
             "Cert": {
-                "SerialNumber": 1337,
                 "Subject": {
-                    "SerialNumber": "1337",
                     "CommonName": "Marblerun Unit Test"
                 }
             },
@@ -111,9 +107,7 @@
             "Type": "cert-rsa",
             "Size": 2048,
             "Cert": {
-                "SerialNumber": 4433,
                 "Subject": {
-                    "SerialNumber": "4433",
                     "CommonName": "Marblerun Unit Test"
                 }
             },
@@ -173,7 +167,7 @@
             "Actions": ["ReadSecret"]
         },
         "secrets-admin": {
-            "Resource": "Secrets",
+            "ResourceType": "Secrets",
             "ResourceNames": ["symmetric_key_shared", "cert_shared", "rsa_shared"],
             "Actions": ["ReadSecret", "WriteSecret"]
         }

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -116,10 +116,8 @@ const ManifestJSON string = `{
 			"Size": 2048,
 			"Type": "cert-rsa",
 			"Cert": {
-				"SerialNumber": 42,
 				"Subject": {
-					"SerialNumber": "42",
-					"CommonName": "Marblerun Unit Test"
+					"CommonName": "Marblerun Unit Test Private"
 				}
 			},
 			"ValidFor": 7
@@ -128,10 +126,8 @@ const ManifestJSON string = `{
 			"Shared": true,
 			"Type": "cert-ed25519",
 			"Cert": {
-				"SerialNumber": 1337,
 				"Subject": {
-					"SerialNumber": "1337",
-					"CommonName": "Marblerun Unit Test"
+					"CommonName": "Marblerun Unit Test Shared"
 				}
 			},
 			"ValidFor": 7
@@ -220,10 +216,8 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Size": 2048,
 			"Type": "cert-rsa",
 			"Cert": {
-				"SerialNumber": 42,
 				"Subject": {
-					"SerialNumber": "42",
-					"CommonName": "Marblerun Unit Test"
+					"CommonName": "Marblerun Unit Test Private"
 				}
 			},
 			"ValidFor": 7
@@ -232,10 +226,8 @@ var ManifestJSONWithRecoveryKey string = `{
 			"Shared": true,
 			"Type": "cert-ed25519",
 			"Cert": {
-				"SerialNumber": 1337,
 				"Subject": {
-					"SerialNumber": "1337",
-					"CommonName": "Marblerun Unit Test"
+					"CommonName": "Marblerun Unit Test Shared"
 				}
 			},
 			"ValidFor": 7


### PR DESCRIPTION
### Proposed changes
- Always use unique serial numbers when generating certificates. This solves an issue where an application may encounter problems when it receives two different certificates with the same serial number form the same CA, which would happen after a manifest update.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Screenshots

-->
