### PR TITLE
Create integration testing framework

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -1,0 +1,537 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package framework provides a testing framework for MarbleRun integration testing.
+package framework
+
+import (
+	"bytes"
+	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/marblerun/coordinator/constants"
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
+	"github.com/edgelesssys/marblerun/coordinator/seal"
+	mconfig "github.com/edgelesssys/marblerun/marble/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// IntegrationTest is a testing framework for MarbleRun tests.
+type IntegrationTest struct {
+	assert  *assert.Assertions
+	require *require.Assertions
+
+	TestManifest        manifest.Manifest
+	UpdatedManifest     manifest.Manifest
+	BuildDir            string
+	SimulationFlag      string
+	NoEnclave           bool
+	MeshServerAddr      string
+	ClientServerAddr    string
+	MarbleTestAddr      string
+	transportSkipVerify http.RoundTripper
+}
+
+// New creates a new IntegrationTest.
+func New(t *testing.T, buildDir, simulation string, noenclave bool,
+	marbleTestAddr, meshServerAddr, clientServerAddr,
+	testManifest, updatedManifest string,
+) *IntegrationTest {
+	i := &IntegrationTest{
+		assert:  assert.New(t),
+		require: require.New(t),
+
+		BuildDir:            buildDir,
+		SimulationFlag:      simulation,
+		NoEnclave:           noenclave,
+		MeshServerAddr:      meshServerAddr,
+		ClientServerAddr:    clientServerAddr,
+		MarbleTestAddr:      marbleTestAddr,
+		transportSkipVerify: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+
+	i.require.NoError(json.Unmarshal([]byte(testManifest), &i.TestManifest))
+	i.require.NoError(json.Unmarshal([]byte(updatedManifest), &i.UpdatedManifest))
+
+	return i
+}
+
+// UpdateManifest updates the manifest with the uniqueID, signerID, productID and securityVersion of the testing marble.
+func (i IntegrationTest) UpdateManifest() {
+	config, err := os.ReadFile(filepath.Join(i.BuildDir, "marble-test-config.json"))
+	i.require.NoError(err)
+	var cfg struct {
+		SecurityVersion uint
+		UniqueID        string
+		SignerID        string
+		ProductID       uint64
+	}
+	i.require.NoError(json.Unmarshal(config, &cfg))
+
+	pkg := i.TestManifest.Packages["backend"]
+	pkg.UniqueID = cfg.UniqueID
+	pkg.SignerID = cfg.SignerID
+	pkg.SecurityVersion = &cfg.SecurityVersion
+	pkg.ProductID = &cfg.ProductID
+	i.TestManifest.Packages["backend"] = pkg
+
+	// Adjust unit test update manifest to work with the integration test
+	i.UpdatedManifest.Packages["backend"] = i.UpdatedManifest.Packages["frontend"]
+}
+
+// CoordinatorConfig contains the configuration for the Coordinator.
+type CoordinatorConfig struct {
+	dnsNames string
+	sealDir  string
+}
+
+// NewCoordinatorConfig creates a new CoordinatorConfig.
+func NewCoordinatorConfig() CoordinatorConfig {
+	sealDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		panic(err)
+	}
+	return CoordinatorConfig{dnsNames: "localhost", sealDir: sealDir}
+}
+
+// Cleanup removes the seal directory.
+func (c CoordinatorConfig) Cleanup() {
+	if err := os.RemoveAll(c.sealDir); err != nil {
+		panic(err)
+	}
+}
+
+// StartCoordinator starts the Coordinator defined by the given config.
+func (i IntegrationTest) StartCoordinator(cfg CoordinatorConfig) *os.Process {
+	var cmd *exec.Cmd
+	if i.NoEnclave {
+		cmd = exec.Command(filepath.Join(i.BuildDir, "coordinator-noenclave"))
+	} else {
+		cmd = exec.Command("erthost", filepath.Join(i.BuildDir, "coordinator-enclave.signed"))
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL} // kill if parent dies
+	cmd.Env = []string{
+		MakeEnv(constants.MeshAddr, i.MeshServerAddr),
+		MakeEnv(constants.ClientAddr, i.ClientServerAddr),
+		MakeEnv(constants.DNSNames, cfg.dnsNames),
+		MakeEnv(constants.SealDir, cfg.sealDir),
+		i.SimulationFlag,
+	}
+	output := i.StartCommand(cmd)
+
+	client := http.Client{Transport: i.transportSkipVerify}
+	url := url.URL{Scheme: "https", Host: i.ClientServerAddr, Path: "status"}
+
+	log.Println("Coordinator starting...")
+	for {
+		time.Sleep(10 * time.Millisecond)
+		select {
+		case out := <-output:
+			// process died
+			log.Println(out)
+			return nil
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url.String(), http.NoBody)
+		i.require.NoError(err)
+
+		resp, err := client.Do(req)
+		if err == nil {
+			log.Println("Coordinator started")
+			resp.Body.Close()
+			i.require.Equal(http.StatusOK, resp.StatusCode)
+			return cmd.Process
+		}
+	}
+}
+
+// StartCommand starts the given command and returns a channel that contains the output.
+func (i IntegrationTest) StartCommand(cmd *exec.Cmd) chan string {
+	output := make(chan string)
+	go func() {
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			if _, ok := err.(*exec.ExitError); !ok {
+				output <- err.Error()
+				return
+			}
+		}
+		output <- string(out)
+	}()
+	return output
+}
+
+// SetManifest sets the manifest of the Coordinator.
+func (i IntegrationTest) SetManifest(manifest manifest.Manifest) ([]byte, error) {
+	// Use ClientAPI to set Manifest
+	client := http.Client{Transport: i.transportSkipVerify}
+	clientAPIURL := url.URL{
+		Scheme: "https",
+		Host:   i.ClientServerAddr,
+		Path:   "manifest",
+	}
+
+	manifestRaw, err := json.Marshal(manifest)
+	i.require.NoError(err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, clientAPIURL.String(), bytes.NewReader(manifestRaw))
+	i.require.NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	i.require.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	i.require.NoError(err)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected %v, but /manifest returned %v: %v", http.StatusOK, resp.Status, string(body))
+	}
+
+	return body, nil
+}
+
+// SetUpdateManifest sets performs a manifest update for the Coordinator.
+func (i IntegrationTest) SetUpdateManifest(manifest manifest.Manifest, certPEM []byte, key *rsa.PrivateKey) ([]byte, error) {
+	// Setup requied client certificate for authentication
+	privk, err := x509.MarshalPKCS8PrivateKey(key)
+	i.require.NoError(err)
+
+	cert, err := tls.X509KeyPair(certPEM, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privk}))
+	i.require.NoError(err)
+
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true,
+	}
+
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+
+	// Use ClientAPI to set Manifest
+	client := http.Client{Transport: transport}
+	clientAPIURL := url.URL{
+		Scheme: "https",
+		Host:   i.ClientServerAddr,
+		Path:   "update",
+	}
+
+	manifestRaw, err := json.Marshal(manifest)
+	i.require.NoError(err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, clientAPIURL.String(), bytes.NewReader(manifestRaw))
+	i.require.NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	i.require.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	i.require.NoError(err)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected %v, but /manifest returned %v: %v", http.StatusOK, resp.Status, string(body))
+	}
+
+	return body, nil
+}
+
+// SetRecover sets the recovery key of the Coordinator.
+func (i IntegrationTest) SetRecover(recoveryKey []byte) error {
+	client := http.Client{Transport: i.transportSkipVerify}
+	clientAPIURL := url.URL{
+		Scheme: "https",
+		Host:   i.ClientServerAddr,
+		Path:   "recover",
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, clientAPIURL.String(), bytes.NewReader(recoveryKey))
+	i.require.NoError(err)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	i.require.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	i.require.NoError(err)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected %v, but /recover returned %v: %v", http.StatusOK, resp.Status, string(body))
+	}
+
+	return nil
+}
+
+// GetStatus returns the status of the Coordinator.
+func (i IntegrationTest) GetStatus() (string, error) {
+	client := http.Client{Transport: i.transportSkipVerify}
+	clientAPIURL := url.URL{
+		Scheme: "https",
+		Host:   i.ClientServerAddr,
+		Path:   "status",
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, clientAPIURL.String(), http.NoBody)
+	i.require.NoError(err)
+	resp, err := client.Do(req)
+	i.require.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	i.require.NoError(err)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("expected %v, but /status returned %v: %v", http.StatusOK, resp.Status, string(body))
+	}
+
+	return string(body), nil
+}
+
+// MarbleConfig contains the configuration for a Marble.
+type MarbleConfig struct {
+	coordinatorAddr string
+	marbleType      string
+	dnsNames        string
+	dataDir         string
+}
+
+// NewMarbleConfig creates a new MarbleConfig.
+func NewMarbleConfig(coordinatorAddr, marbleType, dnsNames string) MarbleConfig {
+	dataDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		panic(err)
+	}
+	return MarbleConfig{
+		coordinatorAddr: coordinatorAddr,
+		marbleType:      marbleType,
+		dnsNames:        dnsNames,
+		dataDir:         dataDir,
+	}
+}
+
+// Cleanup removes the data directory of the Marble.
+func (c MarbleConfig) Cleanup() {
+	if err := os.RemoveAll(c.dataDir); err != nil {
+		panic(err)
+	}
+}
+
+// GetMarbleCmd returns the command to start a Marble.
+func (i IntegrationTest) GetMarbleCmd(cfg MarbleConfig) *exec.Cmd {
+	var cmd *exec.Cmd
+	if i.NoEnclave {
+		cmd = exec.Command(filepath.Join(i.BuildDir, "marble-test-noenclave"))
+	} else {
+		cmd = exec.Command("erthost", filepath.Join(i.BuildDir, "marble-test-enclave.signed"))
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL} // kill if parent dies
+	uuidFile := filepath.Join(cfg.dataDir, "uuid")
+	cmd.Env = []string{
+		MakeEnv(mconfig.CoordinatorAddr, cfg.coordinatorAddr),
+		MakeEnv(mconfig.Type, cfg.marbleType),
+		MakeEnv(mconfig.DNSNames, cfg.dnsNames),
+		MakeEnv(mconfig.UUIDFile, uuidFile),
+		MakeEnv("EDG_TEST_ADDR", i.MarbleTestAddr),
+		i.SimulationFlag,
+	}
+	return cmd
+}
+
+// StartMarbleServer starts a Server Marble.
+func (i IntegrationTest) StartMarbleServer(cfg MarbleConfig) *os.Process {
+	cmd := i.GetMarbleCmd(cfg)
+	output := i.StartCommand(cmd)
+
+	log.Println("Waiting for server...")
+	timeout := time.Second * 5
+	for {
+		time.Sleep(100 * time.Millisecond)
+		select {
+		case out := <-output:
+			// process died
+			log.Println(out)
+			return nil
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", i.MarbleTestAddr, timeout)
+		if err == nil {
+			conn.Close()
+			log.Println("Server started")
+			return cmd.Process
+		}
+	}
+}
+
+// StartMarbleClient starts a Client Marble.
+func (i IntegrationTest) StartMarbleClient(cfg MarbleConfig) bool {
+	out, err := i.GetMarbleCmd(cfg).CombinedOutput()
+	if err == nil {
+		return true
+	}
+
+	if _, ok := err.(*exec.ExitError); ok {
+		return false
+	}
+
+	panic(err.Error() + "\n" + string(out))
+}
+
+// TriggerRecovery starts a Coordinator, sets the manifest, and triggers a recovery.
+func (i IntegrationTest) TriggerRecovery(manifest manifest.Manifest) ([]byte, *os.Process, *os.Process, CoordinatorConfig, MarbleConfig, string) {
+	// start Coordinator
+	log.Println("Starting a coordinator enclave")
+	cfg := NewCoordinatorConfig()
+	coordinatorProc := i.StartCoordinator(cfg)
+	i.require.NotNil(coordinatorProc)
+
+	// set Manifest
+	log.Println("Setting the Manifest")
+	recoveryResponse, err := i.SetManifest(manifest)
+	i.require.NoError(err, "failed to set Manifest")
+
+	// start server
+	log.Println("Starting a Server-Marble")
+	serverCfg := NewMarbleConfig(i.MeshServerAddr, "testMarbleServer", "server,backend,localhost")
+	serverProc := i.StartMarbleServer(serverCfg)
+	i.require.NotNil(serverProc, "failed to start server-marble")
+
+	// get certificate
+	log.Println("Save certificate before we try to recover.")
+	client := http.Client{Transport: i.transportSkipVerify}
+	clientAPIURL := url.URL{Scheme: "https", Host: i.ClientServerAddr, Path: "quote"}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, clientAPIURL.String(), http.NoBody)
+	i.require.NoError(err)
+	resp, err := client.Do(req)
+	i.require.NoError(err)
+	i.require.Equal(http.StatusOK, resp.StatusCode)
+	quote, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	i.require.NoError(err)
+	cert := gjson.GetBytes(quote, "data.Cert").String()
+	i.require.NotEmpty(cert)
+
+	// simulate restart of coordinator
+	log.Println("Simulating a restart of the coordinator enclave...")
+	log.Println("Killing the old instance")
+	i.require.NoError(coordinatorProc.Kill())
+
+	// Garble encryption key to trigger recovery state
+	log.Println("Purposely corrupt sealed key to trigger recovery state...")
+	pathToKeyFile := filepath.Join(cfg.sealDir, seal.SealedKeyFname)
+	sealedKeyData, err := os.ReadFile(pathToKeyFile)
+	i.require.NoError(err)
+	sealedKeyData[0] ^= byte(0x42)
+	i.require.NoError(os.WriteFile(pathToKeyFile, sealedKeyData, 0o600))
+
+	// Restart server, we should be in recovery mode
+	log.Println("Restarting the old instance")
+	coordinatorProc = i.StartCoordinator(cfg)
+	i.require.NotNil(coordinatorProc)
+
+	// Query status API, check if status response begins with Code 1 (recovery state)
+	log.Println("Checking status...")
+	statusResponse, err := i.GetStatus()
+	i.require.NoError(err)
+	i.assert.EqualValues(1, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is not in recovery state, but should be.")
+
+	return recoveryResponse, coordinatorProc, serverProc, cfg, serverCfg, cert
+}
+
+// VerifyCertAfterRecovery verifies the certificate after a recovery.
+func (i IntegrationTest) VerifyCertAfterRecovery(cert string, coordinatorProc *os.Process, cfg CoordinatorConfig, assert *assert.Assertions, require *require.Assertions) *os.Process {
+	// Test with certificate
+	log.Println("Verifying certificate after recovery, without a restart.")
+	pool := x509.NewCertPool()
+	i.require.True(pool.AppendCertsFromPEM([]byte(cert)))
+	client := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
+	clientAPIURL := url.URL{Scheme: "https", Host: i.ClientServerAddr, Path: "status"}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, clientAPIURL.String(), http.NoBody)
+	require.NoError(err)
+	resp, err := client.Do(req)
+	i.require.NoError(err)
+	resp.Body.Close()
+	i.require.Equal(http.StatusOK, resp.StatusCode)
+
+	// Simulate restart of coordinator
+	log.Println("Simulating a restart of the coordinator enclave...")
+	log.Println("Killing the old instance")
+	i.require.NoError(coordinatorProc.Kill())
+
+	// Restart server, we should be in recovery mode
+	log.Println("Restarting the old instance")
+	coordinatorProc = i.StartCoordinator(cfg)
+	i.require.NotNil(coordinatorProc)
+
+	// Finally, check if we survive a restart.
+	log.Println("Restarted instance, now let's see if the state can be restored again successfully.")
+	statusResponse, err := i.GetStatus()
+	i.require.NoError(err)
+	i.assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
+
+	// test with certificate
+	log.Println("Verifying certificate after restart.")
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, clientAPIURL.String(), http.NoBody)
+	require.NoError(err)
+	resp, err = client.Do(req)
+	i.require.NoError(err)
+	resp.Body.Close()
+	i.require.Equal(http.StatusOK, resp.StatusCode)
+
+	return coordinatorProc
+}
+
+// VerifyResetAfterRecovery verifies the Coordinator after a recovery as been reset by setting a new manifest.
+func (i IntegrationTest) VerifyResetAfterRecovery(coordinatorProc *os.Process, cfg CoordinatorConfig) *os.Process {
+	// Check status after setting a new manifest, we should be able
+	log.Println("Check if the manifest was accepted and we are ready to accept Marbles")
+	statusResponse, err := i.GetStatus()
+	i.require.NoError(err)
+	i.assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
+
+	// simulate restart of coordinator
+	log.Println("Simulating a restart of the coordinator enclave...")
+	log.Println("Killing the old instance")
+	i.require.NoError(coordinatorProc.Kill())
+
+	// Restart server, we should be in recovery mode
+	log.Println("Restarting the old instance")
+	coordinatorProc = i.StartCoordinator(cfg)
+	i.require.NotNil(coordinatorProc)
+
+	// Finally, check if we survive a restart.
+	log.Println("Restarted instance, now let's see if the new state can be decrypted successfully...")
+	statusResponse, err = i.GetStatus()
+	i.require.NoError(err)
+	i.assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
+
+	return coordinatorProc
+}
+
+// MakeEnv returns a string that can be used as an environment variable.
+func MakeEnv(key, value string) string {
+	return fmt.Sprintf("%v=%v", key, value)
+}

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -400,7 +400,7 @@ func (i IntegrationTest) StartMarbleClient(cfg MarbleConfig) bool {
 	panic(err.Error() + "\n" + string(out))
 }
 
