### PR TITLE
Disable openapi workflow

### DIFF
--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -1,8 +1,8 @@
 name: Create Pull Request for OpenAPI update
-on:
-  push:
-    branches:
-    - action/update-swagger
+on: {}
+  #push:
+  #  branches:
+  #  - action/update-swagger
 
 jobs:
   pull-request:

--- a/.github/workflows/openapi-publish.yml
+++ b/.github/workflows/openapi-publish.yml
@@ -1,8 +1,8 @@
 name: Publish OpenAPI specification to documentation
-on:
-  push:
-    branches:
-      - master
+on: {}
+#  push:
+#    branches:
+#      - master
 
 jobs:
   publish-to-docs:

--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -1,6 +1,6 @@
 name: Create and validate OpenAPI specification
-on:
-  pull_request:
+on: {}
+#  pull_request:
 
 jobs:
   make-openapi-spec:


### PR DESCRIPTION
### Proposed changes
- Disable the openapi workflow
  - The workflow currently does not work since it expects another action in the `docs.edgeless.systems` repo (which doesn't exist anymore)
  - Refactoring would require a bit of work
  - We probably don't need the workflow anymore since docs are now in the same repo

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
