### PR TITLE
Fix dcap-qpl values reference

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -33,7 +33,6 @@ their default values.
 
 | Parameter                                    | Type           | Description    | Default                              |
 |:---------------------------------------------|:---------------|:---------------|:-------------------------------------|
-| `coordinator.dcapQpl`                        | string         | DCAP_LIBRARY needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default | `"azure"` |
 | `coordinator.clientServerHost`               | string         | Hostname of the client-api server | `"0.0.0.0"` |
 | `coordinator.clientServerPort`               | int            | Port of the client-api server configuration | `4433` |
 | `coordinator.hostname`                       | string         | DNS-Names for the coordinator certificate | `"localhost"` |
@@ -52,7 +51,9 @@ their default values.
 | `marbleInjector.replicas`                    | int            | Replicas of the marbleInjector webhook | `1` |
 | `nodeSelector`                               | object         | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information | `{"beta.kubernetes.io/os": "linux"}` |
 | `tolerations`                                | object         | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information | `{key:"sgx.intel.com/epc",operator:"Exists",effect:"NoSchedule"}` |
-| `dcap`                                       | object         | DCAP configuration settings | `{dcap:{"pccsUrl":"https://localhost:8081/sgx/certification/v3/","useSecureCert:"TRUE"}}` |
+| `dcap.qpl`                                   | string         | SGX quote provider library (QPL) to use. Needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default | `"azure"` |
+| `dcap.pccsUrl`                               | string         | URL of the PCCS. Only applicable if `dcap.qpl=intel` | `"https://localhost:8081/sgx/certification/v3/"`
+| `dcap.useSecureCert`                         | string         | Whether or not the TLS certificate of the PCCS should be verified | `"TRUE"`
 
 ## Add new version (maintainers)
 

--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -51,7 +51,7 @@ spec:
           - name: OE_SIMULATION
             value: {{ if .Values.coordinator.simulation }}"1"{{ else }}"0"{{ end }}
           - name: DCAP_LIBRARY
-            value: "{{ .Values.coordinator.dcapQpl }}"
+            value: "{{ .Values.dcap.qpl }}"
           name: coordinator
           image: "{{ .Values.global.image.repository }}/coordinator:{{ .Values.global.image.version }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -53,12 +53,10 @@ coordinator:
   sealDir: "/coordinator/data/"
   # OE_SIMULATION needs be set to "1" when running on systems without SGX1+FLC capabilities
   simulation: false
-  # DCAP_LIBRARY needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default
-  dcapQpl: "azure"
 
   resources:
     limits:
-      # Disable this if your running on a cluster with an SGX Device Plugin
+      # Disable this if your running on a cluster without an SGX Device Plugin
       sgx.intel.com/epc: "10Mi"
 
   # Set the storage class for your cluster
@@ -79,5 +77,7 @@ nodeSelector:
 
 # DCAP configuration settings
 dcap:
+  # DCAP_LIBRARY needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default
+  qpl: "azure"
   pccsUrl: "https://localhost:8081/sgx/certification/v3/"
   useSecureCert: "TRUE"


### PR DESCRIPTION
### Proposed changes
- Update helm chart to allow the CLI to correctly parse the `dcap-qpl` flag

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- We might want to update our existing helm charts for v0.5-v0.6, since they are broken without this change

<!-- (uncomment if applicable)
### Screenshots

-->
