### PR TITLE
Fix default configuration and acceptedTCBStatuses

### DIFF
--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -110,7 +110,11 @@ func verifyCoordinator(host string, configFilename string, insecure bool, accept
 		return nil, err
 	}
 
-	pemBlock, _, err := era.GetCertificate(host, eraDefaultConfig)
+	pemBlock, tcbStatus, err := era.GetCertificate(host, eraDefaultConfig)
+	if errors.Is(err, attestation.ErrTCBLevelInvalid) && util.StringSliceContains(acceptedTCBStatuses, tcbStatus.String()) {
+		fmt.Println("Warning: TCB level invalid, but accepted by configuration")
+		return pemBlock, nil
+	}
 	return pemBlock, err
 }
 

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -95,22 +95,19 @@ func verifyCoordinator(host string, configFilename string, insecure bool, accept
 		return era.InsecureGetCertificate(host)
 	}
 
+	var configFile string
 	// get certificate using provided config
 	if configFilename != "" {
-		pemBlock, tcbStatus, err := era.GetCertificate(host, configFilename)
-		if errors.Is(err, attestation.ErrTCBLevelInvalid) && util.StringSliceContains(acceptedTCBStatuses, tcbStatus.String()) {
-			fmt.Println("Warning: TCB level invalid, but accepted by configuration")
-			return pemBlock, nil
+		configFile = configFilename
+	} else {
+		// get latest config from github if none specified
+		if err := fetchLatestCoordinatorConfiguration(); err != nil {
+			return nil, err
 		}
-		return pemBlock, err
+		configFile = eraDefaultConfig
 	}
 
-	// get latest config from github if none specified
-	if err := fetchLatestCoordinatorConfiguration(); err != nil {
-		return nil, err
-	}
-
-	pemBlock, tcbStatus, err := era.GetCertificate(host, eraDefaultConfig)
+	pemBlock, tcbStatus, err := era.GetCertificate(host, configFile)
 	if errors.Is(err, attestation.ErrTCBLevelInvalid) && util.StringSliceContains(acceptedTCBStatuses, tcbStatus.String()) {
 		fmt.Println("Warning: TCB level invalid, but accepted by configuration")
 		return pemBlock, nil

--- a/cli/cmd/util.go
+++ b/cli/cmd/util.go
@@ -95,19 +95,15 @@ func verifyCoordinator(host string, configFilename string, insecure bool, accept
 		return era.InsecureGetCertificate(host)
 	}
 
-	var configFile string
-	// get certificate using provided config
-	if configFilename != "" {
-		configFile = configFilename
-	} else {
+	if configFilename == "" {
 		// get latest config from github if none specified
 		if err := fetchLatestCoordinatorConfiguration(); err != nil {
 			return nil, err
 		}
-		configFile = eraDefaultConfig
+		configFilename = eraDefaultConfig
 	}
 
-	pemBlock, tcbStatus, err := era.GetCertificate(host, configFile)
+	pemBlock, tcbStatus, err := era.GetCertificate(host, configFilename)
 	if errors.Is(err, attestation.ErrTCBLevelInvalid) && util.StringSliceContains(acceptedTCBStatuses, tcbStatus.String()) {
 		fmt.Println("Warning: TCB level invalid, but accepted by configuration")
 		return pemBlock, nil


### PR DESCRIPTION
### Proposed changes
This PR fixes the case when a user does not supply the eraconfig explicitly but has the flag `accepted-tcb-statuses` set. This flag only worked if it was explicitly supplied.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
