### PR TITLE
Fix an error that occurs when get a coordinator certificate

### DIFF
--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -34,8 +34,7 @@ const (
 
 const promptForChanges = "Do you want to automatically apply the suggested changes [y/n]? "
 
-const ERADefaultConfig = "era-config.json"
-
+const eraDefaultConfig = "era-config.json"
 var (
 	eraConfig   string
 	insecureEra bool

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -76,7 +76,7 @@ func verifyCoordinator(host string, configFilename string, insecure bool) ([]*pe
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("downloading era config failed with error %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
-	out, err := os.Create(ERADefaultConfig)
+	out, err := os.Create(eraDefaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func verifyCoordinator(host string, configFilename string, insecure bool) ([]*pe
 	}
 	fmt.Println("Got latest config")
 
-	pemBlock, _, err := era.GetCertificate(host, ERADefaultConfig)
+	pemBlock, _, err := era.GetCertificate(host, eraDefaultConfig)
 	return pemBlock, err
 }
 

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -34,6 +34,8 @@ const (
 
 const promptForChanges = "Do you want to automatically apply the suggested changes [y/n]? "
 
+const ERADefaultConfig = "era-config.json"
+
 var (
 	eraConfig   string
 	insecureEra bool
@@ -75,7 +77,7 @@ func verifyCoordinator(host string, configFilename string, insecure bool) ([]*pe
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("downloading era config failed with error %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
-	out, err := os.Create("era-config.json")
+	out, err := os.Create(ERADefaultConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +88,7 @@ func verifyCoordinator(host string, configFilename string, insecure bool) ([]*pe
 	}
 	fmt.Println("Got latest config")
 
-	pemBlock, _, err := era.GetCertificate(host, "era-config.json")
+	pemBlock, _, err := era.GetCertificate(host, ERADefaultConfig)
 	return pemBlock, err
 }
 

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -86,7 +86,7 @@ func verifyCoordinator(host string, configFilename string, insecure bool) ([]*pe
 	}
 	fmt.Println("Got latest config")
 
-	pemBlock, _, err := era.GetCertificate(host, configFilename)
+	pemBlock, _, err := era.GetCertificate(host, "era-config.json")
 	return pemBlock, err
 }
 


### PR DESCRIPTION

### Proposed changes
- use "era-config.json" instead of configFilename variable when the latter is empty.

