### PR TITLE
followup for {cert,key}.pem -> tls.{crt,key} name changes in `injector`, `cli`

### DIFF
--- a/cli/cmd/uninstall_test.go
+++ b/cli/cmd/uninstall_test.go
@@ -106,8 +106,8 @@ func TestCleanupWebhook(t *testing.T) {
 			Namespace: helmNamespace,
 		},
 		Data: map[string][]byte{
-			"cert.pem": {0xAA, 0xAA, 0xAA},
-			"key.pem":  {0xBB, 0xBB, 0xBB},
+			"tls.crt": {0xAA, 0xAA, 0xAA},
+			"tls.key": {0xBB, 0xBB, 0xBB},
 		},
 	}
 

--- a/cmd/marble-injector/main.go
+++ b/cmd/marble-injector/main.go
@@ -21,8 +21,8 @@ func main() {
 	var clusterDomain string
 	var sgxResource string
 	flag.StringVar(&addr, "coordAddr", "coordinator-mesh-api.marblerun:2001", "Address of the MarbleRun coordinator")
-	flag.StringVar(&certFile, "tlsCertFile", "/etc/webhook/certs/cert.pem", "File containing the x509 Certificate for HTTPS.")
-	flag.StringVar(&keyFile, "tlsKeyFile", "/etc/webhook/certs/key.pem", "File containing the x509 private key to --tlsCertFile.")
+	flag.StringVar(&certFile, "tlsCertFile", "/etc/webhook/certs/tls.crt", "File containing the x509 Certificate for HTTPS.")
+	flag.StringVar(&keyFile, "tlsKeyFile", "/etc/webhook/certs/tls.key", "File containing the x509 private key to --tlsCertFile.")
 	flag.StringVar(&clusterDomain, "clusterDomain", "cluster.local", "Domain name of the kubernetes cluster")
 	flag.StringVar(&sgxResource, "sgxResource", "sgx.intel.com/epc", "Defines the resource/toleration to inject, this needs to be exposed on a node through a device plugin")
 


### PR DESCRIPTION
### Proposed changes
- This is a followup PR for the naming changes mad in #368.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
