### PR TITLE
Enable MarbleRun Kubernetes installation using only helm

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -48,12 +48,15 @@ their default values.
 | `global.coordinatorNamespaceLabel`           | string         | Control plane label. Do not edit | `"edgeless.systems/control-plane-ns"` |
 | `global.podAnnotations`                      | object         | Additional annotations to add to all pods | `{}`|
 | `global.podLabels`                           | object         | Additional labels to add to all pods | `{}` |
-| `marbleInjector.CABundle`                    | string         | Set this to use a custom CABundle for the MutatingWebhook | `""` |
+| `marbleInjector.CABundle`                    | string         | MutatingWebhook CA bundle. Automatically configured by the MarbleRun CLI. Ignore when using standalone helm chart | `""` |
 | `marbleInjector.image`                       | string         | Name of the marbleInjector container image | `"coordinator"` |
 | `marbleInjector.start`                       | bool           | Start the marbleInjector webhook | `false` |
 | `marbleInjector.replicas`                    | int            | Replicas of the marbleInjector webhook | `1` |
 | `marbleInjector.repository`                  | string         | Name of the container registry to pull the marbleInjector image from | `"ghcr.io/edgelesssys/marblerun"` |
 | `marbleInjector.version`                     | string         | Version of the marbleInjector container image to pull | `"v1.0.0"` |
+| `marbleInjector.useCertManager`              | bool           | Set to use cert-manager for certificate provisioning. Required when using standalone helm chart for installation | `false` |
+| `marbleInjector.objectSelector`              | object         | ObjectSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector) for more information | `{matchExpressions:[{key:"marblerun/marbletype",operator:"Exists"}]}` |
+| `marbleInjector.namespaceSelector`           | object         | NamespaceSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector) for more information | `{}` |
 | `nodeSelector`                               | object         | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information | `{"beta.kubernetes.io/os": "linux"}` |
 | `tolerations`                                | object         | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information | `{key:"sgx.intel.com/epc",operator:"Exists",effect:"NoSchedule"}` |
 | `dcap.qpl`                                   | string         | SGX quote provider library (QPL) to use. Needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default | `"azure"` |

--- a/charts/templates/marble-injector.yaml
+++ b/charts/templates/marble-injector.yaml
@@ -75,7 +75,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: marble-injector
+  name: marble-injector-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-controller-configuration
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
@@ -87,7 +87,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/marble-injector-serving-cert
   {{- end }}
 webhooks:
-  - name: marble-injector.cluster.local
+  - name: marble-injector-{{ .Release.Namespace }}.cluster.local
     clientConfig:
       {{- if ne .Values.marbleInjector.CABundle "" }}
       caBundle: {{ .Values.marbleInjector.CABundle }}

--- a/charts/templates/marble-injector.yaml
+++ b/charts/templates/marble-injector.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.marbleInjector.start }}
+{{- if .Values.marbleInjector.start }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,8 +54,8 @@ spec:
       containers:
       - args:
         - -coordAddr=coordinator-mesh-api.{{ .Release.Namespace }}:{{ .Values.coordinator.meshServerPort }}
-        - -tlsCertFile=/etc/webhook/certs/cert.pem
-        - -tlsKeyFile=/etc/webhook/certs/key.pem
+        - -tlsCertFile=/etc/webhook/certs/tls.crt
+        - -tlsKeyFile=/etc/webhook/certs/tls.key
         - -sgxResource={{ .Values.marbleInjector.resourceKey }}
         name: marble-injector
         image: "{{ .Values.marbleInjector.repository }}/{{ .Values.marbleInjector.image }}:{{ .Values.marbleInjector.version }}"
@@ -67,7 +67,6 @@ spec:
         ports:
           - containerPort: 8443
             name: http
-
       volumes:
       - name: webhook-certs
         secret:
@@ -83,11 +82,15 @@ metadata:
     app.kubernetes.io/name: marble-injector
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.marbleInjector.version }}
+  {{- if eq .Values.marbleInjector.CABundle "" }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/marble-injector-serving-cert
+  {{- end }}
 webhooks:
   - name: marble-injector.cluster.local
     clientConfig:
-      {{- with .Values.marbleInjector.CABundle }}
-      caBundle: {{ . }}
+      {{- if ne .Values.marbleInjector.CABundle "" }}
+      caBundle: {{ .Values.marbleInjector.CABundle }}
       {{- end }}
       service:
         name: marble-injector
@@ -99,11 +102,14 @@ webhooks:
       apiVersions: ["v1"]
       resources: ["pods"]
       scope: "Namespaced"
+    {{- with .Values.marbleInjector.objectSelector }}
     objectSelector:
-      matchExpressions:
-        - key: marblerun/marbletype
-          operator: Exists
-          values: []
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
+    {{- with .Values.marbleInjector.namespaceSelector }}
+    namespaceSelector:
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
-{{ end }}
+{{- end }}

--- a/charts/templates/webhookConfig.yaml
+++ b/charts/templates/webhookConfig.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.marbleInjector.start .Values.marbleInjector.useCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: marble-injector-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: admission-controller-selfsigned-issuer
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
+    app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.marbleInjector.version }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: marble-injector-serving-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: admission-controller-serving-cert
+    app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
+    app.kubernetes.io/name: marble-injector
+    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/version: {{ .Values.marbleInjector.version }}
+spec:
+  dnsNames:
+  - 'marble-injector.{{ .Release.Namespace }}.svc'
+  - 'marble-injector.{{ .Release.Namespace }}.svc.{{ .Values.coordinator.hostname }}'
+  issuerRef:
+    kind: Issuer
+    name: marble-injector-selfsigned-issuer
+  secretName: marble-injector-webhook-certs
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -28,11 +28,18 @@ marbleInjector:
   start: false
   replicas: 1
   repository: ghcr.io/edgelesssys/marblerun
