### PR TITLE
Fix sample for occlum v0.24

### DIFF
--- a/samples/occlum-hello/Occlum.json
+++ b/samples/occlum-hello/Occlum.json
@@ -61,14 +61,6 @@
             "source": "."
         },
         {
-            "target": "/tmp",
-            "type": "sefs",
-            "source": "./run/mount/tmp",
-            "options": {
-                "temporary": true
-            }
-        },
-        {
             "target": "/proc",
             "type": "procfs"
         },


### PR DESCRIPTION
### Proposed changes
With Occlum v0.24 or newer our sample fails to start, removing the unused `/tmp` mount fixes this

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
