### PR TITLE
Remove sealed_key if no sealed state was found

### DIFF
--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -51,6 +51,10 @@ func (s *AESGCMSealer) Unseal() ([]byte, []byte, error) {
 	sealedData, err := ioutil.ReadFile(s.getFname(SealedDataFname))
 
 	if os.IsNotExist(err) {
+		// No sealed data found, remove sealed key if it exists
+		if err := os.Remove(s.getFname(SealedKeyFname)); err != nil && !os.IsNotExist(err) {
+			return nil, nil, err
+		}
 		return nil, nil, nil
 	} else if err != nil {
 		return nil, nil, err

--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -51,10 +51,8 @@ func (s *AESGCMSealer) Unseal() ([]byte, []byte, error) {
 	sealedData, err := ioutil.ReadFile(s.getFname(SealedDataFname))
 
 	if os.IsNotExist(err) {
-		// No sealed data found, remove sealed key if it exists
-		if err := os.Remove(s.getFname(SealedKeyFname)); err != nil && !os.IsNotExist(err) {
-			return nil, nil, err
-		}
+		// No sealed data found, back up any existing seal keys
+		s.backupEncryptionKey()
 		return nil, nil, nil
 	} else if err != nil {
 		return nil, nil, err
@@ -167,11 +165,7 @@ func (s *AESGCMSealer) generateNewEncryptionKey() error {
 // SetEncryptionKey sets or restores an encryption key
 func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
 	// If there already is an existing key file stored on disk, save it
-	if sealedKeyData, err := ioutil.ReadFile(s.getFname(SealedKeyFname)); err == nil {
-		t := time.Now()
-		newFileName := s.getFname(SealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
-		ioutil.WriteFile(newFileName, sealedKeyData, 0600)
-	}
+	s.backupEncryptionKey()
 
 	// Encrypt encryption key with seal key
 	encryptedKeyData, err := ecrypto.SealWithProductKey(encryptionKey)
@@ -187,6 +181,15 @@ func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
 	s.encryptionKey = encryptionKey
 
 	return nil
+}
+
+// backupEncryptionKey creates a backup of an existing seal key
+func (s *AESGCMSealer) backupEncryptionKey() {
+	if sealedKeyData, err := ioutil.ReadFile(s.getFname(SealedKeyFname)); err == nil {
+		t := time.Now()
+		newFileName := s.getFname(SealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
+		ioutil.WriteFile(newFileName, sealedKeyData, 0600)
+	}
 }
 
 // MockSealer is a mockup sealer


### PR DESCRIPTION
### Proposed changes
- Remove sealed key (if one exists) during `AESGCMSealer.Unseal()` if no sealed state is found

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
