### PR TITLE
charts: fix namespace in injector.yaml

### DIFF
--- a/charts/templates/marble-injector.yaml
+++ b/charts/templates/marble-injector.yaml
@@ -91,7 +91,7 @@ webhooks:
       {{- end }}
       service:
         name: marble-injector
-        namespace: marblerun
+        namespace: {{ .Release.Namespace }}
         path: "/mutate"
     rules:
     - operations: ["CREATE"]


### PR DESCRIPTION
### Proposed changes
The injector's namespace was hardcoded to be `marblerun`, this patch allows it to be substituted with `{{ Release.Namespace }}`
