### PR TITLE
Fix spelling

### DIFF
--- a/test/manifests.go
+++ b/test/manifests.go
@@ -325,7 +325,7 @@ var IntegrationManifestJSON string = `{
 				"Files": {
 					"/tmp/coordinator_test/defg.txt": "foo",
 					"/tmp/coordinator_test/jkl.mno": "bar",
-					"/tmp/coordinator_test/secret.raw": "{{ raw .Secrets.symmetricKeyShared }}{{ raw .Marblerun.MarbleCert.Private }}"
+					"/tmp/coordinator_test/secret.raw": "{{ raw .Secrets.symmetricKeyShared }}{{ raw .MarbleRun.MarbleCert.Private }}"
 				},
 				"Argv": [
 					"./marble",


### PR DESCRIPTION
### Proposed changes
- Fix the spelling of MarbleRun in `test/manfiests.go`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
