### PR TITLE
Remove nodename check for Occlum premain

### DIFF
--- a/cmd/premain-libos/main.go
+++ b/cmd/premain-libos/main.go
@@ -81,7 +81,7 @@ func detectLibOS() (int, error) {
 
 	// Occlum detection
 	// Taken from: https://github.com/occlum/occlum/blob/master/src/libos/src/misc/uname.rs
-	if sysname == "Occlum" && nodename == "occlum-node" {
+	if sysname == "Occlum" {
 		return occlum, nil
 	}
 


### PR DESCRIPTION
### Proposed changes

I have the hunch that the premain might not work for the most recent Occlum 0.27.1 as they [do now fill the `nodename` field for their `uname` struct](https://github.com/occlum/occlum/commit/ffdd4d95a453f6db226daa58d71d212392ae5556) with the hostname of the host machine. So let's just remove that check, the system name should be pretty evident already.

### Additional info
Untested. Actually, I have not tested if it actually breaks since I only stumbled upon this by accident while scrolling around GitHub... but I suspect it does.
