### PR TITLE
Update image name in workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -65,7 +65,7 @@ jobs:
           -d '{"event_type": "docker-build",
               "client_payload":{"repository":"marblerun",
                                 "sign":"nightly",
-                                "imagename":"coordinator",
+                                "imagename":"marblerun/coordinator",
                                 "tag":"nightly",
                                 "file": "dockerfiles/Dockerfile.coordinator",
                                 "target":"release"}}' \
@@ -80,7 +80,7 @@ jobs:
           -d '{"event_type": "docker-build",
               "client_payload":{"repository":"marblerun",
                                 "sign":"nightly",
-                                "imagename":"marble-injector",
+                                "imagename":"marblerun/marble-injector",
                                 "tag":"nightly",
                                 "file": "dockerfiles/Dockerfile.marble-injector",
                                 "target":"release"}}' \

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -65,7 +65,7 @@ jobs:
           -d '{"event_type": "docker-build",
               "client_payload":{"repository":"marblerun",
                                 "sign":"nightly",
-                                "imagename":"marblerun/coordinator",
+                                "imagename":"marblerun/coordinator-debug",
                                 "tag":"nightly",
                                 "file": "dockerfiles/Dockerfile.coordinator",
                                 "target":"release"}}' \


### PR DESCRIPTION
### Proposed changes
- Container image names were updated with v1.0.0 from `ghcr.io/edgelesssys/<app>` to `ghcr.io/edgelesssys/marblerun/<app>`, this PR fixes the workflow to push images using the new naming scheme

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
