### PR TITLE
Allow multiple marblerun instances to be installed with helm

### DIFF
--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: coordinator
         app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
         app.kubernetes.io/name: coordinator
-        app.kubernetes.io/part-of: {{ .Release.Namespace }}
+        app.kubernetes.io/part-of: marblerun
         app.kubernetes.io/version: {{ .Values.coordinator.version }}
         {{ .Values.global.coordinatorComponentLabel }}: coordinator
         {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
@@ -110,7 +110,7 @@ metadata:
     app.kubernetes.io/component: persistent-storage
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator-pv-claim
-    app.kubernetes.io/part-of: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
   {{- with .Values.coordinator.storageClass }}
@@ -131,7 +131,7 @@ metadata:
     app.kubernetes.io/component: client-api
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator-client-api
-    app.kubernetes.io/part-of: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
   type: ClusterIP
@@ -152,7 +152,7 @@ metadata:
     app.kubernetes.io/component: mesh-api
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator-mesh-api
-    app.kubernetes.io/part-of: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
   type: ClusterIP

--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: coordinator
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator
-    app.kubernetes.io/part-of: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
     {{ .Values.global.coordinatorComponentLabel }}: coordinator
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}

--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -134,7 +134,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Namespace }}
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     {{ .Values.global.coordinatorComponentLabel }}: coordinator
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}

--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: coordinator
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator
-    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/part-of: {{ .Release.Namespace }}
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
     {{ .Values.global.coordinatorComponentLabel }}: coordinator
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/component: coordinator
         app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
         app.kubernetes.io/name: coordinator
-        app.kubernetes.io/part-of: marblerun
+        app.kubernetes.io/part-of: {{ .Release.Namespace }}
         app.kubernetes.io/version: {{ .Values.coordinator.version }}
         {{ .Values.global.coordinatorComponentLabel }}: coordinator
         {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
@@ -110,7 +110,7 @@ metadata:
     app.kubernetes.io/component: persistent-storage
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator-pv-claim
-    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/part-of: {{ .Release.Namespace }}
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
   {{- with .Values.coordinator.storageClass }}
@@ -131,10 +131,10 @@ metadata:
     app.kubernetes.io/component: client-api
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator-client-api
-    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/part-of: {{ .Release.Namespace }}
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     {{ .Values.global.coordinatorComponentLabel }}: coordinator
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
@@ -152,7 +152,7 @@ metadata:
     app.kubernetes.io/component: mesh-api
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
     app.kubernetes.io/name: coordinator-mesh-api
-    app.kubernetes.io/part-of: marblerun
+    app.kubernetes.io/part-of: {{ .Release.Namespace }}
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
   type: ClusterIP

--- a/charts/templates/marble-injector.yaml
+++ b/charts/templates/marble-injector.yaml
@@ -75,7 +75,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: marble-injector
+  name: marble-injector-{{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: admission-controller-configuration
     app.kubernetes.io/created-by: {{ .Values.global.createdBy }}
@@ -87,7 +87,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/marble-injector-serving-cert
   {{- end }}
 webhooks:
-  - name: marble-injector.cluster.local
+  - name: marble-injector-{{ .Release.Namespace }}.cluster.local
     clientConfig:
       {{- if ne .Values.marbleInjector.CABundle "" }}
       caBundle: {{ .Values.marbleInjector.CABundle }}

--- a/samples/gramine-redis/kubernetes/templates/redis.yaml
+++ b/samples/gramine-redis/kubernetes/templates/redis.yaml
@@ -2,13 +2,13 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: redis
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-main
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redis
     role: main
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-replica
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
   labels:
     app: redis
     role: replica
@@ -106,7 +106,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-main
-  namespace: redis
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
### Proposed changes
Based on #368 this PR allows multiple Marblerun deployments in the same Kubernetes cluster, but with different namespaces.

~Currently the user needs to create the `namespace` and create the secret manually:~
EDIT: it works without manually creating it.


## Questions: 
### How the `charts/README.md` should be edited?
We used the following helm command to install marblerun:
```bash
helm install marblerun ./charts/ --create-namespace -n $namespace \
        --set marbleInjector.useCertManager=true \
        --set marbleInjector.start=true \
        --set coordinator.hostname=$host
        --set dcap.qpl=intel \
        --set dcap.pccsUrl=https://$host:8081/sgx/certification/v3/ \
        --set dcap.useSecureCert=FALSE \
        -f ./charts/values.yaml 

```
Should it be added to the `README.md`?

