### PR TITLE
AB#1176 Template sanity check

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -7,6 +7,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
@@ -14,6 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"text/template"
 
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
@@ -46,11 +48,11 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 		return nil, err
 	}
 
-	var manifest manifest.Manifest
-	if err := json.Unmarshal(rawManifest, &manifest); err != nil {
+	var mnf manifest.Manifest
+	if err := json.Unmarshal(rawManifest, &mnf); err != nil {
 		return nil, err
 	}
-	if err := manifest.Check(ctx, c.zaplogger); err != nil {
+	if err := mnf.Check(ctx, c.zaplogger); err != nil {
 		return nil, err
 	}
 
@@ -64,25 +66,25 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	}
 
 	// Generate shared secrets specified in manifest
-	secrets, err := c.generateSecrets(ctx, manifest.Secrets, uuid.Nil, marbleRootCert, intermediatePrivK)
+	secrets, err := c.generateSecrets(ctx, mnf.Secrets, uuid.Nil, marbleRootCert, intermediatePrivK)
 	if err != nil {
 		c.zaplogger.Error("Could not generate specified secrets for the given manifest.", zap.Error(err))
 		return nil, err
 	}
 	// generate placeholders for private secrets specified in manifest
-	privSecrets, err := c.generateSecrets(ctx, manifest.Secrets, uuid.New(), marbleRootCert, intermediatePrivK)
+	privSecrets, err := c.generateSecrets(ctx, mnf.Secrets, uuid.New(), marbleRootCert, intermediatePrivK)
 	if err != nil {
 		c.zaplogger.Error("Could not generate specified secrets for the given manifest.", zap.Error(err))
 		return nil, err
 	}
 
 	// Set encryption key & generate recovery data
-	encryptionKey, err := c.recovery.GenerateEncryptionKey(manifest.RecoveryKeys)
+	encryptionKey, err := c.recovery.GenerateEncryptionKey(mnf.RecoveryKeys)
 	if err != nil {
 		c.zaplogger.Error("could not set up encryption key for sealing the state", zap.Error(err))
 		return nil, err
 	}
-	recoverySecretMap, recoveryData, err := c.recovery.GenerateRecoveryData(manifest.RecoveryKeys)
+	recoverySecretMap, recoveryData, err := c.recovery.GenerateRecoveryData(mnf.RecoveryKeys)
 	if err != nil {
 		c.zaplogger.Error("could not generate recovery data", zap.Error(err))
 		return nil, err
@@ -90,7 +92,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	c.sealer.SetEncryptionKey(encryptionKey)
 
 	// Parse X.509 user certificates and permissions from manifest
-	users, err := generateUsersFromManifest(manifest.Users, manifest.Roles)
+	users, err := generateUsersFromManifest(mnf.Users, mnf.Roles)
 	if err != nil {
 		c.zaplogger.Error("Could not parse specified user certificate from supplied manifest", zap.Error(err))
 		return nil, err
@@ -103,43 +105,81 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	defer tx.Rollback()
 	txdata := storeWrapper{tx}
 
-	if err := txdata.putRawManifest(rawManifest); err != nil {
-		return nil, err
-	}
-	for k, v := range manifest.Packages {
-		if err := txdata.putPackage(k, v); err != nil {
-			return nil, err
-		}
-	}
-	for k, v := range manifest.Infrastructures {
-		if err := txdata.putInfrastructure(k, v); err != nil {
-			return nil, err
-		}
-	}
-	for k, v := range manifest.Marbles {
-		if err := txdata.putMarble(k, v); err != nil {
-			return nil, err
-		}
+	for k, v := range privSecrets {
+		secrets[k] = v
 	}
 	for k, v := range secrets {
 		if err := txdata.putSecret(k, v); err != nil {
 			return nil, err
 		}
 	}
-	for k, v := range privSecrets {
-		if err := txdata.putSecret(k, v); err != nil {
-			return nil, err
-		}
-	}
-	// save metadata of user-defined secrets
-	for k, v := range manifest.Secrets {
+	for k, v := range mnf.Secrets {
 		if v.UserDefined {
 			if err := txdata.putSecret(k, v); err != nil {
 				return nil, err
 			}
+
+			// dummy values only used for template validation
+			v.Cert.Raw = []byte{0x41}
+			v.Private = []byte{0x41}
+			v.Public = []byte{0x41}
+			secrets[k] = v
 		}
 	}
-	for k, v := range manifest.TLS {
+
+	templateSecrets := secretsWrapper{
+		Secrets: secrets,
+		Marblerun: reservedSecrets{
+			RootCA: manifest.Secret{
+				Cert: manifest.Certificate{Raw: []byte{0x41}},
+			},
+			MarbleCert: manifest.Secret{
+				Cert:    manifest.Certificate{Raw: []byte{0x41}},
+				Public:  []byte{0x41},
+				Private: []byte{0x41},
+			},
+			SealKey: manifest.Secret{
+				Private: []byte{0x41},
+				Public:  []byte{0x41},
+			},
+		},
+	}
+	for mN, m := range mnf.Marbles {
+		for fN, file := range m.Parameters.Files {
+			if !file.NoTemplates {
+				if err := checkFileTemplates(file.Data, manifest.ManifestFileTemplateFuncMap, templateSecrets); err != nil {
+					return nil, fmt.Errorf("Marble %s: file %s: %v", mN, fN, err)
+				}
+			}
+		}
+		for eN, env := range m.Parameters.Env {
+			if !env.NoTemplates {
+				if err := checkFileTemplates(env.Data, manifest.ManifestEnvTemplateFuncMap, templateSecrets); err != nil {
+					return nil, fmt.Errorf("Marble %s: env variable %s: %v", mN, eN, err)
+				}
+			}
+		}
+	}
+
+	if err := txdata.putRawManifest(rawManifest); err != nil {
+		return nil, err
+	}
+	for k, v := range mnf.Packages {
+		if err := txdata.putPackage(k, v); err != nil {
+			return nil, err
+		}
+	}
+	for k, v := range mnf.Infrastructures {
+		if err := txdata.putInfrastructure(k, v); err != nil {
+			return nil, err
+		}
+	}
+	for k, v := range mnf.Marbles {
+		if err := txdata.putMarble(k, v); err != nil {
+			return nil, err
+		}
+	}
+	for k, v := range mnf.TLS {
 		if err := txdata.putTLS(k, v); err != nil {
 			return nil, err
 		}
@@ -510,4 +550,12 @@ func (c *Core) performRecovery(encryptionKey []byte) error {
 	c.quote = c.generateQuote(rootCert.Raw)
 
 	return nil
+}
+
+func checkFileTemplates(data string, tplFunc template.FuncMap, secrets secretsWrapper) error {
+	tpl, err := template.New("data").Funcs(tplFunc).Parse(data)
+	if err != nil {
+		return err
+	}
+	return tpl.Execute(&bytes.Buffer{}, secrets)
 }

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -130,7 +130,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 
 	templateSecrets := secretsWrapper{
 		Secrets: secrets,
-		Marblerun: reservedSecrets{
+		MarbleRun: reservedSecrets{
 			RootCA: manifest.Secret{
 				Cert: manifest.Certificate{Raw: []byte{0x41}},
 			},
@@ -155,7 +155,7 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 			}
 		}
 		for eN, env := range m.Parameters.Env {
-			// make sure environment variables dont contain NULL bytes, we perform another check at runtime to catch NULL bytes in user-defined secrets
+			// make sure environment variables dont contain NULL bytes, we perform another check at runtime to catch NULL bytes in secrets
 			if strings.Contains(env.Data, string([]byte{0x00})) {
 				return nil, fmt.Errorf("Marble %s: env variable: %s: content contains null bytes", mN, eN)
 			}

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -255,6 +255,28 @@ func TestManifestTemplateChecks(t *testing.T) {
 		}
 	}
 }`)
+	nullByte := []byte(`{
+	"Packages": {
+		"backend": {
+			"UniqueID": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+			"Debug": false
+		}
+	},
+	"Marbles": {
+		"backend_first": {
+			"Package": "backend",
+			"MaxActivations": 1,
+			"Parameters": {
+				"Env": {
+					"NULL_VAR": {
+						"Encoding": "base64",
+						"Data": "AE1hcmJsZQBSdW4A"
+					}
+				}
+			}
+		}
+	}
+}`)
 	assert := assert.New(t)
 
 	c := NewCoreWithMocks()
@@ -271,6 +293,10 @@ func TestManifestTemplateChecks(t *testing.T) {
 
 	c = NewCoreWithMocks()
 	_, err = c.SetManifest(context.TODO(), rawInEnv)
+	assert.Error(err)
+
+	c = NewCoreWithMocks()
+	_, err = c.SetManifest(context.TODO(), nullByte)
 	assert.Error(err)
 }
 

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -620,6 +620,15 @@ func TestWriteSecret(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("MarbleRun Unit Test", string(secret.Public))
 
+	// try to set a secret with NULL bytes
+	genericSecret = []byte(`{
+		"genericSecret": {
+			"Key": "` + base64.StdEncoding.EncodeToString([]byte{0x41, 0x41, 0x00, 0x41}) + `"
+		}
+	}`)
+	err = c.WriteSecrets(context.TODO(), genericSecret, admin)
+	assert.Error(err)
+
 	// try to set a secret incorrect size
 	invalidSecret := []byte(`{
 		"symmetricKeyUnset": {

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -17,7 +17,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math"
-	"strings"
 	"text/template"
 	"time"
 
@@ -298,9 +297,6 @@ func customizeParameters(params manifest.Parameters, specialSecrets reservedSecr
 	}
 
 	for name, data := range params.Env {
-		if strings.Contains(data.Data, string([]byte{0x00})) {
-			return nil, fmt.Errorf("environment variable: %s: content contains null bytes", name)
-		}
 		if data.NoTemplates {
 			newValue = data.Data
 		} else {

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -298,12 +298,12 @@ func customizeParameters(params manifest.Parameters, specialSecrets reservedSecr
 	}
 
 	for name, data := range params.Env {
+		if strings.Contains(data.Data, string([]byte{0x00})) {
+			return nil, fmt.Errorf("environment variable: %s: content contains null bytes", name)
+		}
 		if data.NoTemplates {
 			newValue = data.Data
 		} else {
-			if strings.Contains(data.Data, string([]byte{0x00})) {
-				return nil, fmt.Errorf("environment variable: %s: content contains null bytes", name)
-			}
 			newValue, err = parseSecrets(data.Data, manifest.ManifestEnvTemplateFuncMap, secretsWrapped)
 			if err != nil {
 				return nil, err

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -288,7 +288,7 @@ func customizeParameters(params manifest.Parameters, specialSecrets reservedSecr
 		if data.NoTemplates {
 			newValue = data.Data
 		} else {
-			newValue, err = parseSecrets(data.Data, secretsWrapped)
+			newValue, err = parseSecrets(data.Data, manifest.ManifestFileTemplateFuncMap, secretsWrapped)
 			if err != nil {
 				return nil, err
 			}
@@ -304,7 +304,7 @@ func customizeParameters(params manifest.Parameters, specialSecrets reservedSecr
 			if strings.Contains(data.Data, string([]byte{0x00})) {
 				return nil, fmt.Errorf("environment variable: %s: content contains null bytes", name)
 			}
-			newValue, err = parseSecrets(data.Data, secretsWrapped)
+			newValue, err = parseSecrets(data.Data, manifest.ManifestEnvTemplateFuncMap, secretsWrapped)
 			if err != nil {
 				return nil, err
 			}
@@ -334,10 +334,10 @@ func customizeParameters(params manifest.Parameters, specialSecrets reservedSecr
 	return &customParams, nil
 }
 
-func parseSecrets(data string, secretsWrapped secretsWrapper) (string, error) {
+func parseSecrets(data string, tplFunc template.FuncMap, secretsWrapped secretsWrapper) (string, error) {
 	var templateResult bytes.Buffer
 
-	tpl, err := template.New("data").Funcs(manifest.ManifestTemplateFuncMap).Parse(data)
+	tpl, err := template.New("data").Funcs(tplFunc).Parse(data)
 	if err != nil {
 		return "", err
 	}

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -439,15 +439,21 @@ func TestParseSecrets(t *testing.T) {
 	assert.Error(err)
 
 	testWrappedSecrets.Secrets = map[string]manifest.Secret{
-		"plainSecret": {Type: "plain", Public: []byte{0, 1, 2}},
-		"otherSecret": {Type: "symmetric-key", Public: []byte{0, 1, 2}},
+		"plainSecret": {Type: "plain", Public: []byte{1, 2, 3}},
+		"nullSecret":  {Type: "plain", Public: []byte{0, 1, 2}},
+		"otherSecret": {Type: "symmetric-key", Public: []byte{4, 5, 6}},
 	}
 
-	// plain secrets are allowed using raw formating
-	_, err = parseSecrets("{{ raw .Secrets.plainSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
+	// plain secrets are allowed to use string formating
+	_, err = parseSecrets("{{ string .Secrets.plainSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
 	assert.NoError(err)
 
-	_, err = parseSecrets("{{ raw .Secrets.otherSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
+	// NULL bytes in secret results in an error
+	_, err = parseSecrets("{{ string .Secrets.nullSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
+	assert.Error(err)
+
+	// non plain secrets always result in an error
+	_, err = parseSecrets("{{ string .Secrets.otherSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
 	assert.Error(err)
 }
 

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -203,6 +203,14 @@ var ManifestJSONWithRecoveryKey string = `{
 					"SEAL_KEY": "{{ hex .MarbleRun.SealKey }}"
 				}
 			}
+		},
+		"envMarble": {
+			"Package": "frontend",
+			"Parameters": {
+				"Env": {
+					"ENV_SECRET": "{{ string .Secrets.genericSecret }}"
+				}
+			}
 		}
 	},
 	"Secrets": {


### PR DESCRIPTION
### Proposed changes
- Perform a check on the templates of all file and env declarations during `cc.SetManifest`  to make sure:
  1. All Secrets that are to be injected actually exist
  2. Only valid encodings are used (For example: no symmetric key is assigned PEM encoding)
  3. No raw encoding for secrets injected as environment variables, except for secrets of type `plain`
      *  If a `plain` secret contains NULL bytes, the deployment of the Marble fails. Since `plain` secrets are user-defined, this can be fixed at run time.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
I have also made some errors produce by invalid templates more clear. Instead of receiving `"invalid secret type"` when a template references a non existent secret, we now get `"secret does not exist"`.
Combined with the extra information of what Marble and what file/env contains the invalid declaration, this should help users to find their mistake more easily.

<!-- (uncomment if applicable)
### Screenshots

-->
