### PR TITLE
create intel qpl symlinks from subfolder

### DIFF
--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -5,8 +5,8 @@ then
     # rename the library installed by az-dcap-client
     mv /usr/lib/libdcap_quoteprov.so /usr/lib/libdcap_quoteprov.so.azure
     # create a link to the intel quote provider library
-    mv /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1.intel /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1
-    ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so
+    ln -s /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.intel /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so
+    ln -s /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.intel /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1
 else
     export AZDCAP_DEBUG_LOG_LEVEL="${AZDCAP_DEBUG_LOG_LEVEL:=ERROR}"
 fi


### PR DESCRIPTION
### Proposed changes
Intel QPL libraries in the ert base image were moved to a subfolder: https://github.com/edgelesssys/edgelessrt/pull/79
This PR fixes the links created by by the Coordinator start script.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
