### PR TITLE
AB#2665 Catch potential seg fault when updating debug marbles

### DIFF
--- a/coordinator/core/clientapi.go
+++ b/coordinator/core/clientapi.go
@@ -345,7 +345,18 @@ func (c *Core) UpdateManifest(ctx context.Context, rawUpdateManifest []byte, upd
 
 	// update manifest was valid, increase svn and regenerate secrets
 	for pkgName, pkg := range updateManifest.Packages {
-		*currentPackages[pkgName].SecurityVersion = *pkg.SecurityVersion
+		if currentPackages[pkgName].SecurityVersion == nil {
+			currentPkg := currentPackages[pkgName]
+			currentPackages[pkgName] = quote.PackageProperties{
+				Debug:           currentPkg.Debug,
+				UniqueID:        currentPkg.UniqueID,
+				SecurityVersion: pkg.SecurityVersion,
+				ProductID:       currentPkg.ProductID,
+				SignerID:        currentPkg.SignerID,
+			}
+		} else {
+			*currentPackages[pkgName].SecurityVersion = *pkg.SecurityVersion
+		}
 	}
 
 	rootCert, err := c.data.getCertificate(sKCoordinatorRootCert)


### PR DESCRIPTION
### Proposed changes
- Guard access to `SecurityVersion` of existing packages, since this may be `nil` for debug Marbles

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