-// TriggerRecovery starts a Coordinator, sets the manifest, and triggers a recovery.
+// TriggerRecovery triggers a recovery.
 func (i IntegrationTest) TriggerRecovery(coordinatorCfg CoordinatorConfig, coordinatorProc *os.Process) (*os.Process, string) {
 	// get certificate
 	log.Println("Save certificate before we try to recover.")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -9,31 +9,21 @@
 package test
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"encoding/pem"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 
-	"github.com/edgelesssys/marblerun/coordinator/constants"
-	"github.com/edgelesssys/marblerun/coordinator/manifest"
-	"github.com/edgelesssys/marblerun/coordinator/seal"
-	mconfig "github.com/edgelesssys/marblerun/marble/config"
+	"github.com/edgelesssys/marblerun/test/framework"
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,8 +35,6 @@ var (
 	simulationMode                                   = flag.Bool("s", false, "Execute test in simulation mode (without real quoting)")
 	noenclave                                        = flag.Bool("noenclave", false, "Do not run with erthost")
 	meshServerAddr, clientServerAddr, marbleTestAddr string
-	testManifest                                     manifest.Manifest
-	updatedManifest                                  manifest.Manifest
 	transportSkipVerify                              = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	simFlag                                          string
 )
@@ -54,25 +42,17 @@ var (
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if *buildDir == "" {
-		log.Fatalln("You must provide the path of the build directory using th -b flag.")
+		log.Fatalln("You must provide the path of the build directory using the -b flag.")
 	}
 	if _, err := os.Stat(*buildDir); err != nil {
 		log.Fatalln(err)
 	}
 
 	if *simulationMode {
-		simFlag = makeEnv("OE_SIMULATION", "1")
+		simFlag = framework.MakeEnv("OE_SIMULATION", "1")
 	} else {
-		simFlag = makeEnv("OE_SIMULATION", "0")
+		simFlag = framework.MakeEnv("OE_SIMULATION", "0")
 	}
-
-	if err := json.Unmarshal([]byte(IntegrationManifestJSON), &testManifest); err != nil {
-		log.Fatalln(err)
-	}
-	if err := json.Unmarshal([]byte(UpdateManifest), &updatedManifest); err != nil {
-		log.Fatalln(err)
-	}
-	updateManifest()
 
 	// get unused ports
 	var listenerMeshAPI, listenerClientAPI, listenerTestMarble net.Listener
@@ -87,144 +67,126 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func updateManifest() {
-	config, err := ioutil.ReadFile(filepath.Join(*buildDir, "marble-test-config.json"))
-	if err != nil {
-		panic(err)
-	}
-	var cfg struct {
-		SecurityVersion uint
-		UniqueID        string
-		SignerID        string
-		ProductID       uint64
-	}
-	if err := json.Unmarshal(config, &cfg); err != nil {
-		panic(err)
-	}
-
-	pkg := testManifest.Packages["backend"]
-	pkg.UniqueID = cfg.UniqueID
-	pkg.SignerID = cfg.SignerID
-	pkg.SecurityVersion = &cfg.SecurityVersion
-	pkg.ProductID = &cfg.ProductID
-	testManifest.Packages["backend"] = pkg
-
-	// Adjust unit test update manifest to work with the integration test
-	updatedManifest.Packages["backend"] = updatedManifest.Packages["frontend"]
-}
-
 // sanity test of the integration test environment
 func TestTest(t *testing.T) {
 	assert := assert.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
-	cfg := newCoordinatorConfig()
-	defer cfg.cleanup()
-	assert.Nil(startCoordinator(cfg).Kill())
+	cfg := framework.NewCoordinatorConfig()
+	defer cfg.Cleanup()
+	assert.Nil(f.StartCoordinator(cfg).Kill())
 
-	marbleCfg := newMarbleConfig(meshServerAddr, "testMarbleClient", "localhost")
-	defer marbleCfg.cleanup()
-	assert.False(startMarbleClient(marbleCfg))
+	marbleCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleClient", "localhost")
+	defer marbleCfg.Cleanup()
+	assert.False(f.StartMarbleClient(marbleCfg))
 }
 
 func TestMarbleAPI(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	// start Coordinator
 	log.Println("Starting a coordinator enclave")
-	cfg := newCoordinatorConfig()
-	defer cfg.cleanup()
-	coordinatorProc := startCoordinator(cfg)
+	cfg := framework.NewCoordinatorConfig()
+	defer cfg.Cleanup()
+	coordinatorProc := f.StartCoordinator(cfg)
 	require.NotNil(coordinatorProc)
 	defer coordinatorProc.Kill()
 
 	// set Manifest
 	log.Println("Setting the Manifest")
-	_, err := setManifest(testManifest)
+	_, err := f.SetManifest(f.TestManifest)
 	require.NoError(err, "failed to set Manifest")
 
 	// start server
 	log.Println("Starting a Server-Marble...")
-	serverCfg := newMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
-	defer serverCfg.cleanup()
-	serverProc := startMarbleServer(serverCfg)
+	serverCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
+	defer serverCfg.Cleanup()
+	serverProc := f.StartMarbleServer(serverCfg)
 	require.NotNil(serverProc, "failed to start server-marble")
 	defer serverProc.Kill()
 
 	// start clients
 	log.Println("Starting a bunch of Client-Marbles...")
-	clientCfg := newMarbleConfig(meshServerAddr, "testMarbleClient", "client,frontend,localhost")
-	defer clientCfg.cleanup()
-	assert.True(startMarbleClient(clientCfg))
-	assert.True(startMarbleClient(clientCfg))
+	clientCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleClient", "client,frontend,localhost")
+	defer clientCfg.Cleanup()
+	assert.True(f.StartMarbleClient(clientCfg))
+	assert.True(f.StartMarbleClient(clientCfg))
 	if !*simulationMode && !*noenclave {
 		// start bad marbles (would be accepted if we run in SimulationMode)
-		badCfg := newMarbleConfig(meshServerAddr, "badMarble", "bad,localhost")
-		defer badCfg.cleanup()
-		assert.False(startMarbleClient(badCfg))
-		assert.False(startMarbleClient(badCfg))
+		badCfg := framework.NewMarbleConfig(meshServerAddr, "badMarble", "bad,localhost")
+		defer badCfg.Cleanup()
+		assert.False(f.StartMarbleClient(badCfg))
+		assert.False(f.StartMarbleClient(badCfg))
 	}
 }
 
 func TestRestart(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	log.Println("Testing the restart capabilities")
 	// start Coordinator
 	log.Println("Starting a coordinator enclave...")
-	cfg := newCoordinatorConfig()
-	defer cfg.cleanup()
-	coordinatorProc := startCoordinator(cfg)
+	cfg := framework.NewCoordinatorConfig()
+	defer cfg.Cleanup()
+	coordinatorProc := f.StartCoordinator(cfg)
 	require.NotNil(coordinatorProc)
 
 	// set Manifest
-	_, err := setManifest(testManifest)
+	_, err := f.SetManifest(f.TestManifest)
 	require.NoError(err, "failed to set Manifest")
 
 	// start server
 	log.Println("Starting a Server-Marble...")
-	serverCfg := newMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
-	defer serverCfg.cleanup()
-	serverProc := startMarbleServer(serverCfg)
+	serverCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
+	defer serverCfg.Cleanup()
+	serverProc := f.StartMarbleServer(serverCfg)
 	require.NotNil(serverProc, "failed to start server-marble")
 	defer serverProc.Kill()
 
 	// start clients
 	log.Println("Starting a bunch of Client-Marbles...")
-	clientCfg := newMarbleConfig(meshServerAddr, "testMarbleClient", "client,frontend,localhost")
-	defer clientCfg.cleanup()
-	assert.True(startMarbleClient(clientCfg))
-	assert.True(startMarbleClient(clientCfg))
+	clientCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleClient", "client,frontend,localhost")
+	defer clientCfg.Cleanup()
+	assert.True(f.StartMarbleClient(clientCfg))
+	assert.True(f.StartMarbleClient(clientCfg))
 
 	// simulate restart of coordinator
 	log.Println("Simulating a restart of the coordinator enclave...")
 	log.Println("Killing the old instance")
 	require.NoError(coordinatorProc.Kill())
 	log.Println("Restarting the old instance")
-	coordinatorProc = startCoordinator(cfg)
+	coordinatorProc = f.StartCoordinator(cfg)
 	require.NotNil(coordinatorProc)
 	defer coordinatorProc.Kill()
 
 	// try do malicious update of manifest
 	log.Println("Trying to set a new Manifest, which should already be set")
-	_, err = setManifest(testManifest)
+	_, err = f.SetManifest(f.TestManifest)
 	assert.Error(err, "expected updating of manifest to fail, but succeeded")
 
 	// start a bunch of client marbles and assert they still work with old server marble
 	log.Println("Starting a bunch of Client-Marbles, which should still authenticate successfully with the Server-Marble...")
-	assert.True(startMarbleClient(clientCfg))
-	assert.True(startMarbleClient(clientCfg))
+	assert.True(f.StartMarbleClient(clientCfg))
+	assert.True(f.StartMarbleClient(clientCfg))
 }
 
 func TestClientAPI(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	// start Coordinator
-	cfg := newCoordinatorConfig()
-	defer cfg.cleanup()
-	coordinatorProc := startCoordinator(cfg)
+	cfg := framework.NewCoordinatorConfig()
+	defer cfg.Cleanup()
+	coordinatorProc := f.StartCoordinator(cfg)
 	require.NotNil(coordinatorProc, "could not start coordinator")
 	defer coordinatorProc.Kill()
 
@@ -263,7 +225,7 @@ func TestClientAPI(t *testing.T) {
 	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureRootECDSA":null,"ManifestSignature":"","Manifest":null}}`, string(manifest))
 
 	log.Println("Setting the Manifest")
-	_, err = setManifest(testManifest)
+	_, err = f.SetManifest(f.TestManifest)
 	require.NoError(err, "failed to set Manifest")
 
 	// test reading of secrets
@@ -282,16 +244,18 @@ func TestClientAPI(t *testing.T) {
 func TestSettingSecrets(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	// start Coordinator
-	cfg := newCoordinatorConfig()
-	defer cfg.cleanup()
-	coordinatorProc := startCoordinator(cfg)
+	cfg := framework.NewCoordinatorConfig()
+	defer cfg.Cleanup()
+	coordinatorProc := f.StartCoordinator(cfg)
 	require.NotNil(coordinatorProc, "could not start coordinator")
 	defer coordinatorProc.Kill()
 
 	log.Println("Setting the Manifest")
-	_, err := setManifest(testManifest)
+	_, err := f.SetManifest(f.TestManifest)
 	require.NoError(err, "failed to set Manifest")
 
 	// create client with certificates
@@ -306,17 +270,17 @@ func TestSettingSecrets(t *testing.T) {
 
 	// start server
 	log.Println("Starting a Server-Marble...")
-	serverCfg := newMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
-	defer serverCfg.cleanup()
-	serverProc := startMarbleServer(serverCfg)
+	serverCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
+	defer serverCfg.Cleanup()
+	serverProc := f.StartMarbleServer(serverCfg)
 	require.NotNil(serverProc, "failed to start server-marble")
 	defer serverProc.Kill()
 
 	// start a marble
 	log.Println("Starting a Client-Marble with unset secret, this should fail...")
-	clientCfg := newMarbleConfig(meshServerAddr, "testMarbleUnset", "client,frontend,localhost")
-	defer clientCfg.cleanup()
-	assert.False(startMarbleClient(clientCfg))
+	clientCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleUnset", "client,frontend,localhost")
+	defer clientCfg.Cleanup()
+	assert.False(f.StartMarbleClient(clientCfg))
 
 	// test setting a secret
 	log.Println("Setting a custom secret")
@@ -326,19 +290,21 @@ func TestSettingSecrets(t *testing.T) {
 
 	// start the marble again
 	log.Println("Starting the Client-Marble again, with the secret now set...")
-	assert.True(startMarbleClient(clientCfg))
+	assert.True(f.StartMarbleClient(clientCfg))
 }
 
 func TestRecoveryRestoreKey(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	log.Println("Testing recovery...")
 
 	// Trigger recovery mode
-	recoveryResponse, coordinatorProc, serverProc, cfg, serverCfg, cert := triggerRecovery(testManifest, assert, require)
-	defer cfg.cleanup()
-	defer serverCfg.cleanup()
+	recoveryResponse, coordinatorProc, serverProc, cfg, serverCfg, cert := f.TriggerRecovery(f.TestManifest)
+	defer cfg.Cleanup()
+	defer serverCfg.Cleanup()
 	defer serverProc.Kill()
 	defer coordinatorProc.Kill()
 
@@ -350,37 +316,38 @@ func TestRecoveryRestoreKey(t *testing.T) {
 	require.NoError(err, "Failed to RSA OAEP decrypt the recovery data.")
 
 	// Perform recovery
-	require.NoError(setRecover(recoveryKey))
+	require.NoError(f.SetRecover(recoveryKey))
 	log.Println("Performed recovery, now checking status again...")
-	statusResponse, err := getStatus()
+	statusResponse, err := f.GetStatus()
 	require.NoError(err)
 	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
 
 	// Verify if old certificate is still valid
-	coordinatorProc = verifyCertAfterRecovery(cert, coordinatorProc, cfg, assert, require)
+	coordinatorProc = f.VerifyCertAfterRecovery(cert, coordinatorProc, cfg, assert, require)
 	require.NoError(coordinatorProc.Kill())
 }
 
 func TestRecoveryReset(t *testing.T) {
-	assert := assert.New(t)
 	require := require.New(t)
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	log.Println("Testing recovery...")
 
 	// Trigger recovery mode
-	_, coordinatorProc, serverProc, cfg, serverCfg, _ := triggerRecovery(testManifest, assert, require)
-	defer cfg.cleanup()
-	defer serverCfg.cleanup()
+	_, coordinatorProc, serverProc, cfg, serverCfg, _ := f.TriggerRecovery(f.TestManifest)
+	defer cfg.Cleanup()
+	defer serverCfg.Cleanup()
 	defer serverProc.Kill()
 	defer coordinatorProc.Kill()
 
 	// Set manifest again
 	log.Println("Setting the Manifest")
-	_, err := setManifest(testManifest)
+	_, err := f.SetManifest(f.TestManifest)
 	require.NoError(err, "failed to set Manifest")
 
 	// Verify if a new manifest has been set correctly and we are off to a fresh start
-	coordinatorProc = verifyResetAfterRecovery(coordinatorProc, cfg, assert, require)
+	coordinatorProc = f.VerifyResetAfterRecovery(coordinatorProc, cfg)
 	require.NoError(coordinatorProc.Kill())
 }
 
@@ -390,467 +357,52 @@ func TestManifestUpdate(t *testing.T) {
 		t.Skip("This test cannot be run in Simulation / No Enclave mode.")
 		return
 	}
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
 
 	assert := assert.New(t)
 	require := require.New(t)
 
 	// start Coordinator
 	log.Println("Starting a coordinator enclave")
-	cfg := newCoordinatorConfig()
-	defer cfg.cleanup()
-	coordinatorProc := startCoordinator(cfg)
+	cfg := framework.NewCoordinatorConfig()
+	defer cfg.Cleanup()
+	coordinatorProc := f.StartCoordinator(cfg)
 	require.NotNil(coordinatorProc)
 	defer coordinatorProc.Kill()
 
 	// set Manifest
 	log.Println("Setting the Manifest")
-	_, err := setManifest(testManifest)
+	_, err := f.SetManifest(f.TestManifest)
 	require.NoError(err, "failed to set Manifest")
 
 	// start server
 	log.Println("Starting a Server-Marble")
-	serverCfg := newMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
-	defer serverCfg.cleanup()
-	serverProc := startMarbleServer(serverCfg)
+	serverCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
+	defer serverCfg.Cleanup()
+	serverProc := f.StartMarbleServer(serverCfg)
 	require.NotNil(serverProc, "failed to start server-marble")
 	defer serverProc.Kill()
 
 	// start clients
 	log.Println("Starting a bunch of Client-Marbles (should start successfully)...")
-	clientCfg := newMarbleConfig(meshServerAddr, "testMarbleClient", "client,frontend,localhost")
-	defer clientCfg.cleanup()
-	assert.True(startMarbleClient(clientCfg))
-	assert.True(startMarbleClient(clientCfg))
+	clientCfg := framework.NewMarbleConfig(meshServerAddr, "testMarbleClient", "client,frontend,localhost")
+	defer clientCfg.Cleanup()
+	assert.True(f.StartMarbleClient(clientCfg))
+	assert.True(f.StartMarbleClient(clientCfg))
 	// start bad marbles (would be accepted if we run in SimulationMode)
-	badCfg := newMarbleConfig(meshServerAddr, "badMarble", "bad,localhost")
-	defer badCfg.cleanup()
-	assert.False(startMarbleClient(badCfg))
-	assert.False(startMarbleClient(badCfg))
+	badCfg := framework.NewMarbleConfig(meshServerAddr, "badMarble", "bad,localhost")
+	defer badCfg.Cleanup()
+	assert.False(f.StartMarbleClient(badCfg))
+	assert.False(f.StartMarbleClient(badCfg))
 
 	// Set the update manifest
 	log.Println("Setting the Update Manifest")
-	_, err = setUpdateManifest(updatedManifest)
+	_, err = f.SetUpdateManifest(f.UpdatedManifest, AdminCert, RecoveryPrivateKey)
 	require.NoError(err, "failed to set Update Manifest")
 
 	// Try to start marbles again, should fail now due to increased minimum SecurityVersion
 	log.Println("Starting the same bunch of outdated Client-Marbles again (should fail now)...")
-	assert.False(startMarbleClient(clientCfg), "Did start successfully, but must not run successfully. The increased minimum SecurityVersion was ignored.")
-	assert.False(startMarbleClient(clientCfg), "Did start successfully, but must not run successfully. The increased minimum SecurityVersion was ignored.")
-}
-
-type coordinatorConfig struct {
-	dnsNames string
-	sealDir  string
-}
-
-func newCoordinatorConfig() coordinatorConfig {
-	sealDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	return coordinatorConfig{dnsNames: "localhost", sealDir: sealDir}
-}
-
-func (c coordinatorConfig) cleanup() {
-	if err := os.RemoveAll(c.sealDir); err != nil {
-		panic(err)
-	}
-}
-
-func makeEnv(key, value string) string {
-	return fmt.Sprintf("%v=%v", key, value)
-}
-
-func startCoordinator(cfg coordinatorConfig) *os.Process {
-	var cmd *exec.Cmd
-	if *noenclave {
-		cmd = exec.Command(filepath.Join(*buildDir, "coordinator-noenclave"))
-	} else {
-		cmd = exec.Command("erthost", filepath.Join(*buildDir, "coordinator-enclave.signed"))
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL} // kill if parent dies
-	cmd.Env = []string{
-		makeEnv(constants.MeshAddr, meshServerAddr),
-		makeEnv(constants.ClientAddr, clientServerAddr),
-		makeEnv(constants.DNSNames, cfg.dnsNames),
-		makeEnv(constants.SealDir, cfg.sealDir),
-		simFlag,
-	}
-	output := startCommand(cmd)
-
-	client := http.Client{Transport: transportSkipVerify}
-	url := url.URL{Scheme: "https", Host: clientServerAddr, Path: "status"}
-
-	log.Println("Coordinator starting...")
-	for {
-		time.Sleep(10 * time.Millisecond)
-		select {
-		case out := <-output:
-			// process died
-			log.Println(out)
-			return nil
-		default:
-		}
-		resp, err := client.Get(url.String())
-		if err == nil {
-			log.Println("Coordinator started")
-			resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				panic(resp.Status)
-			}
-			return cmd.Process
-		}
-	}
-}
-
-func startCommand(cmd *exec.Cmd) chan string {
-	output := make(chan string)
-	go func() {
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			if _, ok := err.(*exec.ExitError); !ok {
-				output <- err.Error()
-				return
-			}
-		}
-		output <- string(out)
-	}()
-	return output
-}
-
-func setManifest(manifest manifest.Manifest) ([]byte, error) {
-	// Use ClientAPI to set Manifest
-	client := http.Client{Transport: transportSkipVerify}
-	clientAPIURL := url.URL{
-		Scheme: "https",
-		Host:   clientServerAddr,
-		Path:   "manifest",
-	}
-
-	manifestRaw, err := json.Marshal(manifest)
-	if err != nil {
-		panic(err)
-	}
-
-	resp, err := client.Post(clientAPIURL.String(), "application/json", bytes.NewReader(manifestRaw))
-	if err != nil {
-		panic(err)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expected %v, but /manifest returned %v: %v", http.StatusOK, resp.Status, string(body))
-	}
-
-	return body, nil
-}
-
-func setUpdateManifest(manifest manifest.Manifest) ([]byte, error) {
-	// Setup requied client certificate for authentication
-	privk, err := x509.MarshalPKCS8PrivateKey(RecoveryPrivateKey)
-	if err != nil {
-		panic(err)
-	}
-	cert, err := tls.X509KeyPair(AdminCert, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privk}))
-	if err != nil {
-		panic(err)
-	}
-
-	tlsConfig := &tls.Config{
-		Certificates:       []tls.Certificate{cert},
-		InsecureSkipVerify: true,
-	}
-
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
-
-	// Use ClientAPI to set Manifest
-	client := http.Client{Transport: transport}
-	clientAPIURL := url.URL{
-		Scheme: "https",
-		Host:   clientServerAddr,
-		Path:   "update",
-	}
-
-	manifestRaw, err := json.Marshal(manifest)
-	if err != nil {
-		panic(err)
-	}
-
-	resp, err := client.Post(clientAPIURL.String(), "application/json", bytes.NewReader(manifestRaw))
-	if err != nil {
-		panic(err)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expected %v, but /manifest returned %v: %v", http.StatusOK, resp.Status, string(body))
-	}
-
-	return body, nil
-}
-
-func setRecover(recoveryKey []byte) error {
-	client := http.Client{Transport: transportSkipVerify}
-	clientAPIURL := url.URL{
-		Scheme: "https",
-		Host:   clientServerAddr,
-		Path:   "recover",
-	}
-
-	resp, err := client.Post(clientAPIURL.String(), "application/octet-stream", bytes.NewReader(recoveryKey))
-	if err != nil {
-		panic(err)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("expected %v, but /recover returned %v: %v", http.StatusOK, resp.Status, string(body))
-	}
-
-	return nil
-}
-
-func getStatus() (string, error) {
-	client := http.Client{Transport: transportSkipVerify}
-	clientAPIURL := url.URL{
-		Scheme: "https",
-		Host:   clientServerAddr,
-		Path:   "status",
-	}
-
-	resp, err := client.Get(clientAPIURL.String())
-	if err != nil {
-		panic(err)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("expected %v, but /status returned %v: %v", http.StatusOK, resp.Status, string(body))
-	}
-
-	return string(body), nil
-}
-
-type marbleConfig struct {
-	coordinatorAddr string
-	marbleType      string
-	dnsNames        string
-	dataDir         string
-}
-
-func newMarbleConfig(coordinatorAddr, marbleType, dnsNames string) marbleConfig {
-	dataDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	return marbleConfig{
-		coordinatorAddr: coordinatorAddr,
-		marbleType:      marbleType,
-		dnsNames:        dnsNames,
-		dataDir:         dataDir,
-	}
-}
-
-func (c marbleConfig) cleanup() {
-	if err := os.RemoveAll(c.dataDir); err != nil {
-		panic(err)
-	}
-}
-
-func getMarbleCmd(cfg marbleConfig) *exec.Cmd {
-	var cmd *exec.Cmd
-	if *noenclave {
-		cmd = exec.Command(filepath.Join(*buildDir, "marble-test-noenclave"))
-	} else {
-		cmd = exec.Command("erthost", filepath.Join(*buildDir, "marble-test-enclave.signed"))
-	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL} // kill if parent dies
-	uuidFile := filepath.Join(cfg.dataDir, "uuid")
-	cmd.Env = []string{
-		makeEnv(mconfig.CoordinatorAddr, cfg.coordinatorAddr),
-		makeEnv(mconfig.Type, cfg.marbleType),
-		makeEnv(mconfig.DNSNames, cfg.dnsNames),
-		makeEnv(mconfig.UUIDFile, uuidFile),
-		makeEnv("EDG_TEST_ADDR", marbleTestAddr),
-		simFlag,
-	}
-	return cmd
-}
-
-func startMarbleServer(cfg marbleConfig) *os.Process {
-	cmd := getMarbleCmd(cfg)
-	output := startCommand(cmd)
-
-	log.Println("Waiting for server...")
-	timeout := time.Second * 5
-	for {
-		time.Sleep(100 * time.Millisecond)
-		select {
-		case out := <-output:
-			// process died
-			log.Println(out)
-			return nil
-		default:
-		}
-		conn, err := net.DialTimeout("tcp", marbleTestAddr, timeout)
-		if err == nil {
-			conn.Close()
-			log.Println("Server started")
-			return cmd.Process
-		}
-	}
-}
-
-func startMarbleClient(cfg marbleConfig) bool {
-	out, err := getMarbleCmd(cfg).CombinedOutput()
-	if err == nil {
-		return true
-	}
-
-	if _, ok := err.(*exec.ExitError); ok {
-		return false
-	}
-
-	panic(err.Error() + "\n" + string(out))
-}
-
-func triggerRecovery(manifest manifest.Manifest, assert *assert.Assertions, require *require.Assertions) ([]byte, *os.Process, *os.Process, coordinatorConfig, marbleConfig, string) {
-	// start Coordinator
-	log.Println("Starting a coordinator enclave")
-	cfg := newCoordinatorConfig()
-	coordinatorProc := startCoordinator(cfg)
-	require.NotNil(coordinatorProc)
-
-	// set Manifest
-	log.Println("Setting the Manifest")
-	recoveryResponse, err := setManifest(manifest)
-	require.NoError(err, "failed to set Manifest")
-
-	// start server
-	log.Println("Starting a Server-Marble")
-	serverCfg := newMarbleConfig(meshServerAddr, "testMarbleServer", "server,backend,localhost")
-	serverProc := startMarbleServer(serverCfg)
-	require.NotNil(serverProc, "failed to start server-marble")
-
-	// get certificate
-	log.Println("Save certificate before we try to recover.")
-	client := http.Client{Transport: transportSkipVerify}
-	clientAPIURL := url.URL{Scheme: "https", Host: clientServerAddr, Path: "quote"}
-	resp, err := client.Get(clientAPIURL.String())
-	require.NoError(err)
-	require.Equal(http.StatusOK, resp.StatusCode)
-	quote, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	require.NoError(err)
-	cert := gjson.GetBytes(quote, "data.Cert").String()
-	require.NotEmpty(cert)
-
-	// simulate restart of coordinator
-	log.Println("Simulating a restart of the coordinator enclave...")
-	log.Println("Killing the old instance")
-	require.NoError(coordinatorProc.Kill())
-
-	// Garble encryption key to trigger recovery state
-	log.Println("Purposely corrupt sealed key to trigger recovery state...")
-	pathToKeyFile := filepath.Join(cfg.sealDir, seal.SealedKeyFname)
-	sealedKeyData, err := ioutil.ReadFile(pathToKeyFile)
-	require.NoError(err)
-	sealedKeyData[0] ^= byte(0x42)
-	require.NoError(ioutil.WriteFile(pathToKeyFile, sealedKeyData, 0o600))
-
-	// Restart server, we should be in recovery mode
-	log.Println("Restarting the old instance")
-	coordinatorProc = startCoordinator(cfg)
-	require.NotNil(coordinatorProc)
-
-	// Query status API, check if status response begins with Code 1 (recovery state)
-	log.Println("Checking status...")
-	statusResponse, err := getStatus()
-	require.NoError(err)
-	assert.EqualValues(1, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is not in recovery state, but should be.")
-
-	return recoveryResponse, coordinatorProc, serverProc, cfg, serverCfg, cert
-}
-
-func verifyCertAfterRecovery(cert string, coordinatorProc *os.Process, cfg coordinatorConfig, assert *assert.Assertions, require *require.Assertions) *os.Process {
-	// Test with certificate
-	log.Println("Verifying certificate after recovery, without a restart.")
-	pool := x509.NewCertPool()
-	require.True(pool.AppendCertsFromPEM([]byte(cert)))
-	client := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
-	clientAPIURL := url.URL{Scheme: "https", Host: clientServerAddr, Path: "status"}
-	resp, err := client.Get(clientAPIURL.String())
-	require.NoError(err)
-	resp.Body.Close()
-	require.Equal(http.StatusOK, resp.StatusCode)
-
-	// Simulate restart of coordinator
-	log.Println("Simulating a restart of the coordinator enclave...")
-	log.Println("Killing the old instance")
-	require.NoError(coordinatorProc.Kill())
-
-	// Restart server, we should be in recovery mode
-	log.Println("Restarting the old instance")
-	coordinatorProc = startCoordinator(cfg)
-	require.NotNil(coordinatorProc)
-
-	// Finally, check if we survive a restart.
-	log.Println("Restarted instance, now let's see if the state can be restored again successfully.")
-	statusResponse, err := getStatus()
-	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
-
-	// test with certificate
-	log.Println("Verifying certificate after restart.")
-	resp, err = client.Get(clientAPIURL.String())
-	require.NoError(err)
-	resp.Body.Close()
-	require.Equal(http.StatusOK, resp.StatusCode)
-
-	return coordinatorProc
-}
-
-func verifyResetAfterRecovery(coordinatorProc *os.Process, cfg coordinatorConfig, assert *assert.Assertions, require *require.Assertions) *os.Process {
-	// Check status after setting a new manifest, we should be able
-	log.Println("Check if the manifest was accepted and we are ready to accept Marbles")
-	statusResponse, err := getStatus()
-	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
-
-	// simulate restart of coordinator
-	log.Println("Simulating a restart of the coordinator enclave...")
-	log.Println("Killing the old instance")
-	require.NoError(coordinatorProc.Kill())
-
-	// Restart server, we should be in recovery mode
-	log.Println("Restarting the old instance")
-	coordinatorProc = startCoordinator(cfg)
-	require.NotNil(coordinatorProc)
-
-	// Finally, check if we survive a restart.
-	log.Println("Restarted instance, now let's see if the new state can be decrypted successfully...")
-	statusResponse, err = getStatus()
-	require.NoError(err)
-	assert.EqualValues(3, gjson.Get(statusResponse, "data.StatusCode").Int(), "Server is in wrong status after recovery.")
-
-	return coordinatorProc
+	assert.False(f.StartMarbleClient(clientCfg), "Did start successfully, but must not run successfully. The increased minimum SecurityVersion was ignored.")
+	assert.False(f.StartMarbleClient(clientCfg), "Did start successfully, but must not run successfully. The increased minimum SecurityVersion was ignored.")
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -70,8 +70,7 @@ func TestMain(m *testing.M) {
 // sanity test of the integration test environment
 func TestTest(t *testing.T) {
 	assert := assert.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	cfg := framework.NewCoordinatorConfig()
 	defer cfg.Cleanup()
@@ -85,8 +84,7 @@ func TestTest(t *testing.T) {
 func TestMarbleAPI(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	// start Coordinator
 	log.Println("Starting a coordinator enclave")
@@ -127,8 +125,7 @@ func TestMarbleAPI(t *testing.T) {
 func TestRestart(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	log.Println("Testing the restart capabilities")
 	// start Coordinator
@@ -180,8 +177,7 @@ func TestRestart(t *testing.T) {
 func TestClientAPI(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	// start Coordinator
 	cfg := framework.NewCoordinatorConfig()
@@ -244,8 +240,7 @@ func TestClientAPI(t *testing.T) {
 func TestSettingSecrets(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	// start Coordinator
 	cfg := framework.NewCoordinatorConfig()
@@ -296,8 +291,7 @@ func TestSettingSecrets(t *testing.T) {
 func TestRecoveryRestoreKey(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	log.Println("Testing recovery...")
 	log.Println("Starting a coordinator enclave")
@@ -345,8 +339,7 @@ func TestRecoveryRestoreKey(t *testing.T) {
 
 func TestRecoveryReset(t *testing.T) {
 	require := require.New(t)
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	log.Println("Testing recovery...")
 	log.Println("Starting a coordinator enclave")
@@ -389,8 +382,7 @@ func TestManifestUpdate(t *testing.T) {
 		t.Skip("This test cannot be run in Simulation / No Enclave mode.")
 		return
 	}
-	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
-	f.UpdateManifest()
+	f := newFramework(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -437,4 +429,10 @@ func TestManifestUpdate(t *testing.T) {
 	log.Println("Starting the same bunch of outdated Client-Marbles again (should fail now)...")
 	assert.False(f.StartMarbleClient(clientCfg), "Did start successfully, but must not run successfully. The increased minimum SecurityVersion was ignored.")
 	assert.False(f.StartMarbleClient(clientCfg), "Did start successfully, but must not run successfully. The increased minimum SecurityVersion was ignored.")
+}
+
+func newFramework(t *testing.T) *framework.IntegrationTest {
+	f := framework.New(t, *buildDir, simFlag, *noenclave, marbleTestAddr, meshServerAddr, clientServerAddr, IntegrationManifestJSON, UpdateManifest)
+	f.UpdateManifest()
+	return f
 }


### PR DESCRIPTION
### Proposed changes
- Refactor the integration test to use a framework like approach
  - This allows reuse of the old integration test functions like starting the Coordinator, setting a manifest etc., without having to directly add new functions to `test/integration_test.go`
 
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
