### PR TITLE
Fix parallel build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ add_custom_command(
   COMMAND openssl genrsa -out private.pem -3 3072
   COMMAND openssl rsa -in private.pem -pubout -out public.pem)
 
+add_custom_target(
+  signing-key
+  DEPENDS private.pem)
+
 #
 # Build coordinator
 #
@@ -49,7 +53,7 @@ target_link_libraries(coordinator-enclave
 # Sign enclave
 add_custom_command(
   OUTPUT coordinator-enclave.signed
-  DEPENDS coordinator-enclave enclave/coordinator.conf private.pem
+  DEPENDS coordinator-enclave enclave/coordinator.conf signing-key
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:coordinator-enclave> -c
           ${CMAKE_SOURCE_DIR}/enclave/coordinator.conf -k private.pem)
 
@@ -112,7 +116,7 @@ target_link_libraries(marble-test-enclave
 # Sign enclave
 add_custom_command(
   OUTPUT marble-test-enclave.signed
-  DEPENDS marble-test-enclave enclave/marble-test.conf private.pem
+  DEPENDS marble-test-enclave enclave/marble-test.conf signing-key
   COMMAND openenclave::oesign sign -e $<TARGET_FILE:marble-test-enclave> -c
           ${CMAKE_SOURCE_DIR}/enclave/marble-test.conf -k private.pem)
 


### PR DESCRIPTION
### Proposed changes
- Fix dependencies on `private.pem`
- My guess is that OpenSSL creates the file before generating the key, triggering the dependent Makefile targets.

### Related issue
- https://github.com/edgelesssys/marblerun/issues/216