### PR TITLE
Coordinator API - endpoint for manifest signature

### DIFF
--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -44,9 +44,9 @@ func TestGetManifestSignature(t *testing.T) {
 	sigECDSA, hash, manifest := c.GetManifestSignature(context.TODO())
 	expectedHash := sha256.Sum256([]byte(test.ManifestJSON))
 	assert.Equal(expectedHash[:], hash)
-	intermediatePrivK, err := c.data.getPrivK(sKCoordinatorIntermediateKey)
+	rootPrivK, err := c.data.getPrivK(sKCoordinatorRootKey)
 	assert.Equal(err, nil)
-	assert.True(ecdsa.VerifyASN1(&intermediatePrivK.PublicKey, expectedHash[:], sigECDSA))
+	assert.True(ecdsa.VerifyASN1(&rootPrivK.PublicKey, expectedHash[:], sigECDSA))
 	assert.Equal([]byte(test.ManifestJSON), manifest)
 }
 

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -45,7 +45,7 @@ func TestGetManifestSignature(t *testing.T) {
 	expectedHash := sha256.Sum256([]byte(test.ManifestJSON))
 	assert.Equal(expectedHash[:], hash)
 	rootPrivK, err := c.data.getPrivK(sKCoordinatorRootKey)
-	assert.Equal(err, nil)
+	assert.NoError(err)
 	assert.True(ecdsa.VerifyASN1(&rootPrivK.PublicKey, expectedHash[:], sigECDSA))
 	assert.Equal([]byte(test.ManifestJSON), manifest)
 }