+  resourceKey: "sgx.intel.com/epc"
   image: marble-injector
   pullPolicy: IfNotPresent
   version: v1.0.0
-  # Set this to use a custom CABundle for the MutatingWebhook
-  # CABundle: "CA_Bundle_Base64"
+  useCertManager: false
+  CABundle: ""
+  objectSelector:
+    matchExpressions:
+      - key: marblerun/marbletype
+        operator: Exists
+        values: []
+  namespaceSelector: {}
 
 
 # coordinator configuration

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -353,8 +353,8 @@ func createSecret(privKey *rsa.PrivateKey, crt []byte, kubeClient kubernetes.Int
 			Namespace: helmNamespace,
 		},
 		Data: map[string][]byte{
-			"cert.pem": crt,
-			"key.pem":  rsaPEM,
+			"tls.crt": crt,
+			"tls.key": rsaPEM,
 		},
 	}
 

--- a/cli/cmd/uninstall_test.go
+++ b/cli/cmd/uninstall_test.go
@@ -106,8 +106,8 @@ func TestCleanupWebhook(t *testing.T) {
 			Namespace: helmNamespace,
 		},
 		Data: map[string][]byte{
-			"cert.pem": {0xAA, 0xAA, 0xAA},
-			"key.pem":  {0xBB, 0xBB, 0xBB},
+			"tls.crt": {0xAA, 0xAA, 0xAA},
+			"tls.key": {0xBB, 0xBB, 0xBB},
 		},
 	}
 

--- a/cmd/marble-injector/main.go
+++ b/cmd/marble-injector/main.go
@@ -21,8 +21,8 @@ func main() {
 	var clusterDomain string
 	var sgxResource string
 	flag.StringVar(&addr, "coordAddr", "coordinator-mesh-api.marblerun:2001", "Address of the MarbleRun coordinator")
-	flag.StringVar(&certFile, "tlsCertFile", "/etc/webhook/certs/cert.pem", "File containing the x509 Certificate for HTTPS.")
-	flag.StringVar(&keyFile, "tlsKeyFile", "/etc/webhook/certs/key.pem", "File containing the x509 private key to --tlsCertFile.")
+	flag.StringVar(&certFile, "tlsCertFile", "/etc/webhook/certs/tls.crt", "File containing the x509 Certificate for HTTPS.")
+	flag.StringVar(&keyFile, "tlsKeyFile", "/etc/webhook/certs/tls.key", "File containing the x509 private key to --tlsCertFile.")
 	flag.StringVar(&clusterDomain, "clusterDomain", "cluster.local", "Domain name of the kubernetes cluster")
 	flag.StringVar(&sgxResource, "sgxResource", "sgx.intel.com/epc", "Defines the resource/toleration to inject, this needs to be exposed on a node through a device plugin")
 

--- a/samples/gramine-redis/kubernetes/templates/redis.yaml
+++ b/samples/gramine-redis/kubernetes/templates/redis.yaml
@@ -2,13 +2,13 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: redis
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-main
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redis
     role: main
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-replica
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redis
     role: replica
@@ -106,7 +106,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-main
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
### Proposed changes
- Add cert-manager self signed certificate for marble-injector webhook
  - Allows standalone helm installation, no MarbleRun CLI needed
  - Requires a change in marble-injector cmd line flags. Installing this chart with and older CLI will cause some errors  if the chart is not manually edited.
- Add release namespace name to mutating webhook configuration name of marble-injector
  - Allows installing multiple MarbleRun charts into the same cluster without causing webhook configuration collisions
- Add `objectSelector` and `namespaceSelector` to values file
  - Allows easily updating the mutation triggers of the webhook

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
