### PR TITLE
Dont use apt in running container

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -210,11 +210,11 @@ You can build the Docker image of the Coordinator by providing a signing key:
 
 ```bash
 openssl genrsa -out private.pem -3 3072
-DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=private.pem --tag ghcr.io/edgelesssys/coordinator - < dockerfiles/Dockerfile.coordinator
+DOCKER_BUILDKIT=1 docker build --secret id=signingkey,src=private.pem --tag ghcr.io/edgelesssys/marblerun/coordinator - < dockerfiles/Dockerfile.coordinator
 ```
 
 You can build the Docker image of the marble-injector as follows:
 
 ```bash
-DOCKER_BUILDKIT=1 docker build --tag ghcr.io/edgelesssys/marble-injector -f dockerfiles/Dockerfile.marble-injector .
+DOCKER_BUILDKIT=1 docker build --tag ghcr.io/edgelesssys/marblerun/marble-injector -f dockerfiles/Dockerfile.marble-injector .
 ```

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -46,6 +46,7 @@ COPY --from=build \
 FROM ubuntu:focal-20221130 AS release
 ARG PSW_VERSION=2.18.101.1-focal1
 ARG DCAP_VERSION=1.15.100.3-focal1
+ARG AZ_VERSION=1.11.2
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg libcurl4 wget \
   && wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add \
   && echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' >> /etc/apt/sources.list \
@@ -61,8 +62,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
   libsgx-pce-logic=$DCAP_VERSION \
   libsgx-qe3-logic=$DCAP_VERSION \
   libsgx-urts=$PSW_VERSION \
-  && apt-get install -d az-dcap-client libsgx-dcap-default-qpl=$DCAP_VERSION
+  libsgx-dcap-default-qpl=$DCAP_VERSION \
+  az-dcap-client=$AZ_VERSION \
+  && apt-get autoremove -y && apt-get clean -y
+
+# create backup of libdcap_quoteprov.so.1 and libsgx_default_qcnl_wrapper.so.1 and remove libsgx-dcap-default-qpl
+RUN mkdir /usr/lib/x86_64-linux-gnu/dcap \
+  && cp /usr/lib/x86_64-linux-gnu/libsgx_default_qcnl_wrapper.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/dcap \
+  && apt remove -y libsgx-dcap-default-qpl \
+  && ln -s /usr/lib/x86_64-linux-gnu/dcap/libsgx_default_qcnl_wrapper.so.1 /usr/lib/x86_64-linux-gnu/libsgx_default_qcnl_wrapper.so.1 \
+  && ln -s /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.intel
+
 COPY --from=build /mrbuild/coordinator-enclave.signed /mrbuild/coordinator-config.json /marblerun/dockerfiles/start.sh /
 COPY --from=build /opt/edgelessrt/bin/erthost /opt/edgelessrt/bin/
+RUN chgrp -R 0 /usr/lib/ && chmod -R g=u /usr/lib/
 ENV PATH=${PATH}:/opt/edgelessrt/bin
+ENV AZDCAP_DEBUG_LOG_LEVEL=ERROR
 ENTRYPOINT ["/start.sh"]

--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -2,9 +2,10 @@
 
 if [[ "${DCAP_LIBRARY}" == "intel" ]]
 then
-    apt-get install -qq libsgx-dcap-default-qpl > /dev/null 2>&1
-else
-    apt-get install -qq az-dcap-client > /dev/null 2>&1
+    # rename the library installed by az-dcap-client
+    mv /usr/lib/libdcap_quoteprov.so /usr/lib/libdcap_quoteprov.so.azure
+    # create a link to the intel quote provider library
+    ln -s /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.intel /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so
 fi
 
-erthost coordinator-enclave.signed
+exec erthost coordinator-enclave.signed


### PR DESCRIPTION
### Proposed changes
Don't use apt in running container as this may cause issues when running on Openshift.
Instead, reintroduce our old hack of installing both QPLs and moving/linking them so we only use the one needed.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