--- a/coordinator/core/clientapi_test.go
+++ b/coordinator/core/clientapi_test.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -40,9 +41,12 @@ func TestGetManifestSignature(t *testing.T) {
 
 	assert.NoError(err)
 
-	sig, manifest := c.GetManifestSignature(context.TODO())
+	sigECDSA, hash, manifest := c.GetManifestSignature(context.TODO())
 	expectedHash := sha256.Sum256([]byte(test.ManifestJSON))
-	assert.Equal(expectedHash[:], sig)
+	assert.Equal(expectedHash[:], hash)
+	intermediatePrivK, err := c.data.getPrivK(sKCoordinatorIntermediateKey)
+	assert.Equal(err, nil)
+	assert.True(ecdsa.VerifyASN1(&intermediatePrivK.PublicKey, expectedHash[:], sigECDSA))
 	assert.Equal([]byte(test.ManifestJSON), manifest)
 }
 

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -83,7 +83,7 @@ func TestSeal(t *testing.T) {
 	// Get certificate and signature.
 	cert, err := c.GetTLSRootCertificate(nil)
 	assert.NoError(err)
-	signature, _ := c.GetManifestSignature(context.TODO())
+	signatureIntermediateECDSA, signature, _ := c.GetManifestSignature(context.TODO())
 
 	// Get secrets
 	cSecrets, err := c.data.getSecretMap()
@@ -108,8 +108,9 @@ func TestSeal(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(cSecrets, c2Secrets)
 
-	signature2, _ := c2.GetManifestSignature(context.TODO())
+	signatureIntermediateECDSA2, signature2, _ := c2.GetManifestSignature(context.TODO())
 	assert.Equal(signature, signature2, "manifest signature differs after restart")
+	assert.Equal(signatureIntermediateECDSA, signatureIntermediateECDSA2, "manifest signature intermediate ecdsa differs after restart")
 }
 
 func TestRecover(t *testing.T) {

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -83,7 +83,7 @@ func TestSeal(t *testing.T) {
 	// Get certificate and signature.
 	cert, err := c.GetTLSRootCertificate(nil)
 	assert.NoError(err)
-	signatureIntermediateECDSA, signature, _ := c.GetManifestSignature(context.TODO())
+	signatureRootECDSA, signature, _ := c.GetManifestSignature(context.TODO())
 
 	// Get secrets
 	cSecrets, err := c.data.getSecretMap()
@@ -108,9 +108,9 @@ func TestSeal(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(cSecrets, c2Secrets)
 
-	signatureIntermediateECDSA2, signature2, _ := c2.GetManifestSignature(context.TODO())
+	signatureRootECDSA2, signature2, _ := c2.GetManifestSignature(context.TODO())
 	assert.Equal(signature, signature2, "manifest signature differs after restart")
-	assert.Equal(signatureIntermediateECDSA, signatureIntermediateECDSA2, "manifest signature intermediate ecdsa differs after restart")
+	assert.Equal(signatureRootECDSA, signatureRootECDSA2, "manifest signature root ecdsa differs after restart")
 }
 
 func TestRecover(t *testing.T) {

--- a/coordinator/core/storewrapper.go
+++ b/coordinator/core/storewrapper.go
@@ -20,18 +20,19 @@ import (
 )
 
 const (
-	requestActivations    = "activations"
-	requestCert           = "certificate"
-	requestInfrastructure = "infrastructure"
-	requestManifest       = "manifest"
-	requestMarble         = "marble"
-	requestPackage        = "package"
-	requestPrivKey        = "privateKey"
-	requestSecret         = "secret"
-	requestState          = "state"
-	requestTLS            = "TLS"
-	requestUser           = "user"
-	requestUpdateLog      = "updateLog"
+	requestActivations       = "activations"
+	requestCert              = "certificate"
+	requestInfrastructure    = "infrastructure"
+	requestManifest          = "manifest"
+	requestManifestSignature = "manifestSignature"
+	requestMarble            = "marble"
+	requestPackage           = "package"
+	requestPrivKey           = "privateKey"
+	requestSecret            = "secret"
+	requestState             = "state"
+	requestTLS               = "TLS"
+	requestUser              = "user"
+	requestUpdateLog         = "updateLog"
 )
 
 // storeWrapper is a wrapper for the store interface.
@@ -189,6 +190,16 @@ func (s storeWrapper) getRawManifest() ([]byte, error) {
 // putRawManifest saves the raw manifest to store.
 func (s storeWrapper) putRawManifest(manifest []byte) error {
 	return s.store.Put(requestManifest, manifest)
+}
+
+// getManifestSignature returns manifests signature from store.
+func (s storeWrapper) getManifestSignature() ([]byte, error) {
+	return s.store.Get(requestManifestSignature)
+}
+
+// putManifestSignature saves the manifests signature to store.
+func (s storeWrapper) putManifestSignature(manifestSignature []byte) error {
+	return s.store.Put(requestManifestSignature, manifestSignature)
 }
 
 // getSecret returns a secret from store.

--- a/coordinator/server/client_api.go
+++ b/coordinator/server/client_api.go
@@ -124,8 +124,8 @@ func (s *clientAPIServer) manifestGet(w http.ResponseWriter, r *http.Request) {
 	signatureRootECDSA, signature, manifest := s.cc.GetManifestSignature(r.Context())
 	writeJSON(w, ManifestSignatureResp{
 		ManifestSignatureRootECDSA: signatureRootECDSA,
-		ManifestSignature:                  hex.EncodeToString(signature),
-		Manifest:                           manifest,
+		ManifestSignature:          hex.EncodeToString(signature),
+		Manifest:                   manifest,
 	})
 }
 

--- a/coordinator/server/client_api.go
+++ b/coordinator/server/client_api.go
@@ -89,7 +89,7 @@ func (s *clientAPIServer) statusGet(w http.ResponseWriter, r *http.Request) {
 //
 // Get the currently set manifest.
 //
-// The endpoint returns a manifest signature as base64 encoded bytes 
+// The endpoint returns a manifest signature as base64 encoded bytes
 // (signed by the intermediate ECDSA key) and a SHA-256 of the currently
 // set manifest.
 // Further, the manifest itself is returned as base64 encoded bytes.
@@ -125,8 +125,8 @@ func (s *clientAPIServer) manifestGet(w http.ResponseWriter, r *http.Request) {
 	signatureIntermediateECDSA, signature, manifest := s.cc.GetManifestSignature(r.Context())
 	writeJSON(w, ManifestSignatureResp{
 		ManifestSignatureIntermediateECDSA: signatureIntermediateECDSA,
-		ManifestSignature: hex.EncodeToString(signature),
-		Manifest:          manifest,
+		ManifestSignature:                  hex.EncodeToString(signature),
+		Manifest:                           manifest,
 	})
 }
 

--- a/coordinator/server/client_api.go
+++ b/coordinator/server/client_api.go
@@ -39,8 +39,9 @@ type StatusResp struct {
 }
 
 type ManifestSignatureResp struct {
-	// The manifest signature - signed by the root ECDSA key. Changes upon each call due to a random component.
+	// The manifest signature - signed by the root ECDSA key.
 	// example: MEYCIQCmkqOP0Jf1v5ZR0vUYNnMxmy8j9aYR3Zdemuz8EXNQ4gIhAMk6MCg00Rowilui/66tHrkETMmkPmOktMKXQqv6NmnN
+	// swagger:strfmt byte
 	ManifestSignatureRootECDSA []byte
 	// A SHA-256 of the currently set manifest. Does not change when an update has been applied.
 	// example: 3fff78e99dd9bd801e0a3a22b7f7a24a492302c4d00546d18c7f7ed6e26e95c3

--- a/coordinator/server/client_api.go
+++ b/coordinator/server/client_api.go
@@ -39,6 +39,9 @@ type StatusResp struct {
 }
 
 type ManifestSignatureResp struct {
+	// The manifest signature - signed by the intermediate ECDSA key. Changes upon each call due to a random component.
+	// example: MEYCIQCmkqOP0Jf1v5ZR0vUYNnMxmy8j9aYR3Zdemuz8EXNQ4gIhAMk6MCg00Rowilui/66tHrkETMmkPmOktMKXQqv6NmnN
+	ManifestSignatureIntermediateECDSA []byte
 	// A SHA-256 of the currently set manifest. Does not change when an update has been applied.
 	// example: 3fff78e99dd9bd801e0a3a22b7f7a24a492302c4d00546d18c7f7ed6e26e95c3
 	ManifestSignature string
@@ -86,24 +89,42 @@ func (s *clientAPIServer) statusGet(w http.ResponseWriter, r *http.Request) {
 //
 // Get the currently set manifest.
 //
-// The endpoint returns a SHA-256 of the currently set manifest.
+// The endpoint returns a manifest signature as base64 encoded bytes 
+// (signed by the intermediate ECDSA key) and a SHA-256 of the currently
+// set manifest.
 // Further, the manifest itself is returned as base64 encoded bytes.
-// Both values do not change when an update has been applied.
+// While the SHA-256 hash and the manifest itself do not change when
+// an update has been applied, the ECDSA signature changes upon each
+// request due to a random component.
 //
 // Users can retrieve and inspect the manifest through this endpoint before interacting with the application.
 //
-// Example for verifying the deployed manifest with curl:
+// Example for requesting the deployed manifest hash with curl:
 //
 // ```bash
 // curl --cacert marblerun.crt "https://$MARBLERUN/manifest" | jq '.data.ManifestSignature' --raw-output
+// ```
+//
+// Example for verifying the deployed manifest via the intermediate key signature:
+//
+// ```bash
+// # get manifest signature (signed by coordinator intermediate key)
+// curl --cacert marblerun.crt "https://$MARBLERUN/manifest" | jq '.data.ManifestSignatureIntermediateECDSA' --raw-output | base64 -d > manifest.sig
+// # extract intermediate public key from coordinator certificate chain
+// openssl x509 -in marblerun.crt -pubkey -noout > intermediate.pubkey
+// # remove newlines from manifest
+// awk 'NF {sub(/\r/, ""); printf "%s",$0;}' original.manifest.json  > formated.manifest.json
+// # verify signature
+// openssl dgst -sha256 -verify intermediate.pubkey -signature manifest.sig formated.manifest.json
 // ```
 //
 //     Responses:
 //       200: ManifestResponse
 //		 500: ErrorResponse
 func (s *clientAPIServer) manifestGet(w http.ResponseWriter, r *http.Request) {
-	signature, manifest := s.cc.GetManifestSignature(r.Context())
+	signatureIntermediateECDSA, signature, manifest := s.cc.GetManifestSignature(r.Context())
 	writeJSON(w, ManifestSignatureResp{
+		ManifestSignatureIntermediateECDSA: signatureIntermediateECDSA,
 		ManifestSignature: hex.EncodeToString(signature),
 		Manifest:          manifest,
 	})

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -58,8 +58,8 @@ func TestManifest(t *testing.T) {
 	mux.ServeHTTP(resp, req)
 	require.Equal(http.StatusOK, resp.Code)
 
-	sigIntermediateECDSA, sig, manifest := c.GetManifestSignature(context.TODO())
-	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureIntermediateECDSA":"`+base64.StdEncoding.EncodeToString(sigIntermediateECDSA)+`","ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
+	sigRootECDSA, sig, manifest := c.GetManifestSignature(context.TODO())
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureRootECDSA":"`+base64.StdEncoding.EncodeToString(sigRootECDSA)+`","ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
 
 	// try setting manifest again, should fail
 	req = httptest.NewRequest(http.MethodPost, "/manifest", strings.NewReader(test.ManifestJSON))

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -59,7 +59,7 @@ func TestManifest(t *testing.T) {
 	require.Equal(http.StatusOK, resp.Code)
 
 	sigIntermediateECDSA, sig, manifest := c.GetManifestSignature(context.TODO())
-	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureIntermediateECDSA":"`+hex.EncodeToString(sigIntermediateECDSA)+`","ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureIntermediateECDSA":"`+base64.StdEncoding.EncodeToString(sigIntermediateECDSA)+`","ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
 
 	// try setting manifest again, should fail
 	req = httptest.NewRequest(http.MethodPost, "/manifest", strings.NewReader(test.ManifestJSON))

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -58,8 +58,8 @@ func TestManifest(t *testing.T) {
 	mux.ServeHTTP(resp, req)
 	require.Equal(http.StatusOK, resp.Code)
 
-	sig, manifest := c.GetManifestSignature(context.TODO())
-	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
+	sigIntermediateECDSA, sig, manifest := c.GetManifestSignature(context.TODO())
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureIntermediateECDSA":"`+hex.EncodeToString(sigIntermediateECDSA)+`","ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
 
 	// try setting manifest again, should fail
 	req = httptest.NewRequest(http.MethodPost, "/manifest", strings.NewReader(test.ManifestJSON))

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -258,7 +258,7 @@ func TestClientAPI(t *testing.T) {
 	manifest, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	require.NoError(err)
-	assert.JSONEq(`{"status":"success","data":{"ManifestSignature":"","Manifest":null}}`, string(manifest))
+	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureRootECDSA":null,"ManifestSignature":"","Manifest":null}}`, string(manifest))
 
 	log.Println("Setting the Manifest")
 	_, err = setManifest(testManifest)


### PR DESCRIPTION
### Proposed changes
- enhance the Coordinator API `manifest` endpoint to return the manifests ECDSA signature - signed by intermediate key

### Related issue
- #290 

### Open Questions
- The ECDSA signature contains a random element, which means that with the current implementation the signature will change upon each request. An attacker who would like to guess the ECDSA key might find this useful. It could be sensible to create the signature only once and store it in the storeWrapper. @m1ghtym0 any preferences?
