### PR TITLE
Set az-dcap-client log level on start

### DIFF
--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -11,5 +11,5 @@ RUN --mount=type=secret,id=signingkey,dst=/coordinator/build/private.pem,require
 
 FROM ghcr.io/edgelesssys/edgelessrt-deploy AS release
 LABEL description="EdgelessCoordinator"
-COPY --from=build /coordinator/build/coordinator-enclave.signed /coordinator/build/coordinator-noenclave /coordinator/dockerfiles/start.sh /
+COPY --from=build /coordinator/build/coordinator-enclave.signed /coordinator/build/coordinator-noenclave /coordinator/build/coordinator-config.json /coordinator/dockerfiles/start.sh /
 ENTRYPOINT ["/start.sh"]

--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -7,6 +7,8 @@ then
     # create a link to the intel quote provider library
     mv /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1.intel /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1
     ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so
+else
+    export AZDCAP_DEBUG_LOG_LEVEL="${AZDCAP_DEBUG_LOG_LEVEL:=ERROR}"
 fi
 
 erthost coordinator-enclave.signed


### PR DESCRIPTION
### Proposed changes
- Set `AZDCAP_DEBUG_LOG_LEVEL` using the start script, if azure qpl is used, to avoid unnecessary debug output
- Add `coordinator-config.json` to the Coordinator container, allowing users to easily retrieve it with `docker cp`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
