### PR TITLE
Add delete operations to StdStore

### DIFF
--- a/coordinator/store/stdstore/stdstore_test.go
+++ b/coordinator/store/stdstore/stdstore_test.go
@@ -167,3 +167,24 @@ func TestStdStoreRollback(t *testing.T) {
 	_, err = store.Get("another:input")
 	assert.Error(err)
 }
+
+func TestStdStoreDelete(t *testing.T) {
+	assert := assert.New(t)
+
+	str := New(&seal.MockSealer{})
+
+	inputName := "test:input"
+	inputData := []byte("test data")
+
+	assert.NoError(str.Delete(inputName))
+
+	assert.NoError(str.Put(inputName, inputData))
+	out, err := str.Get("test:input")
+	assert.NoError(err)
+	assert.Equal(inputData, out)
+
+	assert.NoError(str.Delete(inputName))
+	_, err = str.Get(inputName)
+	assert.Error(err)
+	assert.ErrorIs(err, store.ErrValueUnset)
+}

--- a/coordinator/store/store.go
+++ b/coordinator/store/store.go
@@ -34,6 +34,8 @@ type Transaction interface {
 	Get(string) ([]byte, error)
 	// Put saves a value to store by key
 	Put(string, []byte) error
+	// Delete removes a value from store by key
+	Delete(string) error
 	// Iterator returns an Iterator for a given prefix
 	Iterator(string) (Iterator, error)
 	// Commit ends a transaction and persists the changes


### PR DESCRIPTION
### Proposed changes
- Add delete operation to StdStore to delete entries from store
  - `Delete()` is not part of the regular `store.Store` interface
  - I decided to add `Delete` to `store.Transaction` to save on some type assertions when using store transaction

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
