### PR TITLE
Allow usage of custom PVC for Coordinator storage

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -39,10 +39,12 @@ their default values.
 | `coordinator.image`                          | string         | Name of the coordinator container image | `"coordinator"` |
 | `coordinator.meshServerHost`                 | string         | Hostname of the mesh-api server | `"0.0.0.0"` |
 | `coordinator.meshServerPort`                 | int            | Port of the mesh-api server configuration | `2001` |
+| `coordinator.pvcName`                        | string         | Name of a [Persistent Volume Claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to use for the Coordinator's state. Leave empty to create a new one using the configured StorageClass |
 | `coordinator.replicas`                       | int            | Number of replicas for each control plane pod | `1` |
 | `coordinator.repository`                     | string         | Name of the container registry to pull the coordinator image from | `"ghcr.io/edgelesssys/marblerun"` |
 | `coordinator.sealDir`                        | string         | Path to the directory used for sealing data. Needs to be consistent with the persisten storage setup | `"/coordinator/data/"` |
 | `coordinator.simulation`                     | bool           | SGX simulation settings, set to `true` if your not running on an SGX capable cluster | `false` |
+| `coordinator.storageClass`                   | string         | Kubernetes [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to use for creating the Coordinator PVC. Leave empty to use the default StorageClass |
 | `coordinator.version`                        | string         | Version of the coordinator container image to pull | `"v1.0.0"` |
 | `global.coordinatorComponentLabel`           | string         | Control plane label. Do not edit | `"edgeless.systems/control-plane-component"` |
 | `global.coordinatorNamespaceLabel`           | string         | Control plane label. Do not edit | `"edgeless.systems/control-plane-ns"` |

--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -94,13 +94,14 @@ spec:
       volumes:
         - name: coordinator-pv-storage
           persistentVolumeClaim:
-            claimName: coordinator-pv-claim
+            claimName: {{ .Values.coordinator.pvcName | default "coordinator-pv-claim" }}
         {{ if .Values.dcap }}
         - name: dcap-conf
           configMap:
             name: coordinator-dcap-config
         {{ end }}
 ---
+{{- if not .Values.coordinator.pvcName }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -113,14 +114,13 @@ metadata:
     app.kubernetes.io/part-of: marblerun
     app.kubernetes.io/version: {{ .Values.coordinator.version }}
 spec:
-  {{- with .Values.coordinator.storageClass }}
   storageClassName: {{ .Values.coordinator.storageClass }}
-  {{ end }}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 10Mi
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -71,8 +71,12 @@ coordinator:
       sgx.intel.com/enclave: 1
       sgx.intel.com/provision: 1
 
+
   # Set the storage class for your cluster
-  # storageClass:
+  storageClass: ""
+  # Set to use an existing PVC for Coordinator storage
+  # Otherwise a new one will be created using the configured storage class
+  pvcName: ""
 
 
 # Tolerations constraints for control-plane components

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,4 +1,4 @@
-# Default values for marblerun-coordinator.
+# Default values for MarbleRun helm deployment
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -25,20 +25,33 @@ global:
 
 # webhook configuration
 marbleInjector:
-  start: false
   replicas: 1
   repository: ghcr.io/edgelesssys/marblerun
-  resourceKey: "sgx.intel.com/epc"
   image: marble-injector
   pullPolicy: IfNotPresent
   version: v1.0.0
+
+  # Set to true to install the injection webhook
+  start: false
+  # SGX resource request to inject into pods
+  resourceKey: "sgx.intel.com/epc"
+  # Set to true if using standalone helm installation (cert-manager is required)
   useCertManager: false
+  # Automatically injected by the MarbleRun CLI. Ignore in helm standalone installation
   CABundle: ""
+
+  # objectSelector configuration.
+  # See: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
+  # Customize to limit injection to specific pods
+  # The default configuration injects all Pods with the "marblerun/marbletype" label
   objectSelector:
     matchExpressions:
       - key: marblerun/marbletype
         operator: Exists
         values: []
+  # namespaceSelector configuration.
+  # See: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+  # Customize to limit injection to specific namespaces
   namespaceSelector: {}
 
 
@@ -64,13 +77,15 @@ coordinator:
   # OE_SIMULATION needs be set to "1" when running on systems without SGX1+FLC capabilities
   simulation: false
 
+  # Resource limits for the Coordinator
   resources:
     limits:
-      # Disable this if your running on a cluster without an SGX Device Plugin
+      # Resource request to use Intel SGX Device Plugin
+      # If you are running in simulation mode, or are using a different plugin,
+      # update these values accordingly
       sgx.intel.com/epc: "10Mi"
       sgx.intel.com/enclave: 1
       sgx.intel.com/provision: 1
-
 
   # Set the storage class for your cluster
   storageClass: ""


### PR DESCRIPTION
### Proposed changes
- Update helm chart to allow users the usage of pre-created PVCs for the Coordinator's persistent storage.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
