### PR TITLE
Fix version parsing for uninstall cmd

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
@@ -78,19 +77,11 @@ func cleanupSecrets(kubeClient kubernetes.Interface) error {
 // cleanupCSR removes a potentially leftover CSR from the Admission Controller.
 func cleanupCSR(kubeClient kubernetes.Interface) error {
 	// in case of kubernetes version < 1.19 no CSR was created by the install command
-	versionInfo, err := kubeClient.Discovery().ServerVersion()
+	isLegacy, err := checkLegacyKubernetesVersion(kubeClient)
 	if err != nil {
 		return err
 	}
-	majorVersion, err := strconv.Atoi(versionInfo.Major)
-	if err != nil {
-		return err
-	}
-	minorVersion, err := strconv.Atoi(versionInfo.Minor)
-	if err != nil {
-		return err
-	}
-	if majorVersion == 1 && minorVersion < 19 {
+	if isLegacy {
 		return nil
 	}
 

--- a/cli/cmd/uninstall_test.go
+++ b/cli/cmd/uninstall_test.go
@@ -20,8 +20,9 @@ func TestCleanupWebhook(t *testing.T) {
 	require := require.New(t)
 	testClient := fake.NewSimpleClientset()
 	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		Major: "1",
-		Minor: "19",
+		Major:      "1",
+		Minor:      "19",
+		GitVersion: "v1.19.4",
 	}
 
 	// Try to remove non existent CSR using function
@@ -61,8 +62,25 @@ func TestCleanupWebhook(t *testing.T) {
 
 	// try changing to version lower than 19 and removing CSR (this should always return nil)
 	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		Major: "1",
-		Minor: "18",
+		Major:      "1",
+		Minor:      "18",
+		GitVersion: "v1.18.4",
+	}
+	err = cleanupCSR(testClient)
+	require.NoError(err)
+
+	// try changing to version string containing non-digit characters and removing the CSR
+
+	_, err = testClient.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
+	require.NoError(err)
+
+	_, err = testClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), webhookName, metav1.GetOptions{})
+	require.NoError(err)
+
+	testClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major:      "1",
+		Minor:      "24+",
+		GitVersion: "v1.24.3-2+63243a96d1c393",
 	}
 	err = cleanupCSR(testClient)
 	require.NoError(err)


### PR DESCRIPTION
### Proposed changes
- Forgot that uninstall also parses the version
- Moved that parsing to util now, so we don't duplicate the code

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
