### PR TITLE
AB#1253 Fix injected DNS names

### DIFF
--- a/injector/injector.go
+++ b/injector/injector.go
@@ -119,7 +119,7 @@ func mutate(body []byte, coordAddr string, domainName string, resourceKey string
 	}
 
 	// get namespace of pod
-	namespace := pod.Namespace
+	namespace := admReviewReq.Request.Namespace
 	if len(namespace) == 0 {
 		namespace = "default"
 	}

--- a/injector/injector_test.go
+++ b/injector/injector_test.go
@@ -25,7 +25,6 @@ func TestMutatesValidRequest(t *testing.T) {
 				"apiVersion": "v1",
 				"metadata": {
 					"name": "testpod",
-					"namespace": "injectable",
 					"creationTimestamp": null,
 					"labels": {
 						"name": "testpod",


### PR DESCRIPTION
### Proposed changes
The injected env variable `EDG_MARBLE_DNS_NAMES` was generated incorrectly, if the targeted Pod came from a deployment or similar.

Instead of setting `namespace` to the namespace of the Pod in `EDG_MARBLE_DNS_NAMES=service, service.namespace, service.namespace.svc.cluster.local`, the webhook always set `namespace` to `default`.

This is fixed by fetching the value for `namespace` from the Admission Request itself instead of relying on the value being present in the Pod spec.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
