### PR TITLE
Reuse existing era config file

### DIFF
--- a/cli/cmd/certificateChain.go
+++ b/cli/cmd/certificateChain.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
@@ -24,7 +25,7 @@ func newCertificateChain() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			return cliCertificateChain(hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
+			return cliCertificateChain(cmd.OutOrStdout(), hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
 		},
 		SilenceUsage: true,
 	}
@@ -35,14 +36,14 @@ func newCertificateChain() *cobra.Command {
 }
 
 // cliCertificateChain gets the certificate chain of the MarbleRun Coordinator.
-func cliCertificateChain(host string, output string, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
-	certs, err := verifyCoordinator(host, configFilename, insecure, acceptedTCBStatuses)
+func cliCertificateChain(out io.Writer, host, output, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
+	certs, err := verifyCoordinator(out, host, configFilename, insecure, acceptedTCBStatuses)
 	if err != nil {
 		return err
 	}
 
 	if len(certs) == 1 {
-		fmt.Println("WARNING: Only received root certificate from host.")
+		fmt.Fprintln(out, "WARNING: Only received root certificate from host.")
 	}
 
 	var chain []byte
@@ -54,7 +55,7 @@ func cliCertificateChain(host string, output string, configFilename string, inse
 		return err
 	}
 
-	fmt.Println("Certificate chain written to", output)
+	fmt.Fprintln(out, "Certificate chain written to", output)
 
 	return nil
 }

--- a/cli/cmd/certificateIntermediate.go
+++ b/cli/cmd/certificateIntermediate.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
@@ -24,7 +25,7 @@ func newCertificateIntermediate() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			return cliCertificateIntermediate(hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
+			return cliCertificateIntermediate(cmd.OutOrStdout(), hostName, certFilename, eraConfig, insecureEra, acceptedTCBStatuses)
 		},
 		SilenceUsage: true,
 	}
@@ -35,8 +36,8 @@ func newCertificateIntermediate() *cobra.Command {
 }
 
 // cliCertificateIntermediate gets the intermediate certificate of the MarbleRun Coordinator.
