### PR TITLE
RFC: emit cert as Java KeyStore

### DIFF
--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -424,6 +424,10 @@ func TestParseSecrets(t *testing.T) {
 	_, err = parseSecrets("{{ hex .Secrets.emptysecret }}", manifest.ManifestFileTemplateFuncMap, testWrappedSecrets)
 	assert.Error(err)
 
+	// Test if we can encode as jks
+	parsedSecret, err = parseSecrets("{{ jks \"password\" .Secrets.testcertificate }}", manifest.ManifestFileTemplateFuncMap, testWrappedSecrets)
+	require.NoError(err)
+
 	testWrappedSecrets.Secrets = map[string]manifest.Secret{
 		"plainSecret": {Type: "plain", Public: []byte{1, 2, 3}},
 		"nullSecret":  {Type: "plain", Public: []byte{0, 1, 2}},
@@ -440,6 +444,10 @@ func TestParseSecrets(t *testing.T) {
 
 	// non plain secrets always result in an error
 	_, err = parseSecrets("{{ string .Secrets.otherSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
+	assert.Error(err)
+
+	// jks must fail encoding a symmetric key
+	_, err = parseSecrets("{{ jks \"password\" .Secrets.otherSecret }}", manifest.ManifestEnvTemplateFuncMap, testWrappedSecrets)
 	assert.Error(err)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
+	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -921,6 +921,8 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.0 h1:y9azNmMzvkNBPyczpNRwaV4bm0U6e7Oyrj7gi2/SNFI=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.0/go.mod h1:lAVhWwbNaveeJmxrxuSTxMgKpF6DjnuVpn6T8WiBwYQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=


### PR DESCRIPTION
see #307

turns out jks is slightly more annoying because it is usually used in a multi-step process of adding certs into a store,
but we need to emit the file in one go, merging all the inputs.

so the proposed semantic is

```json
"/app/keystore.jks": "{{ jks 'password' 'alias'  .MarbleRun.MarbleCert.Private .MarbleRun.MarbleCert.Cert }}", 
"/app/trustme.jks": "{{ jks 'password' 'alias'  nil .MarbleRun.MarbleCert.Cert }}", 
```

we could add another helper function to make the structure more explicit, but i feel like it's a can of worms and this works fine for all sensible use cases.

we could also go the opposite way and reduce it to only accept manifest.Secret

```json
"/app/keystore.jks": "{{ jks 'password' 'alias' MarbleRun.MarbleCert 'alias2' MarbleRun.OtherCert  }}", 
```

which is alot prettier, but i don't know if people maybe have weird use cases where they want control over what exactly gets emitted.

on second thought, i'd much prefer that if we can get away with it.
So do you see any use cases where someone would want to emit something that is NOT a manifest.Secret?