### PR TITLE
Update readme files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,9 +9,11 @@ assignees: ''
 
 
 ### Issue description
+
 A clear and concise description of what the bug is.
 
 ### To reproduce
+
 Steps to reproduce the behavior:
 
 1.
@@ -21,11 +23,12 @@ Steps to reproduce the behavior:
 ### Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-### Environment:
- - MarbleRun version:
- - Edgeless RT version:
- - Go version:
- - Minikube version:
+### Environment
+
+- MarbleRun version:
+- Edgeless RT version:
+- Go version:
+- Minikube version:
 
 ### Additional info / screenshots
 <!--  Add any other context about the problem here. -->

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,21 +8,22 @@ MarbleRun is written entirely in Go and builds on Edgeless RT, which is written 
 ### Control plane
 
 * [`coordinator`](coordinator):
-    * [`config`](coordinator/config): Environment variables for configuration
-    * [`core`](coordinator/core): Provides the gRPC API for Marbles and HTTP-REST API for clients
-    * [`quote`](coordinator/quote): Provides remote attestation quotes
-    * [`rpc`](coordinator/rpc): Protobuf definitions for the control plane <-> data plane communication
-    * [`server`](coordinator/server): Provides the Marble and client API server
+  * [`config`](coordinator/config): Environment variables for configuration
+  * [`core`](coordinator/core): Provides the gRPC API for Marbles and HTTP-REST API for clients
+  * [`quote`](coordinator/quote): Provides remote attestation quotes
+  * [`rpc`](coordinator/rpc): Protobuf definitions for the control plane <-> data plane communication
+  * [`server`](coordinator/server): Provides the Marble and client API server
 
 ### Data plane
 
 * [`marble`](marble):
-	* [`config`](marble/config): Environment variables for configuration
-	* [`premain`](marble/premain): The data plane code that prepares the Marble's environment
+  * [`config`](marble/config): Environment variables for configuration
+  * [`premain`](marble/premain): The data plane code that prepares the Marble's environment
 
 ## Build
 
 *Prerequisites*:
