### PR TITLE
Allow TCB levels to be accepted besides UpToDate

### DIFF
--- a/cli/cmd/certificate.go
+++ b/cli/cmd/certificate.go
@@ -19,6 +19,7 @@ func newCertificateCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&eraConfig, "era-config", "", "Path to remote attestation config file in json format, if none provided the newest configuration will be loaded from github")
 	cmd.PersistentFlags().BoolVarP(&insecureEra, "insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
+	cmd.PersistentFlags().StringSliceVar(&acceptedTCBStatuses, "accepted-tcb-statuses", []string{"UpToDate"}, "Coma seperated list of user accepted TCB statuses (e.g. ConfigurationNeeded,ConfigurationAndSWHardeningNeeded)")
 	cmd.AddCommand(newCertificateRoot())
 	cmd.AddCommand(newCertificateIntermediate())
 	cmd.AddCommand(newCertificateChain())

--- a/cli/cmd/certificateChain.go
+++ b/cli/cmd/certificateChain.go
@@ -24,7 +24,7 @@ func newCertificateChain() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			return cliCertificateChain(hostName, certFilename, eraConfig, insecureEra)
+			return cliCertificateChain(hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
 		},
 		SilenceUsage: true,
 	}
@@ -35,8 +35,8 @@ func newCertificateChain() *cobra.Command {
 }
 
 // cliCertificateChain gets the certificate chain of the MarbleRun Coordinator.
