### PR TITLE
charts: add EDG_COORDINATOR_PROMETHEUS_ADDR to helm

### DIFF
--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -46,6 +46,8 @@ spec:
             value: "{{ .Values.coordinator.clientServerHost }}:{{ .Values.coordinator.clientServerPort }}"
           - name: EDG_COORDINATOR_DNS_NAMES
             value: "{{ .Values.coordinator.hostname }},coordinator-mesh-api,coordinator-client-api,coordinator-mesh-api.{{ .Release.Namespace }},coordinator-client-api.{{ .Release.Namespace }},coordinator-mesh-api.{{ .Release.Namespace }}.svc.cluster.local,coordinator-client-api.{{ .Release.Namespace }}.svc.cluster.local"
+          - name: EDG_COORDINATOR_PROMETHEUS_ADDR
+            value: "{{ .Values.coordinator.prometheusHost }}:{{ .Values.coordinator.prometheusPort }}"
           - name: EDG_COORDINATOR_SEAL_DIR
             value: "{{ .Values.coordinator.sealDir }}"
           - name: OE_SIMULATION
@@ -81,6 +83,8 @@ spec:
               name: http
             - containerPort: {{ .Values.coordinator.meshServerPort }}
               name: grcp
+            - containerPort: {{ .Values.coordinator.prometheusPort }}
+              name: prometheus
           resources:
           {{- toYaml .Values.coordinator.resources | nindent 12 }}
           volumeMounts:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -57,6 +57,9 @@ coordinator:
   # clientServerPort needs to be configured to the same port as in your client tool stack
   clientServerHost: "0.0.0.0"
   clientServerPort: 4433
+  # Prometheus exporter address
+  prometheusHost: "0.0.0.0"
+  prometheusPort: 9944
   # hosName needs to match the host you expect the coordinator to run on
   hostname: "localhost"
   # SEAL_DIR needs to be set according to persistent storage


### PR DESCRIPTION
### Proposed changes
This PR allows the configuration of the Prometheus exporter from Helm charts.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
