### PR TITLE
use short "permalinks" in code

### DIFF
--- a/cli/cmd/graphenePrepare.go
+++ b/cli/cmd/graphenePrepare.go
@@ -33,7 +33,7 @@ const longDescription = `Modifies a Graphene manifest for use with Marblerun.
 This command tries to automatically adjust the required parameters in an already existing Graphene manifest template, simplifying the migration of your existing Graphene application to Marblerun.
 Please note that you still need to manually create a Marblerun manifest.
 
-For more information about the requirements and  changes performed, consult the documentation: https://docs.edgeless.systems/marblerun/#/building-services/graphene
+For more information about the requirements and  changes performed, consult the documentation: https://edglss.cc/doc-mr-graphene
 
 The parameter of this command is the path of the Graphene manifest template you want to modify.
 `

--- a/cli/cmd/precheck.go
+++ b/cli/cmd/precheck.go
@@ -49,7 +49,7 @@ func cliCheckSGXSupport(kubeClient kubernetes.Interface) error {
 		fmt.Println("Cluster does not support SGX, you may still run Marblerun in simulation mode")
 		fmt.Println("To install Marblerun run [marblerun install --simulation]")
 		fmt.Println("If your nodes have SGX support you might be missing an SGX device plugin")
-		fmt.Println("Check https://docs.edgeless.systems/marblerun/#/deployment/kubernetes?id=prerequisites for more information")
+		fmt.Println("Check https://edglss.cc/doc-mr-k8s-prereq for more information")
 	} else {
 		nodeString := "node"
 		if supportedNodes > 1 {


### PR DESCRIPTION
As doc URLs break if the docs are reorganized, we should use short URLs in code.