### PR TITLE
Add comparison methods

### DIFF
--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -558,6 +558,7 @@ func TestTLSTagEqual(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantEqual, tc.a.Equal(tc.b))
+			assert.Equal(t, tc.wantEqual, tc.b.Equal(tc.a))
 		})
 	}
 }
@@ -602,6 +603,7 @@ func TestFileEqual(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantEqual, tc.a.Equal(tc.b))
+			assert.Equal(t, tc.wantEqual, tc.b.Equal(tc.a))
 		})
 	}
 }
@@ -662,6 +664,7 @@ func TestParametersEqual(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantEqual, tc.a.Equal(tc.b))
+			assert.Equal(t, tc.wantEqual, tc.b.Equal(tc.a))
 		})
 	}
 }
@@ -729,6 +732,7 @@ func TestMarbleEqual(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantEqual, tc.a.Equal(tc.b))
+			assert.Equal(t, tc.wantEqual, tc.b.Equal(tc.a))
 		})
 	}
 }
@@ -845,6 +849,9 @@ func TestSecretEqual(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantEqual, tc.a.Equal(tc.b))
 			assert.Equal(t, tc.wantEqualDefinition, tc.a.EqualDefinition(tc.b))
+
+			assert.Equal(t, tc.wantEqual, tc.b.Equal(tc.a))
+			assert.Equal(t, tc.wantEqualDefinition, tc.b.EqualDefinition(tc.a))
 		})
 	}
 }

--- a/coordinator/quote/ert.go
+++ b/coordinator/quote/ert.go
@@ -7,6 +7,7 @@
 package quote
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -40,6 +41,29 @@ type InfrastructureProperties struct {
 	RootCA []byte
 }
 
+// Equal returns true if both packages are equal.
+func (p PackageProperties) Equal(other PackageProperties) bool {
+	if p.Debug != other.Debug || p.UniqueID != other.UniqueID || p.SignerID != other.SignerID {
+		return false
+	}
+
+	if p.ProductID == nil && other.ProductID != nil || p.ProductID != nil && other.ProductID == nil {
+		return false
+	}
+	if p.ProductID != nil && other.ProductID != nil && *p.ProductID != *other.ProductID {
+		return false
+	}
+
+	if p.SecurityVersion == nil && other.SecurityVersion != nil || p.SecurityVersion != nil && other.SecurityVersion == nil {
+		return false
+	}
+	if p.SecurityVersion != nil && other.SecurityVersion != nil && *p.SecurityVersion != *other.SecurityVersion {
+		return false
+	}
+
+	return true
+}
+
 // IsCompliant checks if the given package properties comply with the requirements.
 func (required PackageProperties) IsCompliant(given PackageProperties) bool {
 	if required.Debug != given.Debug {
@@ -57,6 +81,29 @@ func (required PackageProperties) IsCompliant(given PackageProperties) bool {
 	if required.SecurityVersion != nil && *required.SecurityVersion > *given.SecurityVersion {
 		return false
 	}
+	return true
+}
+
+// Equal returns true if both infrastructures are equal.
+func (p InfrastructureProperties) Equal(other InfrastructureProperties) bool {
+	if !bytes.Equal(p.CPUSVN, other.CPUSVN) || !bytes.Equal(p.RootCA, other.RootCA) {
+		return false
+	}
+
+	if p.QESVN == nil && other.QESVN != nil || p.QESVN != nil && other.QESVN == nil {
+		return false
+	}
+	if p.QESVN != nil && other.QESVN != nil && *p.QESVN != *other.QESVN {
+		return false
+	}
+
+	if p.PCESVN == nil && other.PCESVN != nil || p.PCESVN != nil && other.PCESVN == nil {
+		return false
+	}
+	if p.PCESVN != nil && other.PCESVN != nil && *p.PCESVN != *other.PCESVN {
+		return false
+	}
+
 	return true
 }
 

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -107,6 +107,26 @@ func (u *User) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Equal returns true if both users are the same.
+func (u *User) Equal(other *User) bool {
+	// Check if the other user is granted
+	// all permissions of the current user
+	for _, perm := range u.permissions {
+		if !other.IsGranted(perm) {
+			return false
+		}
+	}
+	// Check if the current user is granted
+	// all permissions of the other user
+	for _, perm := range other.permissions {
+		if !u.IsGranted(perm) {
+			return false
+		}
+	}
+
+	return u.name == other.name && u.certificate.Equal(other.certificate)
+}
+
 // Permission represents the permissions of a MarbleRun user.
 type Permission struct {
 	PermissionID string

--- a/coordinator/user/user_test.go
+++ b/coordinator/user/user_test.go
@@ -137,23 +137,6 @@ func TestEqual(t *testing.T) {
 			},
 			wantEqual: false,
 		},
-		"user2 lacks user1 resource permissions": {
-			user1: &User{
-				name:        "test-user",
-				certificate: &x509.Certificate{Raw: []byte("test")},
-				permissions: map[string]Permission{
-					"perm-1": NewPermission("perm-1", []string{"res-1", "res-2", "res-3"}),
-				},
-			},
-			user2: &User{
-				name:        "test-user",
-				certificate: &x509.Certificate{Raw: []byte("test")},
-				permissions: map[string]Permission{
-					"perm-1": NewPermission("perm-1", []string{"res-1", "res-2"}),
-				},
-			},
-			wantEqual: false,
-		},
 		"user1 has more permissions than user2": {
 			user1: &User{
 				name:        "test-user",
@@ -168,24 +151,6 @@ func TestEqual(t *testing.T) {
 				certificate: &x509.Certificate{Raw: []byte("test")},
 				permissions: map[string]Permission{
 					"perm-1": NewPermission("perm-1", []string{"res-1", "res-2"}),
-				},
-			},
-			wantEqual: false,
-		},
-		"user2 has more permissions than user1": {
-			user1: &User{
-				name:        "test-user",
-				certificate: &x509.Certificate{Raw: []byte("test")},
-				permissions: map[string]Permission{
-					"perm-1": NewPermission("perm-1", []string{"res-1", "res-2"}),
-				},
-			},
-			user2: &User{
-				name:        "test-user",
-				certificate: &x509.Certificate{Raw: []byte("test")},
-				permissions: map[string]Permission{
-					"perm-1": NewPermission("perm-1", []string{"res-1", "res-2"}),
-					"perm-2": NewPermission("perm-2", []string{"res-3", "res-4"}),
 				},
 			},
 			wantEqual: false,
@@ -229,6 +194,7 @@ func TestEqual(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantEqual, tc.user1.Equal(tc.user2))
+			assert.Equal(t, tc.wantEqual, tc.user2.Equal(tc.user1))
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes
- Add `Equal` methods (and unit tests) for easy comparison to types used in the manifest
- Add a `IsUpdateManifest` method to easily check whether or not a manifest only contains package definitions

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