-func cliCertificateChain(host string, output string, configFilename string, insecure bool) error {
-	certs, err := verifyCoordinator(host, configFilename, insecure)
+func cliCertificateChain(host string, output string, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
+	certs, err := verifyCoordinator(host, configFilename, insecure, acceptedTCBStatuses)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/certificateIntermediate.go
+++ b/cli/cmd/certificateIntermediate.go
@@ -24,7 +24,7 @@ func newCertificateIntermediate() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			return cliCertificateIntermediate(hostName, certFilename, eraConfig, insecureEra)
+			return cliCertificateIntermediate(hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
 		},
 		SilenceUsage: true,
 	}
@@ -35,8 +35,8 @@ func newCertificateIntermediate() *cobra.Command {
 }
 
 // cliCertificateIntermediate gets the intermediate certificate of the MarbleRun Coordinator.
-func cliCertificateIntermediate(host string, output string, configFilename string, insecure bool) error {
-	certs, err := verifyCoordinator(host, configFilename, insecure)
+func cliCertificateIntermediate(host string, output string, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
+	certs, err := verifyCoordinator(host, configFilename, insecure, acceptedTCBStatuses)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/certificateRoot.go
+++ b/cli/cmd/certificateRoot.go
@@ -24,7 +24,7 @@ func newCertificateRoot() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			return cliCertificateRoot(hostName, certFilename, eraConfig, insecureEra)
+			return cliCertificateRoot(hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
 		},
 		SilenceUsage: true,
 	}
@@ -35,9 +35,9 @@ func newCertificateRoot() *cobra.Command {
 }
 
 // cliCertificateRoot gets the root certificate of the MarbleRun Coordinator and saves it to a file.
-func cliCertificateRoot(host string, output string, configFilename string, insecure bool) error {
+func cliCertificateRoot(host string, output string, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
 	var certs []*pem.Block
-	certs, err := verifyCoordinator(host, configFilename, insecure)
+	certs, err := verifyCoordinator(host, configFilename, insecure, acceptedTCBStatuses)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/manifest.go
+++ b/cli/cmd/manifest.go
@@ -31,6 +31,7 @@ or return a signature of the currently set manifest to the user`,
 
 	cmd.PersistentFlags().StringVar(&eraConfig, "era-config", "", "Path to remote attestation config file in json format, if none provided the newest configuration will be loaded from github")
 	cmd.PersistentFlags().BoolVarP(&insecureEra, "insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
+	cmd.PersistentFlags().StringSliceVar(&acceptedTCBStatuses, "accepted-tcb-statuses", []string{"UpToDate"}, "Coma seperated list of user accepted TCB statuses (e.g. ConfigurationNeeded,ConfigurationAndSWHardeningNeeded)")
 	cmd.AddCommand(newManifestGet())
 	cmd.AddCommand(newManifestLog())
 	cmd.AddCommand(newManifestSet())

--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -31,7 +31,7 @@ Optionally get the manifests signature or merge updates into the displayed manif
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/manifestLog.go
+++ b/cli/cmd/manifestLog.go
@@ -25,7 +25,7 @@ func newManifestLog() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/manifestSet.go
+++ b/cli/cmd/manifestSet.go
@@ -32,7 +32,7 @@ func newManifestSet() *cobra.Command {
 			manifestFile := args[0]
 			hostName := args[1]
 
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/manifestUpdate.go
+++ b/cli/cmd/manifestUpdate.go
@@ -35,7 +35,7 @@ An admin certificate specified in the original manifest is needed to verify the 
 			manifestFile := args[0]
 			hostName := args[1]
 
-			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/manifestVerify.go
+++ b/cli/cmd/manifestVerify.go
@@ -27,7 +27,7 @@ func newManifestVerify() *cobra.Command {
 			manifest := args[0]
 			hostName := args[1]
 
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -28,7 +28,7 @@ func newRecoverCmd() *cobra.Command {
 			keyFile := args[0]
 			hostName := args[1]
 
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}
@@ -48,6 +48,7 @@ func newRecoverCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&eraConfig, "era-config", "", "Path to remote attestation config file in json format, if none provided the newest configuration will be loaded from github")
 	cmd.Flags().BoolVarP(&insecureEra, "insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
+	cmd.PersistentFlags().StringSliceVar(&acceptedTCBStatuses, "accepted-tcb-statuses", []string{"UpToDate"}, "Coma seperated list of user accepted TCB statuses (e.g. ConfigurationNeeded,ConfigurationAndSWHardeningNeeded)")
 
 	return cmd
 }

--- a/cli/cmd/secret.go
+++ b/cli/cmd/secret.go
@@ -28,6 +28,7 @@ Set or retrieve a secret defined in the manifest.`,
 	cmd.PersistentFlags().StringVarP(&userCertFile, "cert", "c", "", "PEM encoded MarbleRun user certificate file (required)")
 	cmd.PersistentFlags().StringVarP(&userKeyFile, "key", "k", "", "PEM encoded MarbleRun user key file (required)")
 	cmd.PersistentFlags().BoolVarP(&insecureEra, "insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
+	cmd.PersistentFlags().StringSliceVar(&acceptedTCBStatuses, "accepted-tcb-statuses", []string{"UpToDate"}, "Coma seperated list of user accepted TCB statuses (e.g. ConfigurationNeeded,ConfigurationAndSWHardeningNeeded)")
 	cmd.MarkPersistentFlagRequired("key")
 	cmd.MarkPersistentFlagRequired("cert")
 	cmd.AddCommand(newSecretSet())

--- a/cli/cmd/secretGet.go
+++ b/cli/cmd/secretGet.go
@@ -41,7 +41,7 @@ and need permissions in the manifest to read the requested secrets.
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[len(args)-1]
-			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/secretSet.go
+++ b/cli/cmd/secretSet.go
@@ -42,7 +42,7 @@ and need permissions in the manifest to write the requested secrets.
 			secretFile := args[0]
 			hostName := args[1]
 
-			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra)
+			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -48,7 +48,7 @@ func newStatusCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := args[0]
-			cert, err := verifyCoordinator(hostname, eraConfig, insecureEra)
+			cert, err := verifyCoordinator(hostname, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}
@@ -59,6 +59,7 @@ func newStatusCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&eraConfig, "era-config", "", "Path to remote attestation config file in json format, if none provided the newest configuration will be loaded from github")
 	cmd.Flags().BoolVarP(&insecureEra, "insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
+	cmd.PersistentFlags().StringSliceVar(&acceptedTCBStatuses, "accepted-tcb-statuses", []string{"UpToDate"}, "Coma seperated list of user accepted TCB statuses (e.g. ConfigurationNeeded,ConfigurationAndSWHardeningNeeded)")
 
 	return cmd
 }

--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -493,11 +493,12 @@ func (a *ClientAPI) UpdateManifest(rawUpdateManifest []byte, updater *user.User)
 		if currentPackages[pkgName].SecurityVersion == nil {
 			currentPkg := currentPackages[pkgName]
 			currentPackages[pkgName] = quote.PackageProperties{
-				Debug:           currentPkg.Debug,
-				UniqueID:        currentPkg.UniqueID,
-				SecurityVersion: pkg.SecurityVersion,
-				ProductID:       currentPkg.ProductID,
-				SignerID:        currentPkg.SignerID,
+				Debug:               currentPkg.Debug,
+				UniqueID:            currentPkg.UniqueID,
+				SecurityVersion:     pkg.SecurityVersion,
+				ProductID:           currentPkg.ProductID,
+				SignerID:            currentPkg.SignerID,
+				AcceptedTCBStatuses: currentPkg.AcceptedTCBStatuses,
 			}
 		} else {
 			*currentPackages[pkgName].SecurityVersion = *pkg.SecurityVersion

--- a/coordinator/quote/ert.go
+++ b/coordinator/quote/ert.go
@@ -26,6 +26,8 @@ type PackageProperties struct {
 	ProductID *uint64
 	// Security version number of the package.
 	SecurityVersion *uint
+	// Accepted TCB levels
+	AcceptedTCBStatuses []string
 }
 
 // InfrastructureProperties contains the infrastructure-specific properties of a SGX DCAP quote.


### PR DESCRIPTION
### Proposed changes
This PR aims to give users the ability to accept different TCB levels. This can be useful in cases where the grace period has ended but for some reason (e.g. the BIOS update has not been relased yet) SWHardening could not take place.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
Currently a user needs to set **both** the command line flags and in the manifest as well. The command line flag was necessary for me as I could not find a way to extract the manifest values and inject them to the call site without major refactoring. Could you please give me some hints regarding this?

I was unable to run E2E tests via Kubernetes deployment because it seemed to me that some package (ego? era? not sure) were using the upstream version instead of my patched branch (I was using the provided Dockerfile in redis-gramine). This is likely a fault on my side, but wanted to mention it nevertheless. I would appreciate it if you could run E2E on it before merging.



