### PR TITLE
Fix version parsing

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"helm.sh/helm/v3/pkg/strvals"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -329,21 +329,17 @@ func createSecret(privKey *rsa.PrivateKey, crt []byte, kubeClient kubernetes.Int
 }
 
 func getCertificateHandler(kubeClient kubernetes.Interface) (certificateInterface, error) {
-	versionInfo, err := kubeClient.Discovery().ServerVersion()
+	serverVersion, err := kubeClient.Discovery().ServerVersion()
 	if err != nil {
 		return nil, err
 	}
-	majorVersion, err := strconv.Atoi(versionInfo.Major)
-	if err != nil {
-		return nil, err
-	}
-	minorVersion, err := strconv.Atoi(versionInfo.Minor)
+	versionInfo, err := version.ParseGeneric(serverVersion.String())
 	if err != nil {
 		return nil, err
 	}
 
 	// return the legacy interface if kubernetes version is < 1.19
-	if majorVersion == 1 && minorVersion < 19 {
+	if versionInfo.Major() == 1 && versionInfo.Minor() < 19 {
 		fmt.Printf("\nKubernetes version lower than 1.19 detected, using self-signed certificates as CABundle")
 		return newCertificateLegacy()
 	}

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -53,20 +53,31 @@ func TestGetCertificateHandler(t *testing.T) {
 	testClient := fake.NewSimpleClientset()
 
 	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		Major: "1",
-		Minor: "19",
+		Major:      "1",
+		Minor:      "19",
+		GitVersion: "v1.19.4",
 	}
 	testHandler, err := getCertificateHandler(testClient)
 	require.NoError(err)
-	assert.Equal(reflect.TypeOf(testHandler).String(), "*cmd.certificateV1")
+	assert.Equal("*cmd.certificateV1", reflect.TypeOf(testHandler).String())
 
 	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		Major: "1",
-		Minor: "18",
+		Major:      "1",
+		Minor:      "18",
+		GitVersion: "v1.18.4",
 	}
 	testHandler, err = getCertificateHandler(testClient)
 	require.NoError(err)
-	assert.Equal(reflect.TypeOf(testHandler).String(), "*cmd.certificateLegacy")
+	assert.Equal("*cmd.certificateLegacy", reflect.TypeOf(testHandler).String())
+
+	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major:      "1",
+		Minor:      "24+",
+		GitVersion: "v1.24.3-2+63243a96d1c393",
+	}
+	testHandler, err = getCertificateHandler(testClient)
+	require.NoError(err)
+	assert.Equal("*cmd.certificateV1", reflect.TypeOf(testHandler).String())
 }
 
 func TestVerifyNamespace(t *testing.T) {
@@ -93,8 +104,9 @@ func TestInstallWebhook(t *testing.T) {
 
 	testClient := fake.NewSimpleClientset()
 	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		Major: "1",
-		Minor: "18",
+		Major:      "1",
+		Minor:      "18",
+		GitVersion: "v1.18.4",
 	}
 
 	testValues, err := installWebhook(testClient)
@@ -136,8 +148,9 @@ func TestErrorAndCleanup(t *testing.T) {
 
 	testClient := fake.NewSimpleClientset()
 	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		Major: "1",
-		Minor: "19",
+		Major:      "1",
+		Minor:      "19",
+		GitVersion: "v1.19.4",
 	}
 
 	testError := errors.New("test")


### PR DESCRIPTION
### Proposed changes
- Version output in microk8s is `Server Version: version.Info{Major:"1", Minor:"24+", GitVersion:"v1.24.3-2+63243a96d1c393",`
- This breaks the `stringcov.Atoi` call
- Uses[ apimachery](https://github.com/kubernetes/apimachinery/blob/master/pkg/util/version/version.go) for version parsing
- Updates the test accordingly

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
