### PR TITLE
Enforce unique certificates for users

### DIFF
--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -401,6 +401,7 @@ func (m Manifest) Check(zaplogger *zap.Logger) error {
 		}
 	}
 
+	uniqueUsers := make(map[string]string)
 	for userName, user := range m.Users {
 		if len(user.Certificate) <= 0 {
 			return fmt.Errorf("manifest does not contain a certificate for user %s", userName)
@@ -410,6 +411,12 @@ func (m Manifest) Check(zaplogger *zap.Logger) error {
 				return fmt.Errorf("manifest specifies role %s for user %s, but role does not exist", role, userName)
 			}
 		}
+
+		// Check if user certificate is unique
+		if otherUser, ok := uniqueUsers[user.Certificate]; ok {
+			return fmt.Errorf("manifest contains the same certificate for users %s and %s", userName, otherUser)
+		}
+		uniqueUsers[user.Certificate] = userName
 	}
 
 	for roleName, role := range m.Roles {

--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -261,13 +261,19 @@ func TestManifestCheck(t *testing.T) {
 	require := require.New(t)
 
 	var manifest Manifest
-	err := json.Unmarshal([]byte(test.ManifestJSON), &manifest)
+	err := json.Unmarshal([]byte(test.ManifestJSONWithRecoveryKey), &manifest)
 	require.NoError(err)
 
 	zap, err := zap.NewDevelopment()
 	require.NoError(err)
 	err = manifest.Check(zap)
 	assert.NoError(err)
+
+	manifest.Users["anotherUser"] = User{
+		Certificate: manifest.Users["admin"].Certificate,
+	}
+	err = manifest.Check(zap)
+	assert.Error(err)
 }
 
 func TestCertificate(t *testing.T) {


### PR DESCRIPTION
### Proposed changes
- Enforce unique certificates for all users when setting a manifest

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
