### PR TITLE
AB#1173 Get trusted time

### DIFF
--- a/cmd/coordinator/enclavemain.go
+++ b/cmd/coordinator/enclavemain.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/quote/ertvalidator"
 	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
+	"github.com/edgelesssys/marblerun/coordinator/ttime"
 	"github.com/edgelesssys/marblerun/util"
 )
 

--- a/cmd/coordinator/enclavemain.go
+++ b/cmd/coordinator/enclavemain.go
@@ -24,7 +24,7 @@ func main() {
 	sealDirPrefix := filepath.Join(filepath.FromSlash("/edg"), "hostfs")
 	sealDir := util.Getenv(config.SealDir, config.SealDirDefault())
 	sealDir = filepath.Join(sealDirPrefix, sealDir)
-	sealer := seal.NewAESGCMSealer(sealDir)
+	sealer := seal.NewAESGCMSealer(sealDir, ttime.UntrustedTime{})
 	recovery := recovery.NewSinglePartyRecovery()
 	run(validator, issuer, sealDir, sealer, recovery)
 }

--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -68,6 +68,9 @@ func (c *Core) SetManifest(ctx context.Context, rawManifest []byte) (map[string]
 	}
 
 	c.time = ttime.NewTime(mnf.TimeServers, c.zaplogger)
+	if _, ok := c.time.(ttime.TrustedTime); !ok {
+		c.zaplogger.Warn("No trusted time source specified. Proceeding with untrusted host time.")
+	}
 
 	// Generate shared secrets specified in manifest
 	secrets, err := c.generateSecrets(ctx, mnf.Secrets, uuid.Nil, marbleRootCert, intermediatePrivK)

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 	"text/template"
-	"time"
 
 	"github.com/edgelesssys/ego/marble"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
