### PR TITLE
Fix example gramine redis Dockerfile

### DIFF
--- a/samples/gramine-redis/Dockerfile
+++ b/samples/gramine-redis/Dockerfile
@@ -11,7 +11,6 @@ COPY --from=pull_marblerun /marblerun /premain
 WORKDIR /premain/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 RUN make premain-libos
-COPY ./premain-libos /premain/build/premain-libos
 
 FROM ubuntu:20.04
 RUN apt update && \

--- a/samples/gramine-redis/Dockerfile
+++ b/samples/gramine-redis/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && apt-get install -y \
     libsgx-quote-ex-dev \
     libsgx-aesm-launch-plugin \
     build-essential \
-    libssl-dev \
     libprotobuf-c-dev \
     gramine && \
     apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y


### PR DESCRIPTION
### Proposed changes
The `COPY ./premain-libos /premain/build/premain-libos` is not required as this artifact will be built by the previous command.
Also removed a duplicate package in the `apt-get install` step.
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
