### PR TITLE
Fix check-license workflow for external PRs

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -18,8 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
-        with:
-          ref: ${{ github.head_ref }}
+        uses: actions/checkout@v3
+
       - name: Check for files without license header
         run: "! grep -rL --include='*.go' -e'// Copyright (c) Edgeless Systems GmbH.' -e'DO NOT EDIT' | grep ''"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *.pem
 *.test
 marblerun-coordinator-data/
+debug/


### PR DESCRIPTION

### Proposed changes
- Don't use ref when performing checkout in license check workflow
  - We don't do this for any other workflow
  - This seems to break the workflow for external contributions

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