@@ -239,7 +238,7 @@ func (c *Core) generateCertFromCSR(csrReq []byte, pubk ecdsa.PublicKey, marbleTy
 	// create certificate
 	csr.Subject.CommonName = marbleUUID
 	csr.Subject.Organization = marbleRootCert.Issuer.Organization
-	notBefore := time.Now()
+	notBefore := c.time.Now()
 	// TODO: produce shorter lived certificates
 	notAfter := notBefore.Add(math.MaxInt64)
 	template := x509.Certificate{

--- a/coordinator/core/storewrapper.go
+++ b/coordinator/core/storewrapper.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cloudflare/roughtime/config"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
 	"github.com/edgelesssys/marblerun/coordinator/quote"
 	"github.com/edgelesssys/marblerun/coordinator/store"
@@ -32,6 +33,7 @@ const (
 	requestTLS            = "TLS"
 	requestUser           = "user"
 	requestUpdateLog      = "updateLog"
+	requestTimeServers    = "timeServers"
 )
 
 // storeWrapper is a wrapper for the store interface
@@ -289,6 +291,18 @@ func (s storeWrapper) getUser(userName string) (*user.User, error) {
 // putUser saves user information to store
 func (s storeWrapper) putUser(newUser *user.User) error {
 	return s._put(requestUser, newUser.Name(), newUser)
+}
+
+// getTimeServers returns time server information from store
+func (s storeWrapper) getTimeServers() ([]config.Server, error) {
+	var servers []config.Server
+	err := s._get(requestTimeServers, "", servers)
+	return servers, err
+}
+
+// putTimeServers saves time server information to store
+func (s storeWrapper) putTimeServers(servers []config.Server) error {
+	return s._put(requestTimeServers, "", servers)
 }
 
 // _put is the default method for marshaling and saving data to store

--- a/coordinator/core/storewrapper_test.go
+++ b/coordinator/core/storewrapper_test.go
@@ -37,9 +37,9 @@ func TestStoreWrapper(t *testing.T) {
 		Size:   16,
 		Shared: true,
 	}
-	someCert, somePrivK, err := generateCert([]string{"example.com"}, coordinatorName, nil, nil, nil)
+	someCert, somePrivK, err := generateCert([]string{"example.com"}, coordinatorName, nil, nil, nil, c.time)
 	require.NoError(err)
-	testUserCert, _, err := generateCert([]string{"example.com"}, "test-user", nil, nil, nil)
+	testUserCert, _, err := generateCert([]string{"example.com"}, "test-user", nil, nil, nil, c.time)
 	require.NoError(err)
 	testUser := user.NewUser("test-user", testUserCert)
 

--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -186,7 +186,7 @@ func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
 // backupEncryptionKey creates a backup of an existing seal key
 func (s *AESGCMSealer) backupEncryptionKey() {
 	if sealedKeyData, err := ioutil.ReadFile(s.getFname(SealedKeyFname)); err == nil {
-		t := time.Now()
+		t := time.Now() // TODO(katexochen): trusted time?
 		newFileName := s.getFname(SealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
 		ioutil.WriteFile(newFileName, sealedKeyData, 0600)
 	}

--- a/coordinator/ttime/ttime.go
+++ b/coordinator/ttime/ttime.go
@@ -19,6 +19,12 @@ type Time interface {
 	Now() time.Time
 }
 
+// TimeUser is a type that uses a Time. A time user offers
+// the possibility to set the time.
+type TimeUser interface {
+	SetTime(Time)
+}
+
 // NewTime returns a trusted or untrusted time, based on
 // the servers you handed over.
 func NewTime(servers []config.Server, logger *zap.Logger) Time {
@@ -51,7 +57,7 @@ func (t TrustedTime) Now() time.Time {
 	rt, err := t.Roughtime()
 	if err != nil {
 		if t.zaplogger != nil {
-			t.zaplogger.Error("error getting Roughtime", zap.Error(err))
+			t.zaplogger.Error("could not get a trusted time", zap.Error(err))
 		}
 		return time.Time{}
 	}

--- a/coordinator/ttime/ttime.go
+++ b/coordinator/ttime/ttime.go
@@ -1,0 +1,69 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package ttime
+
+import (
+	"time"
+
+	"github.com/cloudflare/roughtime"
+	"github.com/cloudflare/roughtime/config"
+	"go.uber.org/zap"
+)
+
+// Time is an intrface that gives you the current time.
+type Time interface {
+	Now() time.Time
+}
+
+// NewTime returns a trusted or untrusted time, based on
+// the servers you handed over.
+func NewTime(servers []config.Server, logger *zap.Logger) Time {
+	if len(servers) == 0 {
+		return &UntrustedTime{}
+	}
+	return TrustedTime{servers: servers, zaplogger: logger}
+}
+
+// TrustedTime is a trusted time client.
+// It uses the Roughtime protocol to obtain trusted timestamps from specified servers.
+type TrustedTime struct {
+	servers   []config.Server
+	zaplogger *zap.Logger
+}
+
+// Roughtime parses a configuration file, requests a Roughtime from
+// the first server that was parsed correctly, and returns this time.
+func (t TrustedTime) Roughtime() (*roughtime.Roughtime, error) {
+	rt, err := roughtime.Get(&t.servers[0], roughtime.DefaultQueryAttempts, roughtime.DefaultQueryTimeout, nil)
+	if err != nil {
+		return nil, err
+	}
+	return rt, nil
+}
+
+// Now returns a time.Time that was delivered by a Roughtime server.
+// The radius of the Roughtime is ignored.
+func (t TrustedTime) Now() time.Time {
+	rt, err := t.Roughtime()
+	if err != nil {
+		if t.zaplogger != nil {
+			t.zaplogger.Error("error getting Roughtime", zap.Error(err))
+		}
+		return time.Time{}
+	}
+	now, _ := rt.Now()
+	return now
+}
+
+// UntrustedTime is just a wrapper around the default time package.
+// The time package can't be trusted since it uses the host's time.
+type UntrustedTime struct{}
+
+// Now is a wrapper around time.Now().
+func (u UntrustedTime) Now() time.Time {
+	return time.Now()
+}

--- a/coordinator/ttime/ttime_test.go
+++ b/coordinator/ttime/ttime_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package ttime
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/roughtime/config"
+	"github.com/cloudflare/roughtime/mjd"
+	"github.com/cloudflare/roughtime/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoughtime(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// Create mock server.
+	server, configs, err := NewRoughtimeMockServer("127.0.0.1:2002")
+	require.NoError(err)
+
+	// Start server.
+	server.Start()
+	defer server.Close()
+
+	// Create trusted time client.
+	tt := TrustedTime{servers: configs}
+
+	// Obtain time.
+	rt, err := tt.Roughtime()
+	require.NoError(err)
+
+	// Compare times. Obviously, this is a bidirectional test that heavily
+	// depends on the correctness of testing hardware's local time.
+	// TODO(katexochen): Maybe remove this later.
+	t1 := time.Now()
+	t0, radius := rt.Now()
+	diff := t1.Sub(t0)
+	assert.LessOrEqual(diff, radius)
+}
+
+func TestNewTime(t *testing.T) {
+	require := require.New(t)
+
+	// Get a configuration.
+	_, configs, err := NewRoughtimeMockServer("127.0.0.1:2002")
+	require.NoError(err)
+
+	// Check if NewTime returns a TrustedTime.
+	time := NewTime(configs, nil)
+	require.IsType(TrustedTime{}, time)
+}
+
+type MockRoughtimeServer struct {
+	cert    []byte
+	priv    ed25519.PrivateKey
+	pub     ed25519.PublicKey
+	netAddr *net.UDPAddr
+	server  *net.UDPConn
+}
+
+func NewRoughtimeMockServer(addr string) (*MockRoughtimeServer, []config.Server, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, []config.Server{}, err
+	}
+	netAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, []config.Server{}, err
+	}
+	now := mjd.Now()
+	yesterday := mjd.New(now.Day()-1, now.Microseconds())
+	tomorrow := mjd.New(now.Day()+1, now.Microseconds())
+	cert, err := protocol.CreateCertificate(yesterday, tomorrow, pub, priv)
+	if err != nil {
+		return nil, []config.Server{}, err
+	}
+	var configs []config.Server
+	conf := config.Server{
+		Name:          "RoughtimeMockServer",
+		PublicKeyType: "ed25519",
+		PublicKey:     pub,
+		Addresses: []config.ServerAddress{
+			{
+				Protocol: "udp",
+				Address:  addr,
+			},
+		},
+	}
+	configs = append(configs, conf)
+	return &MockRoughtimeServer{
+		cert:    cert,
+		priv:    priv,
+		pub:     pub,
+		netAddr: netAddr,
+	}, configs, nil
+}
+
+func (s *MockRoughtimeServer) Start() {
+	var err error
+	s.server, err = net.ListenUDP("udp", s.netAddr)
+	if err != nil {
+		return
+	}
+	go func() {
+		query := make([]byte, 1280)
+		for {
+			queryLen, peer, err := s.server.ReadFrom(query)
+			if err != nil {
+				return
+			}
+			resp, err := protocol.CreateReply(query[:queryLen], mjd.Now(), 1000000, s.cert, s.priv)
+			if err != nil {
+				return
+			}
+			s.server.WriteTo(resp, peer)
+		}
+	}()
+}
+
+func (s *MockRoughtimeServer) Close() {
+	s.server.Close()
+}

--- a/coordinator/ttime/ttime_test.go
+++ b/coordinator/ttime/ttime_test.go
@@ -11,18 +11,15 @@ import (
 	"crypto/rand"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/cloudflare/roughtime/config"
 	"github.com/cloudflare/roughtime/mjd"
 	"github.com/cloudflare/roughtime/protocol"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRoughtime(t *testing.T) {
 	require := require.New(t)
-	assert := assert.New(t)
 
 	// Create mock server.
 	server, configs, err := NewRoughtimeMockServer("127.0.0.1:2002")
@@ -36,16 +33,8 @@ func TestRoughtime(t *testing.T) {
 	tt := TrustedTime{servers: configs}
 
 	// Obtain time.
-	rt, err := tt.Roughtime()
+	_, err = tt.Roughtime()
 	require.NoError(err)
-
-	// Compare times. Obviously, this is a bidirectional test that heavily
-	// depends on the correctness of testing hardware's local time.
-	// TODO(katexochen): Maybe remove this later.
-	t1 := time.Now()
-	t0, radius := rt.Now()
-	diff := t1.Sub(t0)
-	assert.LessOrEqual(diff, radius)
 }
 
 func TestNewTime(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
+	github.com/cloudflare/roughtime v0.0.0-20210217223727-1fe56bcbcfd4
 	github.com/edgelesssys/ego v0.2.4-0.20210609075311-d09986cbed77
 	github.com/edgelesssys/era v0.3.0
 	github.com/edgelesssys/ertgolib v0.1.5-0.20210208080427-0d5e24e2f855 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/roughtime v0.0.0-20210217223727-1fe56bcbcfd4 h1:aCis8Toh0cWPLYwYrIjFbVkKS0jHo+TBwDsHTBqqxJw=
+github.com/cloudflare/roughtime v0.0.0-20210217223727-1fe56bcbcfd4/go.mod h1:+M4UQsInIRfmHn6RPcDqS4kKLUAACHW70TG9LqKsp70=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -862,12 +864,15 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1003,6 +1008,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
### Proposed changes
- Add trusted time (ttime) package that uses Roughtime to get a trusted time.
- Add Roughtime server list to the manifest.
- Let the Coordinator use trusted time as soon as a manifest with Roughtime servers is set.

Regarding the last point, I'm currently not sure if I got every relevant call to the time package replaced with the trusted time. There are also some calls where I'm not sure if it's worth or needed to replace them.