### PR TITLE
AB#1138 / AB#1139: Add escaped PEM as secret encoding

### DIFF
--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -409,12 +409,12 @@ func TestParseSecrets(t *testing.T) {
 	assert.EqualValues(testCert, parsedCertificate)
 
 	// Check if we can correctly escape PEM input for use in JSON
-	parsedSecret, err = parseSecrets("{{ pemEscaped .Secrets.testcertificate.Cert }}", testWrappedSecrets)
+	parsedSecret, err = parseSecrets(`{ "certificate": "{{ pemEscaped .Secrets.testcertificate.Cert }}" }`, testWrappedSecrets)
 	require.NoError(err)
 	assert.Contains(parsedSecret, "-----BEGIN CERTIFICATE-----\\n")
 	assert.Contains(parsedSecret, "-----END CERTIFICATE-----\\n")
-	pemToMarshal := &testEscapedPemForJson{Certificate: parsedSecret}
-	_, err = json.Marshal(pemToMarshal)
+	var pemUnmarshalled testEscapedPemForJson
+	err = json.Unmarshal([]byte(parsedSecret), &pemUnmarshalled)
 	assert.NoError(err)
 
 	// Check if we can parse a certificate from the outputted raw type

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -325,6 +325,15 @@ func EncodeSecretDataToHex(data interface{}) (string, error) {
 	return hex.EncodeToString([]byte(raw)), nil
 }
 
+// EncodeSecretDataToPemEscaped encodes a secret to a PEM block and escapes the newlines (e.g. for injecting a secret into a JSON string)
+func EncodeSecretDataToPemEscaped(data interface{}) (string, error) {
+	pem, err := EncodeSecretDataToPem(data)
+	if err != nil {
+		return "", err
+	}
+	return strings.Replace(pem, "\n", "\\n", -1), nil
+}
+
 // EncodeSecretDataToRaw encodes a secret to a raw byte string
 func EncodeSecretDataToRaw(data interface{}) (string, error) {
 	var raw []byte
@@ -361,10 +370,11 @@ func EncodeSecretDataToBase64(data interface{}) (string, error) {
 
 // ManifestTemplateFuncMap defines the functions which can be specified for secrets in the in go template format
 var ManifestTemplateFuncMap = template.FuncMap{
-	"pem":    EncodeSecretDataToPem,
-	"hex":    EncodeSecretDataToHex,
-	"raw":    EncodeSecretDataToRaw,
-	"base64": EncodeSecretDataToBase64,
+	"pem":        EncodeSecretDataToPem,
+	"pemEscaped": EncodeSecretDataToPemEscaped,
+	"hex":        EncodeSecretDataToHex,
+	"raw":        EncodeSecretDataToRaw,
+	"base64":     EncodeSecretDataToBase64,
 }
 
 // CheckUpdate checks if the manifest is consistent and only contains supported values.


### PR DESCRIPTION
### Proposed changes
- Add a new type `pemEscaped` for secrets to inject PEM secrets into e.g. JSON configuration so we can replace such a secret definition:
```json
"ca": "-----BEGIN CERTIFICATE-----\n{{ base64 .Marblerun.RootCA.Cert }}\n-----END CERTIFICATE-----\n"
```

With this one:
```json
"ca": "{{ pemEscaped .Marblerun.RootCA.Cert }}"
```

Normal `pem` would fail here, as JSON expects new lines to be escaped and does not have a "raw string" type, unfortunately.

### Additional info
- Personally, I do not quite like the name `pemEscaped`, however I also did not want to call it `pemJSON` as it might also be useful in other types. Let me know if you have better suggestions.



