### PR TITLE
MarbleRun release v0.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(marblerun VERSION 0.5.0)
+project(marblerun VERSION 0.5.1)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.5.0
+appVersion: v0.5.1
 description: The control plane for confidential computing.
 home: https://edgeless.systems
 keywords:
@@ -9,7 +9,7 @@ kubeVersion: ">=1.13.0-0"
 name: marblerun
 sources:
 - https://github.com/edgelesssys/marblerun
-version: 0.5.0
+version: 0.5.1
 maintainers:
   - name: Edgeless Systems
     email: contact@edgeless.systems

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -7,7 +7,7 @@
 global:
   image:
     pullPolicy: IfNotPresent
-    version: v0.5.0
+    version: v0.5.1
     repository: ghcr.io/edgelesssys
 
   # Additional annotations to add to all pods


### PR DESCRIPTION
Changelog, correct me if i missed anything:

* CLI:
  * Removed `namespace` command

* Injector:
  * Pods with the `marblerun/marbletype` label will be automatically injected. Use the label `marblerun/resource-injection=disabled` to disable injection for a Pod.
  * Fix injecting DNS names with uppercase letters

* Coordinator:
  * Throw an error when the Coordinator is unable to generate a quote in SGX mode. Use the `EDG_COORDINATOR_DEV_MODE=1` to ignore this error.

* Samples:
  * Graphene was renamed to [Gramine](https://github.com/gramineproject/gramine). Use their [binary release](https://github.com/gramineproject/gramine/releases) to run our samples!
  * Update Occlum sample to use release v0.24.1

* Repository:
  * Add ROADMAP.md
  * Add MarbleRun helm chart