### PR TITLE
AB#1164 Enhanced files and env declarations

### DIFF
--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -473,7 +473,7 @@ func (c *Core) setTTLSConfig(marble manifest.Marble, specialSecrets reservedSecr
 	if marble.Parameters.Env == nil {
 		marble.Parameters.Env = make(map[string]manifest.File)
 	}
-	marble.Parameters.Env["MARBLE_TTLS_CONFIG"] = manifest.File{Data: string(ttlsConfJSON), Encoding: "UTF-8"}
+	marble.Parameters.Env["MARBLE_TTLS_CONFIG"] = manifest.File{Data: string(ttlsConfJSON), Encoding: "string"}
 
 	return nil
 }

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -217,7 +217,7 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 
 	// Validate generated secret (only specified in backend_first)
 	if marbleType == "backend_first" {
-		ms.assert.Len(params.Env["TEST_SECRET_SYMMETRIC_KEY"], 16)
+		ms.assert.Len(params.Env["TEST_SECRET_SYMMETRIC_KEY"], 32)
 	} else {
 		ms.assert.Empty(params.Env["TEST_SECRET_SYMMETRIC_KEY"])
 	}

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -162,15 +162,11 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	// Validate response
 	params := resp.GetParameters()
 	// Validate Files
-	if marble.Parameters.Files != nil {
-		for k, v := range marble.Parameters.Files {
-			ms.assert.EqualValues(v, resp.Parameters.Files[k])
-		}
+	for k, v := range marble.Parameters.Files {
+		ms.assert.EqualValues(v.Data, resp.Parameters.Files[k])
 	}
 	// Validate Argv
-	if marble.Parameters.Argv != nil {
-		ms.assert.Equal(marble.Parameters.Argv, params.Argv)
-	}
+	ms.assert.Equal(marble.Parameters.Argv, params.Argv)
 
 	// Validate SealKey
 	sealKey, err := hex.DecodeString(string(params.Env["SEAL_KEY"]))

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -114,13 +114,13 @@ func (f *File) UnmarshalJSON(data []byte) error {
 
 	switch t := v.(type) {
 	case string:
-		// File was defined using a single string. Set NoTemplates to false and Encoding to "string"
+		// File was defined using a single string. Set default value for NoTemplates and Encoding to "string", since we don't want to make assumptions about possible data encodings
 		f.Data = t
 		f.Encoding = "string"
 		f.NoTemplates = false
 		return nil
 	case interface{}:
-		// To avoid infinit recursion, try to unmarshal into a struct with the same datatypes as File
+		// To avoid infinite recursion, try to unmarshal into a struct with the same data types as File
 		var vF struct {
 			Data        string
 			Encoding    string

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -60,9 +60,100 @@ type Marble struct {
 
 // Parameters contains lists for files, environment variables and commandline arguments that should be passed to an application
 type Parameters struct {
-	Files map[string]string
-	Env   map[string]string
+	Files map[string]File
+	Env   map[string]File
 	Argv  []string
+}
+
+// File defines data, encoding type, and if data contains templates for a File or Env variable
+type File struct {
+	// Data is the data to be saved as a file or environment variable
+	Data string
+	// Encoding is the initial encoding of Data (as it is written in the manifest). One of {'string', 'UTF-8', 'base64'}
+	Encoding string
+	// NoTemplates specifies if Data contains templates which should be filled with information by the Coordinator
+	NoTemplates bool
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (f File) MarshalJSON() ([]byte, error) {
+	tmp := struct {
+		Data        string
+		Encoding    string
+		NoTemplates bool
+	}{
+		Encoding:    f.Encoding,
+		NoTemplates: f.NoTemplates,
+	}
+
+	switch f.Encoding {
+	case "string", "UTF-8":
+		// just marshal f as is
+		tmp.Data = f.Data
+		return json.Marshal(tmp)
+	case "base64":
+		// encode the Data field back to base64
+		tmp.Data = base64.StdEncoding.EncodeToString([]byte(f.Data))
+		return json.Marshal(tmp)
+	default:
+		return nil, fmt.Errorf("unkown encoding type: %s", f.Encoding)
+	}
+}
+
+// UnmarshalJSON implements the json.Marshaler interface.
+func (f *File) UnmarshalJSON(data []byte) error {
+	// a File or Env in the manifest can be defined two ways:
+	//   1. as a single string: "<name>": "<content>"
+	//   2. as a struct with Data, Encoding, and NoTemplate fields: "<name>": {"Data": "<data>", "Encoding": "<encoding>", "NoTemplates": <true/false>}
+
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch t := v.(type) {
+	case string:
+		// File was defined using a single string. Set NoTemplates to false and Encoding to "UTF-8"
+		f.Data = t
+		f.Encoding = "UTF-8"
+		f.NoTemplates = false
+		return nil
+	case interface{}:
+		// To avoid infinit recursion, try to unmarshal into a struct with the same datatypes as File
+		var vF struct {
+			Data        string
+			Encoding    string
+			NoTemplates bool
+		}
+		if err := json.Unmarshal(data, &vF); err != nil {
+			return err
+		}
+
+		f.Encoding = vF.Encoding
+		if f.Encoding == "" {
+			f.Encoding = "UTF-8"
+		}
+
+		// decode Data if it was encoded
+		switch f.Encoding {
+		case "UTF-8", "string":
+			f.Data = vF.Data
+		case "base64":
+			decoded, err := base64.StdEncoding.DecodeString(vF.Data)
+			if err != nil {
+				return err
+			}
+			f.Data = string(decoded)
+		default:
+			return fmt.Errorf("unkown encoding type: %s", f.Encoding)
+		}
+
+		f.NoTemplates = vF.NoTemplates
+	default:
+		return fmt.Errorf("got: %t, expected: string or interface", t)
+	}
+
+	return nil
 }
 
 // TLStag describes which entries should be used to determine the ttls connections of a marble

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -135,10 +135,10 @@ func (f *File) UnmarshalJSON(data []byte) error {
 		}
 
 		// decode Data if it was encoded
-		switch f.Encoding {
-		case "UTF-8", "string":
+		switch e := f.Encoding; {
+		case strings.ToLower(e) == "utf-8", strings.ToLower(e) == "string":
 			f.Data = vF.Data
-		case "base64":
+		case strings.ToLower(e) == "base64":
 			decoded, err := base64.StdEncoding.DecodeString(vF.Data)
 			if err != nil {
 				return err

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -86,12 +86,12 @@ func (f File) MarshalJSON() ([]byte, error) {
 		NoTemplates: f.NoTemplates,
 	}
 
-	switch f.Encoding {
-	case "string", "UTF-8":
+	switch e := f.Encoding; {
+	case strings.ToLower(e) == "utf-8", strings.ToLower(e) == "string":
 		// just marshal f as is
 		tmp.Data = f.Data
 		return json.Marshal(tmp)
-	case "base64":
+	case strings.ToLower(e) == "base64":
 		// encode the Data field back to base64
 		tmp.Data = base64.StdEncoding.EncodeToString([]byte(f.Data))
 		return json.Marshal(tmp)

--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -24,7 +24,7 @@ func TestFile(t *testing.T) {
 {
 	"string": "helloworld",
 	"string_struct": {
-		"Encoding": "utf-8",
+		"Encoding": "string",
 		"NoTemplates": false,
 		"Data": "foo"
 	},
@@ -34,11 +34,15 @@ func TestFile(t *testing.T) {
 		"Data": "YmFy"
 	},
 	"base64_value": {
-		"Encoding": "utf-8",
+		"Encoding": "string",
 		"Data": "YmFy"
 	},
+	"hex": {
+		"Encoding": "hex",
+		"Data": "4d6172626c6552756e"
+	},
 	"no_templates": {
-		"Encoding": "utf-8",
+		"Encoding": "string",
 		"NoTemplates": true,
 		"Data": "{{ string .Secrets.symmetric_key_shared }}"
 	}
@@ -50,10 +54,11 @@ func TestFile(t *testing.T) {
 	err := json.Unmarshal(dataJSON, &testFiles)
 	require.NoError(err)
 	assert.Equal("helloworld", testFiles["string"].Data)
-	assert.Equal("UTF-8", testFiles["string"].Encoding)
+	assert.Equal("string", testFiles["string"].Encoding)
 	assert.Equal("foo", testFiles["string_struct"].Data)
 	assert.Equal("bar", testFiles["base64"].Data)
 	assert.Equal("YmFy", testFiles["base64_value"].Data)
+	assert.Equal("MarbleRun", testFiles["hex"].Data)
 	assert.Equal("{{ string .Secrets.symmetric_key_shared }}", testFiles["no_templates"].Data)
 
 	_, err = json.Marshal(testFiles)

--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -23,7 +23,7 @@ func TestFile(t *testing.T) {
 	dataJSON := []byte(`
 {
 	"string": "helloworld",
-	"string_struct": {
+	"stringStruct": {
 		"Encoding": "string",
 		"NoTemplates": false,
 		"Data": "foo"
@@ -33,7 +33,7 @@ func TestFile(t *testing.T) {
 		"NoTemplates": true,
 		"Data": "YmFy"
 	},
-	"base64_value": {
+	"base64Value": {
 		"Encoding": "string",
 		"Data": "YmFy"
 	},
@@ -41,7 +41,7 @@ func TestFile(t *testing.T) {
 		"Encoding": "hex",
 		"Data": "4d6172626c6552756e"
 	},
-	"no_templates": {
+	"withoutTemplates": {
 		"Encoding": "string",
 		"NoTemplates": true,
 		"Data": "{{ string .Secrets.symmetric_key_shared }}"
@@ -55,11 +55,11 @@ func TestFile(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("helloworld", testFiles["string"].Data)
 	assert.Equal("string", testFiles["string"].Encoding)
-	assert.Equal("foo", testFiles["string_struct"].Data)
+	assert.Equal("foo", testFiles["stringStruct"].Data)
 	assert.Equal("bar", testFiles["base64"].Data)
-	assert.Equal("YmFy", testFiles["base64_value"].Data)
+	assert.Equal("YmFy", testFiles["base64Value"].Data)
 	assert.Equal("MarbleRun", testFiles["hex"].Data)
-	assert.Equal("{{ string .Secrets.symmetric_key_shared }}", testFiles["no_templates"].Data)
+	assert.Equal("{{ string .Secrets.symmetric_key_shared }}", testFiles["withoutTemplates"].Data)
 
 	_, err = json.Marshal(testFiles)
 	assert.NoError(err)

--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package manifest
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"testing"
+
+	"github.com/edgelesssys/marblerun/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestFile(t *testing.T) {
+	dataJSON := []byte(`
+{
+	"string": "helloworld",
+	"string_struct": {
+		"Encoding": "utf-8",
+		"NoTemplates": false,
+		"Data": "foo"
+	},
+	"base64": {
+		"Encoding": "base64",
+		"NoTemplates": true,
+		"Data": "YmFy"
+	},
+	"base64_value": {
+		"Encoding": "utf-8",
+		"Data": "YmFy"
+	},
+	"no_templates": {
+		"Encoding": "utf-8",
+		"NoTemplates": true,
+		"Data": "{{ string .Secrets.symmetric_key_shared }}"
+	}
+}`)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	testFiles := make(map[string]File)
+	err := json.Unmarshal(dataJSON, &testFiles)
+	require.NoError(err)
+	assert.Equal("helloworld", testFiles["string"].Data)
+	assert.Equal("UTF-8", testFiles["string"].Encoding)
+	assert.Equal("foo", testFiles["string_struct"].Data)
+	assert.Equal("bar", testFiles["base64"].Data)
+	assert.Equal("YmFy", testFiles["base64_value"].Data)
+	assert.Equal("{{ string .Secrets.symmetric_key_shared }}", testFiles["no_templates"].Data)
+
+	_, err = json.Marshal(testFiles)
+	assert.NoError(err)
+}
+
+func TestManifestCheck(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var manifest Manifest
+	err := json.Unmarshal([]byte(test.ManifestJSON), &manifest)
+	require.NoError(err)
+
+	zap, err := zap.NewDevelopment()
+	require.NoError(err)
+	err = manifest.Check(context.TODO(), zap)
+	assert.NoError(err)
+}
+
+func TestCertificate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	block, _ := pem.Decode(test.AdminCert)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(err)
+
+	certJSON, err := json.Marshal(Certificate(*cert))
+	assert.NoError(err)
+
+	var cert2 Certificate
+	err = json.Unmarshal(certJSON, &cert2)
+	assert.NoError(err)
+	assert.Equal(cert.Raw, cert2.Raw)
+}

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -20,13 +20,32 @@
             "MaxActivations": 1,
             "Parameters": {
                 "Files": {
-                    "/tmp/defg.txt": "foo",
-                    "/tmp/jkl.mno": "bar"
+                    "/tmp/abc.txt": "helloworld",
+                    "/tmp/helloworld.sh": "#!/usr/bin/env bash\necho {{ string .Secrets.hello }} {{ string .Secrets.hello }}",
+                    "/tmp/defg.txt": {
+                        "Encoding": "string",
+                        "NoTemplates": false,
+                        "Data": "foo"
+                    },
+                    "/tmp/jkl.mno": {
+                        "Encoding": "base64",
+                        "NoTemplates": true,
+                        "Data": "YmFy"
+                    },
+                    "/tmp/enc.key": {
+                        "Encoding": "string",
+                        "NoTemplates": true,
+                        "Data": "{{ string .Secrets.symmetric_key_shared }}"
+                    }
                 },
                 "Env": {
                     "IS_FIRST": "true",
+                    "IS_SECOND": {
+                        "Encoding": "string",
+                        "Data": "false"
+                    },
                     "SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-                    "TEST_SECRET_SYMMETRIC_KEY": "{{ raw .Secrets.symmetric_key_shared }}",
+                    "API_KEY": "{{ string .Secrets.api_key }}",
                     "TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
                     "TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
                 },
@@ -73,6 +92,18 @@
     },
 
     "Secrets": {
+        "hello": {
+            "Type": "plain",
+            "UserDefined": true
+        },
+        "world": {
+            "Type": "plain",
+            "UserDefined": true
+        },
+        "api_key": {
+            "Type": "plain",
+            "UserDefined": true
+        },
         "symmetric_key_shared": {
             "Type": "symmetric-key",
             "Size": 128,

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -21,7 +21,7 @@
             "Parameters": {
                 "Files": {
                     "/tmp/abc.txt": "helloworld",
-                    "/tmp/helloworld.sh": "#!/usr/bin/env bash\necho {{ string .Secrets.hello }} {{ string .Secrets.hello }}",
+                    "/tmp/helloworld.sh": "#!/usr/bin/env bash\necho {{ raw .Secrets.hello }} {{ raw .Secrets.hello }}",
                     "/tmp/defg.txt": {
                         "Encoding": "string",
                         "NoTemplates": false,
@@ -35,7 +35,7 @@
                     "/tmp/enc.key": {
                         "Encoding": "string",
                         "NoTemplates": true,
-                        "Data": "{{ string .Secrets.symmetric_key_shared }}"
+                        "Data": "{{ raw .Secrets.symmetric_key_shared }}"
                     }
                 },
                 "Env": {
@@ -45,7 +45,7 @@
                         "Data": "false"
                     },
                     "SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-                    "API_KEY": "{{ string .Secrets.apiKey }}",
+                    "API_KEY": "{{ raw .Secrets.apiKey }}",
                     "TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
                     "TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
                 },

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -45,7 +45,7 @@
                         "Data": "false"
                     },
                     "SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-                    "API_KEY": "{{ string .Secrets.api_key }}",
+                    "API_KEY": "{{ string .Secrets.apiKey }}",
                     "TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
                     "TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
                 },
@@ -100,7 +100,7 @@
             "Type": "plain",
             "UserDefined": true
         },
-        "api_key": {
+        "apiKey": {
             "Type": "plain",
             "UserDefined": true
         },

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -67,7 +67,7 @@ const ManifestJSON string = `{
 					"IS_FIRST": "true",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
 					"TEST_SECRET_SYMMETRIC_KEY": {
-						"Data": "{{ raw .Secrets.symmetric_key_shared }}",
+						"Data": "{{ hex .Secrets.symmetric_key_shared }}",
 						"Encoding": "string"
 					},
 					"TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -56,12 +56,20 @@ const ManifestJSON string = `{
 			"Parameters": {
 				"Files": {
 					"/tmp/defg.txt": "foo",
-					"/tmp/jkl.mno": "bar"
+					"/tmp/jkl.mno": "bar",
+					"/tmp/base64.txt": {
+						"Data": "TWFyYmxlUnVuIGJhc2U2NA==",
+						"Encoding": "base64",
+						"NoTemplates": true
+					}
 				},
 				"Env": {
 					"IS_FIRST": "true",
 					"SEAL_KEY": "{{ hex .Marblerun.SealKey }}",
-					"TEST_SECRET_SYMMETRIC_KEY": "{{ raw .Secrets.symmetric_key_shared }}",
+					"TEST_SECRET_SYMMETRIC_KEY": {
+						"Data": "{{ raw .Secrets.symmetric_key_shared }}",
+						"Encoding": "string"
+					},
 					"TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
 					"TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
 				},


### PR DESCRIPTION
### Proposed changes
Allow users to specify the encoding type of files and env in the manifest. See https://github.com/edgelesssys/marblerun/pull/231 for reference
Users may still define files or environment variables as a single string.

If not defined as a string these options are available:
  * `Data`: The content of the file
  * `Encoding`: The encoding of `Data` as it is written in the manifest. Currently supported are `base64`, `hex` and `string`.
    * `base64` marked content is decoded from base64 before it is passed to a Marble to be saved as a file/env var
    * `hex` is the same as `base64`, but content is decoded from hex
    * `string` causes no change to the input data
    * Spelling of `Encoding` is case insensitive. `string`, `String` and `sTrInG` are all valid spellings
  * `NoTemplates`: If this flag is set content in `Data` is not processed by the template engine and passed to a Marble as is. This means no secrets or other values are injected into the file at runtime.
 

In a manifest the file declaration can look similar to the following:
```Javascript
"Files": {
  "/file/from_string.txt": "Foo",
  "/file/from_struct.txt": {
    "Encoding": "string",
    "Data": "SGVsbG8gV29ybGQ=",
    "NoTemplates": true
  },
  "/file/from_base64.txt": {
    "Encoding": "base64",
    "Data": "SGVsbG8gV29ybGQ=",
    "NoTemplates": true
  }
}
```
Here `/file/from_struct.txt` and `/file/from_base64.txt` both have the same value set for `Data`, but because they declared different encoding types `/file/from_struct.txt` will contain `SGVsbG8gV29ybGQ=` when it is passed to a Marble, while  the content of `/file/from_base64.txt` will first get decoded, resulting in a file containing `Hello World`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->