-func cliCertificateIntermediate(host string, output string, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
-	certs, err := verifyCoordinator(host, configFilename, insecure, acceptedTCBStatuses)
+func cliCertificateIntermediate(out io.Writer, host, output, configFilename string, insecure bool, acceptedTCBStatuses []string) error {
+	certs, err := verifyCoordinator(out, host, configFilename, insecure, acceptedTCBStatuses)
 	if err != nil {
 		return err
 	}
@@ -45,9 +46,9 @@ func cliCertificateIntermediate(host string, output string, configFilename strin
 		if err := ioutil.WriteFile(output, pem.EncodeToMemory(certs[0]), 0o644); err != nil {
 			return err
 		}
-		fmt.Println("Intermediate certificate written to", output)
+		fmt.Fprintln(out, "Intermediate certificate written to", output)
 	} else {
-		fmt.Println("WARNING: No intermediate certificate received.")
+		fmt.Fprintln(out, "WARNING: No intermediate certificate received.")
 	}
 
 	return nil

--- a/cli/cmd/manifestGet.go
+++ b/cli/cmd/manifestGet.go
@@ -32,11 +32,11 @@ Optionally get the manifests signature or merge updates into the displayed manif
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+			cert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Successfully verified Coordinator, now requesting manifest")
+			cmd.Println("Successfully verified Coordinator, now requesting manifest")
 			response, err := cliDataGet(hostName, "manifest", "data", cert)
 			if err != nil {
 				return err
@@ -53,7 +53,7 @@ Optionally get the manifests signature or merge updates into the displayed manif
 			if len(output) > 0 {
 				return ioutil.WriteFile(output, []byte(manifest), 0o644)
 			}
-			fmt.Println(manifest)
+			cmd.Println(manifest)
 			return nil
 		},
 		SilenceUsage: true,

--- a/cli/cmd/manifestLog.go
+++ b/cli/cmd/manifestLog.go
@@ -7,7 +7,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
@@ -26,11 +25,11 @@ func newManifestLog() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+			cert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Successfully verified Coordinator, now requesting update log")
+			cmd.Println("Successfully verified Coordinator, now requesting update log")
 			response, err := cliDataGet(hostName, "update", "data", cert)
 			if err != nil {
 				return err
@@ -38,7 +37,7 @@ func newManifestLog() *cobra.Command {
 			if len(output) > 0 {
 				return ioutil.WriteFile(output, response, 0o644)
 			}
-			fmt.Printf("Update log:\n%s", string(response))
+			cmd.Printf("Update log:\n%s", string(response))
 			return nil
 		},
 		SilenceUsage: true,

--- a/cli/cmd/manifestUpdate.go
+++ b/cli/cmd/manifestUpdate.go
@@ -159,7 +159,7 @@ func newUpdateGet() *cobra.Command {
 }
 
 func authenticatedClient(cmd *cobra.Command, hostName string) (*http.Client, error) {
-	caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+	caCert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func runUpdateGet(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+	caCert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/manifestVerify.go
+++ b/cli/cmd/manifestVerify.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -28,7 +29,7 @@ func newManifestVerify() *cobra.Command {
 			manifest := args[0]
 			hostName := args[1]
 
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+			cert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}
@@ -38,7 +39,7 @@ func newManifestVerify() *cobra.Command {
 				return err
 			}
 
-			return cliManifestVerify(localSignature, hostName, cert)
+			return cliManifestVerify(cmd.OutOrStdout(), localSignature, hostName, cert)
 		},
 		SilenceUsage: true,
 	}
@@ -73,7 +74,7 @@ func getSignatureFromString(manifest string) (string, error) {
 }
 
 // cliManifestVerify verifies if a signature returned by the MarbleRun Coordinator is equal to one locally created.
-func cliManifestVerify(localSignature string, host string, cert []*pem.Block) error {
+func cliManifestVerify(out io.Writer, localSignature string, host string, cert []*pem.Block) error {
 	remoteSignature, err := cliDataGet(host, "manifest", "data.ManifestSignature", cert)
 	if err != nil {
 		return err
@@ -83,6 +84,6 @@ func cliManifestVerify(localSignature string, host string, cert []*pem.Block) er
 		return fmt.Errorf("remote signature differs from local signature: %s != %s", string(remoteSignature), localSignature)
 	}
 
-	fmt.Println("OK")
+	fmt.Fprintln(out, "OK")
 	return nil
 }

--- a/cli/cmd/manifest_test.go
+++ b/cli/cmd/manifest_test.go
@@ -159,20 +159,22 @@ func TestCliManifestSet(t *testing.T) {
 	require.NoError(err)
 	defer os.RemoveAll(dir)
 
-	err = cliManifestSet([]byte("00"), host, []*pem.Block{cert}, "")
+	var out bytes.Buffer
+
+	err = cliManifestSet(&out, []byte("00"), host, []*pem.Block{cert}, "")
 	require.NoError(err)
 
-	err = cliManifestSet([]byte("11"), host, []*pem.Block{cert}, "")
+	err = cliManifestSet(&out, []byte("11"), host, []*pem.Block{cert}, "")
 	require.NoError(err)
 
 	responseFile := filepath.Join(dir, "tmp-recovery.json")
-	err = cliManifestSet([]byte("11"), host, []*pem.Block{cert}, responseFile)
+	err = cliManifestSet(&out, []byte("11"), host, []*pem.Block{cert}, responseFile)
 	require.NoError(err)
 
-	err = cliManifestSet([]byte("22"), host, []*pem.Block{cert}, "")
+	err = cliManifestSet(&out, []byte("22"), host, []*pem.Block{cert}, "")
 	require.Error(err)
 
-	err = cliManifestSet([]byte("55"), host, []*pem.Block{cert}, "")
+	err = cliManifestSet(&out, []byte("55"), host, []*pem.Block{cert}, "")
 	require.Error(err)
 }
 
@@ -344,10 +346,13 @@ func TestCliManifestVerify(t *testing.T) {
 	}))
 	defer s.Close()
 
-	err := cliManifestVerify("TestSignature", host, []*pem.Block{cert})
-	assert.NoError(err)
+	var out bytes.Buffer
 
-	err = cliManifestVerify("InvalidSignature", host, []*pem.Block{cert})
+	err := cliManifestVerify(&out, "TestSignature", host, []*pem.Block{cert})
+	assert.NoError(err)
+	assert.Equal("OK\n", out.String())
+
+	err = cliManifestVerify(&out, "InvalidSignature", host, []*pem.Block{cert})
 	assert.Error(err)
 }
 

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -29,7 +29,7 @@ func newRecoverCmd() *cobra.Command {
 			keyFile := args[0]
 			hostName := args[1]
 
-			cert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+			cert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}
@@ -40,7 +40,7 @@ func newRecoverCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Println("Successfully verified Coordinator, now uploading key")
+			cmd.Println("Successfully verified Coordinator, now uploading key")
 
 			return cliRecover(hostName, recoveryKey, cert)
 		},

--- a/cli/cmd/secretSet.go
+++ b/cli/cmd/secretSet.go
@@ -47,7 +47,7 @@ marblerun secret set certificate.pem $MARBLERUN -c admin.crt -k admin.key --from
 			secretFile := args[0]
 			hostName := args[1]
 
-			caCert, err := verifyCoordinator(hostName, eraConfig, insecureEra, acceptedTCBStatuses)
+			caCert, err := verifyCoordinator(cmd.OutOrStdout(), hostName, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/secret_test.go
+++ b/cli/cmd/secret_test.go
@@ -7,6 +7,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"encoding/pem"
@@ -117,15 +118,18 @@ func TestGetSecrets(t *testing.T) {
 		clCert: tls.Certificate{},
 		caCert: []*pem.Block{cert},
 	}
-	err := cliSecretGet(options)
+
+	var out bytes.Buffer
+
+	err := cliSecretGet(&out, options)
 	assert.NoError(err)
 
 	options.secretIDs = []string{"restrictedSecret"}
-	err = cliSecretGet(options)
+	err = cliSecretGet(&out, options)
 	assert.Error(err)
 
 	options.secretIDs = []string{"this should cause an error"}
-	err = cliSecretGet(options)
+	err = cliSecretGet(&out, options)
 	assert.Error(err)
 }
 

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -48,7 +48,7 @@ func newStatusCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := args[0]
-			cert, err := verifyCoordinator(hostname, eraConfig, insecureEra, acceptedTCBStatuses)
+			cert, err := verifyCoordinator(cmd.OutOrStdout(), hostname, eraConfig, insecureEra, acceptedTCBStatuses)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Proposed changes
- reuse era config file if one exists in the current working directory
- replace generic `fmt.PrintX` statements with either `fmt.FprintX(cmd.OutOrStdout(),...)` or `cmd.PrintX` in CLI
  - only affects code I already had to change for this PR

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