+
 * [Edgeless RT](https://github.com/edgelesssys/edgelessrt) is installed and sourced
 * Go 1.14 or newer
 
@@ -36,6 +37,7 @@ make
 ```
 
 ## Run
+
 Here's how to run the Coordinator and test Marbles.
 
 ### Run the Coordinator
@@ -68,54 +70,55 @@ $ cat build/marble-test-config.json
         "UniqueID": "ac923351e562a127e7d5f58eae0787d13a1309b09893f6b6eb9eda49b1758621",
         "SignerID": "233ac7711eba0f5b8c67c4abfef811bf8ff4cbca4fc7be6fb98e0dcd7a0ddad1"
 }
-
 ```
+
 Here's an example that has the `SecurityVersion`, `ProductID`, and `SignerID` set:
 
 ```json
 {
-	"Packages": {
-		"backend": {
-			"Debug": true,
-			"SecurityVersion": 1,
-			"ProductID": 1,
-			"SignerID": "233ac7711eba0f5b8c67c4abfef811bf8ff4cbca4fc7be6fb98e0dcd7a0ddad1"
-		}
-	},
-	"Infrastructures": {
-		"localhost": {}
-	},
-	"Marbles": {
-		"server" : {
-			"Package": "backend",
-			"Parameters": {
-				"Argv": [
-					"./marble",
-					"serve"
-				],
-				"Env": {
-					"ROOT_CA": "{{ pem .MarbleRun.RootCA.Cert }}",
-					"MARBLE_CERT": "{{ pem .MarbleRun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .MarbleRun.MarbleCert.Private }}"
-				}
-			}
-		},
-		"client": {
-			"Package": "backend",
-			"Parameters": {
-				"Argv": [
-					"./marble"
-				],
-				"Env": {
-					"ROOT_CA": "{{ pem .MarbleRun.RootCA.Cert }}",
-					"MARBLE_CERT": "{{ pem .MarbleRun.MarbleCert.Cert }}",
-					"MARBLE_KEY": "{{ pem .MarbleRun.MarbleCert.Private }}"
-				}
-			}
-	    }
-	}
+  "Packages": {
+    "backend": {
+      "Debug": true,
+      "SecurityVersion": 1,
+      "ProductID": 1,
+      "SignerID": "233ac7711eba0f5b8c67c4abfef811bf8ff4cbca4fc7be6fb98e0dcd7a0ddad1"
+    }
+  },
+  "Infrastructures": {
+    "localhost": {}
+  },
+  "Marbles": {
+    "server" : {
+      "Package": "backend",
+      "Parameters": {
+        "Argv": [
+          "./marble",
+          "serve"
+        ],
+        "Env": {
+          "ROOT_CA": "{{ pem .MarbleRun.RootCA.Cert }}",
+          "MARBLE_CERT": "{{ pem .MarbleRun.MarbleCert.Cert }}",
+          "MARBLE_KEY": "{{ pem .MarbleRun.MarbleCert.Private }}"
+        }
+      }
+    },
+    "client": {
+      "Package": "backend",
+      "Parameters": {
+        "Argv": [
+          "./marble"
+        ],
+        "Env": {
+          "ROOT_CA": "{{ pem .MarbleRun.RootCA.Cert }}",
+          "MARBLE_CERT": "{{ pem .MarbleRun.MarbleCert.Cert }}",
+          "MARBLE_KEY": "{{ pem .MarbleRun.MarbleCert.Private }}"
+        }
+      }
+    }
+  }
 }
 ```
+
 **Replace the `SignerID` with YOUR value from `build/marble-test-config.json`**
 
 *Note*: `Debug` is set to `true` here so that this example works with SGX debug enclaves. This is not secure for production.
@@ -154,12 +157,12 @@ Run a simple application.
 
 * *Note*: A Marble starts with the following default values. You can set your desired configuration by setting the environment variables.
 
-	| Setting | Default Value | Environment Variable |
-	| --- | --- | --- |
-	| network address of the Coordinator’s API for Marbles | localhost:2001 |  EDG_MARBLE_COORDINATOR_ADDR |
-	| reference on one entry from your Manifest’s `Marbles` section | - (this needs to be set every time) | EDG_MARBLE_TYPE |
-	| local file path where the Marble stores its UUID | $PWD/uuid | EDG_MARBLE_UUID_FILE |
-	| DNS names the Coordinator will issue the Marble’s certificate for | localhost | EDG_MARBLE_DNS_NAMES |
+  | Setting | Default Value | Environment Variable |
+  | --- | --- | --- |
+  | network address of the Coordinator’s API for Marbles | localhost:2001 |  EDG_MARBLE_COORDINATOR_ADDR |
+  | reference on one entry from your Manifest’s `Marbles` section | - (this needs to be set every time) | EDG_MARBLE_TYPE |
+  | local file path where the Marble stores its UUID | $PWD/uuid | EDG_MARBLE_UUID_FILE |
+  | DNS names the Coordinator will issue the Marble’s certificate for | localhost | EDG_MARBLE_DNS_NAMES |
 
 ## Marble-Injector
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -208,11 +208,11 @@ You can build the Docker image of the Coordinator by providing a signing key:
 
 ```bash
 openssl genrsa -out private.pem -3 3072
-docker buildx build --secret id=signingkey,src=private.pem --target release --tag ghcr.io/edgelesssys/coordinator -f dockerfiles/Dockerfile.coordinator .
+DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=private.pem --target release --tag ghcr.io/edgelesssys/coordinator -f dockerfiles/Dockerfile.coordinator .
 ```
 
 You can build the Docker image of the marble-injector as follows:
 
 ```bash
-docker buildx build --tag ghcr.io/edgelesssys/marble-injector -f dockerfiles/Dockerfile.marble-injector .
+DOCKER_BUILDKIT=1 docker build --tag ghcr.io/edgelesssys/marble-injector -f dockerfiles/Dockerfile.marble-injector .
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ MarbleRun guarantees that the topology of your distributed app adheres to a Mani
 
 To keep things simple, MarbleRun issues one concise remote attestation statement for your whole distributed app. This can be used by anyone to verify the integrity of your distributed app.
 
-### Key features
+## Key features
 
 :lock: Authentication and integrity verification of microservices with respect to a Manifest written in simple JSON
 
@@ -26,12 +26,14 @@ To keep things simple, MarbleRun issues one concise remote attestation statement
 
 :globe_with_meridians: Remote attestation of the entire cluster
 
-### Overview
+## Overview
 
-<img src="assets/overview.svg" alt="overview" width="600"/>
+![overview](./assets/overview.svg)
 
-### Supported runtimes
+## Supported runtimes
+
 MarbleRun supports services built with one of the following frameworks:
+
 * [EGo][ego]
 * [Gramine][gramine]
 * [Occlum][occlum]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@
 * Support for Alibaba's DCAP infrastructure
 * Add transparency log for manifest updates
 * Role-based access control for users and Marbles:
-    * Secrets upload/download and distribution at runtime
-    * Deployment/Package updates
+  * Secrets upload/download and distribution at runtime
+  * Deployment/Package updates
 * TTLS support for EGo Marbles
 * Plugin system for storage backends
 

--- a/samples/gramine-hello/README.md
+++ b/samples/gramine-hello/README.md
@@ -1,24 +1,32 @@
 # Gramine "Hello World!" example
+
 This example shows how to run a [Gramine](https://github.com/gramineproject/gramine) application in MarbleRun. In essence, you have to add the `premain` process to the Gramine manifest. `premain` will contact the Coordinator, set up the environment, and run the actual application. See the commented [hello.manifest.template](hello.manifest.template) for details.
 
 ## Requirements
+
 First, install Gramine on [release v1.0](https://github.com/gramineproject/gramine/releases/tag/v1.0). You will need hardware with Intel SGX support.
 
 Then, before you can run the example, make sure you got the prerequisites for ECDSA remote attestation installed on your system. You can collectively install them with the following command:
+
 ```sh
 sudo apt install libsgx-quote-ex-dev
 ```
 
 ## Build
+
 You can build the example as follows:
+
 ```sh
 openssl genrsa -3 -out enclave-key.pem 3072
 make
 ```
+
 Then get `mr_enclave` from the build output and set it as `UniqueID` in `manifest.json`.
 
 ## Run
+
 Next, use the `erthost` command to start the Coordinator in a local enclave:
+
 ```sh
 erthost ../../build/coordinator-enclave.signed
 ```
@@ -26,7 +34,8 @@ erthost ../../build/coordinator-enclave.signed
 The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (port 2001). While the Coordinator and your Marble communicate via the mesh API, you can administrate the Coordinator via the REST API.
 
 Once the Coordinator instance is running, you can upload the manifest to the Coordinator's client API:
-```
+
+```sh
 curl -k --data-binary @manifest.json https://localhost:4433/manifest
 ```
 

--- a/samples/gramine-nginx/README.md
+++ b/samples/gramine-nginx/README.md
@@ -1,4 +1,5 @@
 # Gramine nginx example
+
 This example is a slightly modified variant of the [Gramine nginx example](https://github.com/gramineproject/gramine/tree/master/CI-Examples/nginx). These changes are required to run it with MarbleRun.
 
 *Prerequisite*: Gramine is installed on [release v1.0](https://github.com/gramineproject/gramine/releases/tag/v1.0) and the original nginx example is working. You will need hardware with Intel SGX support, and the Coordinator must not run in simulation mode.
@@ -8,12 +9,14 @@ To marbleize the example we edited [nginx.manifest.template](nginx.manifest.temp
 We also removed certificate generation from the Makefile because it will be provisioned by the Coordinator. See [manifest.json](manifest.json) on how this is specified.
 
 We now build the example as follows:
+
 ```sh
 openssl genrsa -3 -out enclave-key.pem 3072
 make SGX=1
 ```
 
 Start the Coordinator in a SGX enclave:
+
 ```sh
 erthost ../../build/coordinator-enclave.signed
 ```
@@ -21,7 +24,8 @@ erthost ../../build/coordinator-enclave.signed
 The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (port 2001). While the Coordinator and your Marble communicate via the mesh API, you can administrate the Coordinator via the REST API.
 
 Once the Coordinator instance is running, you can upload the manifest to the Coordinator's client API:
-```
+
+```sh
 curl -k --data-binary @manifest.json https://localhost:4433/manifest
 ```
 
@@ -32,6 +36,7 @@ EDG_MARBLE_TYPE=frontend gramine-sgx nginx
 ```
 
 From a new terminal, check if nginx is running properly:
+
 ```sh
 curl -k https://localhost:8443
 ```

--- a/samples/gramine-redis/README.md
+++ b/samples/gramine-redis/README.md
@@ -4,6 +4,7 @@ This example is a slightly modified variant of the [Gramine Redis example](https
 Instead of running a single [Redis](https://redis.io/) server instance, MarbleRun unleashes the full potential of Redis and takes care of distributing the Redis server in *replication* mode.
 
 *Prerequisite:*
+
 * Ensure you have access to a Kubernetes cluster with SGX-enabled nodes and kubectl installed and configured. Probably the easiest way to get started is to run Kubernetes on an [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-get-started), which offers SGX-enabled nodes.
 * Ensure you have the [MarbleRun CLI](https://docs.edgeless.systems/marblerun/#/reference/cli) installed.
 
@@ -100,7 +101,6 @@ You can now securely connect to the Redis server using the `redis-cli` and the M
 ## Building the Docker image
 
 To marbleize the example we edited [redis-server.manifest.template](redis-server.manifest.template). See comments starting with `MARBLERUN` for explanations of the required changes.
-
 
 Build the Docker image:
 

--- a/samples/gramine-redis/README.md
+++ b/samples/gramine-redis/README.md
@@ -105,5 +105,5 @@ To marbleize the example we edited [redis-server.manifest.template](redis-server
 Build the Docker image:
 
 ```bash
-docker buildx build --secret id=signingkey,src=<path to private.pem> --tag ghcr.io/edgelesssys/redis-gramine-marble -f ./Dockerfile .
+DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=<path to private.pem> --tag ghcr.io/edgelesssys/redis-gramine-marble -f ./Dockerfile .
 ```

--- a/samples/helloc++/README.md
+++ b/samples/helloc++/README.md
@@ -1,4 +1,5 @@
 # How to create a C++ Marble
+
 This example shows how to build a confidential C++ application and run it in MarbleRun. This can serve you as a blueprint for making existing applications MarbleRun-ready or creating new [Marbles](https://docs.edgeless.systems/marblerun/#/getting-started/marbles). If you haven't already, [setup MarbleRun](../../BUILD.md#build) to get ready.
 
 **Note:** You can run this example on any hardware by simulating the enclave through setting `OE_SIMULATION=1` as environment variable. This might help you to get started with with the development of confidential apps. However, please notice that this bypasses any security. Detailed information on how to develop secure Marbles can be found in [MarbleRun's documentation](https://docs.edgeless.systems/marblerun/#/workflows/add-service).
@@ -26,6 +27,7 @@ oesign dump -e enclave.signed | grep mrenclave
 and set it as `UniqueID` in `manifest.json`.
 
 Next, use the `erthost` command to start the Coordinator in a local enclave:
+
 ```sh
 erthost ../../../build/coordinator-enclave.signed
 ```
@@ -33,11 +35,13 @@ erthost ../../../build/coordinator-enclave.signed
 The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (port 2001). While the Coordinator and your Marble communicate via the mesh API, you can administrate the Coordinator via the REST API.
 
 Once the Coordinator instance is running, you can upload the manifest to the Coordinator's client API:
+
 ```sh
 curl -k --data-binary @../manifest.json https://localhost:4433/manifest
 ```
 
 To run the application, you need to set some environment variables. The type of the Marble is defined in the `manifest.json`. In this example, the manifest defines a single Marble, which is called "hello". The Marble's DNS name and the Coordinator's address are used to establish a connection between the Coordinator's mesh API and the Marble. Further, the UUID file stores a unique ID that enables a restart of the application.
+
 ```sh
 EDG_MARBLE_TYPE=hello \
 EDG_MARBLE_COORDINATOR_ADDR=localhost:2001 \
@@ -45,4 +49,5 @@ EDG_MARBLE_UUID_FILE=$PWD/uuid \
 EDG_MARBLE_DNS_NAMES=localhost \
 erthost enclave.signed
 ```
+
 The app prints a "Hello world!" followed by the command line arguments that are defined in the `manifest.json`.

--- a/samples/helloworld/README.md
+++ b/samples/helloworld/README.md
@@ -1,21 +1,26 @@
 # How to build a helloworld Marble
+
 This example shows how to build a confidential Go application with [EGo](https://ego.dev) and run it in MarbleRun. This can serve you as a blueprint for making existing applications MarbleRun-ready or creating new [Marbles](https://docs.edgeless.systems/marblerun/#/getting-started/marbles). If you haven't already, [setup MarbleRun](../../BUILD.md#build) and EGo to get ready.
 
 **Note:** You can run this example on any hardware by simulating the enclave through setting `OE_SIMULATION=1` as environment variable. This might help you to get started with with the development of confidential apps. However, please notice that this bypasses any security. Detailed information on how to develop secure Marbles can be found in [MarbleRun's documentation](https://docs.edgeless.systems/marblerun/#/workflows/add-service).
 
 You can build and sign the example (or your app) like this:
+
 ```sh
 ego-go build
 ego sign hello
 ```
 
 Get the enclave's unique ID aka `MRENCLAVE` with
+
 ```sh
 ego uniqueid hello
 ```
+
 and set it as `UniqueID` in `manifest.json`.
 
 Next, use the `erthost` command to start the Coordinator in a local simulated enclave:
+
 ```sh
 erthost ../../build/coordinator-enclave.signed
 ```
@@ -23,17 +28,21 @@ erthost ../../build/coordinator-enclave.signed
 The Coordinator exposes two APIs, a client REST API (port 4433) and a mesh API (port 2001). While the Coordinator and your Marble communicate via the mesh API, you can administrate the Coordinator via the REST API.
 
 You can now upload the manifest to the Coordinator's client API:
+
 ```sh
 curl -k --data-binary @manifest.json https://localhost:4433/manifest
 ```
 
 Finaly, you can run the helloworld Marble (or whatever Marble you just created) with the `ego marblerun` command. You just need to set `EDG_MARBLE_TYPE` to a Marble that was defined in the `manifest.json`. In this example, the manifest defines a single Marble, which is called "hello".
+
 ```sh
 EDG_MARBLE_TYPE=hello ego marblerun hello
 ```
+
 EGo starts the Marble, which will then connect itself to the mesh API of the Coordinator.
 
 The helloworld example app will then serve HTTP on port 8080:
+
 ```sh
 $ curl http://localhost:8080
 Hello world!

--- a/samples/occlum-hello/README.md
+++ b/samples/occlum-hello/README.md
@@ -12,7 +12,7 @@ If you are trying to run this sample on Azure, you might want to use the provide
 
 ```sh
 # Assuming `samples/occlum-hello` is the current working directory
-docker buildx build -t occlum-azure .
+DOCKER_BUILDKIT=1 docker build -t occlum-azure .
 docker run -it --network host --device /dev/sgx occlum-azure
 ```
 

--- a/samples/occlum-hello/README.md
+++ b/samples/occlum-hello/README.md
@@ -1,7 +1,9 @@
 # Occlum "Hello World!" sample
+
 This sample shows how to run an [Occlum](https://github.com/occlum/occlum) application in MarbleRun. In essence, you have to add the `premain-libos` process to your Occlum image, use it as an entry point for your instance and supply the original entry point as an `Argv` value in MarbleRun's [manifest.json](manifest.json). `premain` will contact the Coordinator, set up the environment, and run the actual application. Take a look into the [Makefile](Makefile) for details.
 
 ## Requirements
+
 First, get Occlum and its build toolchain up and running. This can become quite complex if you run it on your existing environment. Therefore, we use the official Docker image and expose the SGX device to it:
 
 ```sh
@@ -19,6 +21,7 @@ docker run -it --network host --device /dev/sgx occlum-azure
 Note that we also chose `--network host` here, as we assume you do not run the coordinator in the same Docker instance. **This option is potentially insecure in production use**, as it disables the isolation of the container network. For a production setup, we recommend that you choose a setup that exposes the coordinator to the container.
 
 ## Build
+
 Inside the Docker instance, clone the MarbleRun repository and run the Makefile included in this directory. It will automatically build the premain process and "Hello World" application, create the Occlum instance and run `occlum build` to create the final image.
 
 ```sh
@@ -36,7 +39,8 @@ chmod +x marblerun
 ```
 
 The output is similar to the following:
-```
+
+```sh
 Detected Occlum image.
 PackageProperties for Occlum image at './occlum-instance':
 UniqueID (MRENCLAVE)      : ccad2391e0b79d9108209135c26b2c276c5a24f4f55bc67ccf5ab90fd3f5fc22
@@ -50,6 +54,7 @@ From this point, you can take the `UniqueID` (or `SignerID`/`ProductID`/`Securit
 If you want to change the entry point of your application, you can also edit the first `Argv` value in the manifest. This needs to be a path to the virtual file system of your Occlum image.
 
 ## Run
+
 We assume that the Coordinator is run with the following environment variables:
 
 - EDG_COORDINATOR_MESH_ADDR=localhost:2001
@@ -59,33 +64,36 @@ We assume that the Coordinator is run with the following environment variables:
 
 Once the [Coordinator instance is running](../../BUILD.md#run-the-coordinator), upload the manifest to the Coordinator:
 
-```
+```sh
 curl -k --data-binary @manifest.json https://localhost:4433/manifest
 ```
 
 Now we automatically run our application with the help of the Makefile:
+
 ```sh
 make run
 ```
 
 Or manually:
+
 ```sh
 cd occlum_instance
 occlum run /bin/premain-libos
 ```
 
 ## Troubleshooting
-* If you receive the following error message on launch:
 
-    ```
+- If you receive the following error message on launch:
+
+    ```sh
     fatal error: failed to reserve page summary memory
     ```
 
     Make sure you allocated enough memory in `enclave.json`. The most important parameters are `user_space_size` and `default_mmap_size`. For safe values to start, check out the provided [demo manifest](Occlum.json).
 
-* Else, if you receive:
+- Else, if you receive:
 
-    ```
+    ```sh
     ERROR: The entrypoint does not seem to exist: '/bin/your_application'
     Please make sure that you define a valid entrypoint in your manifest (for example: /bin/hello_world).
     panic: "invalid entrypoint definition in argv[0]"
@@ -93,12 +101,14 @@ occlum run /bin/premain-libos
 
     Make sure you specified the correct filename of your target application.
 
-* If you are running into other issues, Occlum's error logging might help:
+- If you are running into other issues, Occlum's error logging might help:
+
     ```sh
     OCCLUM_LOG_LEVEL=error make run
     ```
 
     or:
+
     ```sh
     OCCLUM_LOG_LEVEL=error occlum run /bin/premain-libos
     ```

--- a/samples/sample-manifest.json
+++ b/samples/sample-manifest.json
@@ -65,9 +65,7 @@
             "Parameters": {
                 "Env": {
                     "TEST_SECRET_CERT": "{{ pem .Secrets.certShared.Cert }}",
-                    "TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.certPrivate.Cert }}",
-                    "TEST_SECRET_CERT": "{{ pem .Secrets.cert_shared.Cert }}",
-                    "TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.cert_private.Cert }}"
+                    "TEST_SECRET_PRIVATE_CERT": "{{ pem .Secrets.certPrivate.Cert }}"
                 },
                 "Argv": [
                     "serve"


### PR DESCRIPTION
### Proposed changes
- Deprecated usage of `docker buildx build` in favor of `DOCKER_BUILDKIT=1 docker build
- Apply changes from markdown linting
- Fix duplicate key in manifest sample