### PR TITLE
AB#1088 Set dcap library on docker container start

### DIFF
--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -7,9 +7,9 @@ FROM ghcr.io/edgelesssys/edgelessrt-dev AS build
 COPY --from=pull /coordinator /coordinator
 WORKDIR /coordinator/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-RUN --mount=type=secret,id=signingkey,dst=/coordinator/build/private.pem,required=true make
+RUN --mount=type=secret,id=signingkey,dst=/coordinator/build/private.pem,required=true make sign-coordinator coordinator-noenclave
 
 FROM ghcr.io/edgelesssys/edgelessrt-deploy AS release
 LABEL description="EdgelessCoordinator"
-COPY --from=build /coordinator/build/coordinator-enclave.signed /coordinator/build/coordinator-noenclave /
-ENTRYPOINT ["erthost", "coordinator-enclave.signed"]
+COPY --from=build /coordinator/build/coordinator-enclave.signed /coordinator/build/coordinator-noenclave /coordinator/dockerfiles/start.sh /
+ENTRYPOINT ["/start.sh"]

--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "${EDG_DCAP_LIBRARY}" == "intel" ]]
+if [[ "${DCAP_LIBRARY}" == "intel" ]]
 then
     # rename the library installed by az-dcap-client
     mv /usr/lib/libdcap_quoteprov.so /usr/lib/libdcap_quoteprov.so.azure

--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ "${EDG_DCAP_LIBRARY}" == "intel" ]]
+then
+    # rename the library installed by az-dcap-client
+    mv /usr/lib/libdcap_quoteprov.so /usr/lib/libdcap_quoteprov.so.azure
+    # create a link to the intel quote provider library
+    mv /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1.intel /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1
+    ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so
+fi
+
+erthost coordinator-enclave.signed


### PR DESCRIPTION
### Proposed changes
- Use a script on container start to set the used quote provider library. The choice is made using the `EDG_DCAP_LIBRARY` env variable

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- PR in EdgelessRT that allows this change: https://github.com/edgelesssys/edgelessrt/pull/71


<!-- (uncomment if applicable)
### Screenshots

-->
