### PR TITLE
Disable mux logging

### DIFF
--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http"
-	"os"
 
 	"github.com/edgelesssys/marblerun/coordinator/core"
 	"github.com/edgelesssys/marblerun/coordinator/events"
@@ -20,7 +19,6 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/coordinator/state"
 	"github.com/edgelesssys/marblerun/coordinator/user"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -118,10 +116,9 @@ func CreateServeMux(api clientAPI, promFactory *promauto.Factory) serveMux {
 
 // RunClientServer runs a HTTP server serving mux.
 func RunClientServer(mux http.Handler, address string, tlsConfig *tls.Config, zapLogger *zap.Logger) {
-	loggedRouter := handlers.LoggingHandler(os.Stdout, mux)
 	server := http.Server{
 		Addr:      address,
-		Handler:   loggedRouter,
+		Handler:   mux,
 		TLSConfig: tlsConfig,
 	}
 	zapLogger.Info("starting client https server", zap.String("address", address))


### PR DESCRIPTION
### Proposed changes
- Disable logging for http server mux
  - The handler we useed formats the message in  Apache Common Log Format, this resulted in two different logging styles throughout a Coordinators life cycle
-

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Going forward we probably want to replace the mux library we use (gorrila mux) with a different one, or just use the default Go multiplexer, since the project has since [been archived and is no longer being maintained](https://github.com/gorilla/#gorilla-toolkit)

<!-- (uncomment if applicable)
### Screenshots

-->
