### PR TITLE
Remove direct dependency on gorilla mux

### DIFF
--- a/coordinator/server/client_api.go
+++ b/coordinator/server/client_api.go
@@ -409,6 +409,20 @@ func (s *clientAPIServer) secretsPost(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, nil)
 }
 
+func (s *clientAPIServer) handleGetPost(getHandler, postHandler func(http.ResponseWriter, *http.Request),
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getHandler(w, r)
+		case http.MethodPost:
+			postHandler(w, r)
+		default:
+			s.methodNotAllowedHandler(w, r)
+		}
+	}
+}
+
 func (s *clientAPIServer) methodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSONError(w, "", http.StatusMethodNotAllowed)
 }

--- a/coordinator/server/metrics_test.go
+++ b/coordinator/server/metrics_test.go
@@ -69,15 +69,15 @@ func TestClientApiRequestMetrics(t *testing.T) {
 			mux := CreateServeMux(api, &fac)
 
 			metrics := mux.(*promServeMux).metrics[tc.target]
-			assert.Equal(0, promtest.CollectAndCount(metrics.reqest))
-			assert.Equal(float64(0), promtest.ToFloat64(metrics.reqest.WithLabelValues(tc.expectedStatusCode, strings.ToLower(tc.method))))
+			assert.Equal(0, promtest.CollectAndCount(metrics.request))
+			assert.Equal(float64(0), promtest.ToFloat64(metrics.request.WithLabelValues(tc.expectedStatusCode, strings.ToLower(tc.method))))
 
 			for i := 1; i < 6; i++ {
 				req := httptest.NewRequest(tc.method, tc.target, nil)
 				resp := httptest.NewRecorder()
 				mux.ServeHTTP(resp, req)
-				assert.Equal(1, promtest.CollectAndCount(metrics.reqest))
-				assert.Equal(float64(i), promtest.ToFloat64(metrics.reqest.WithLabelValues(tc.expectedStatusCode, strings.ToLower(tc.method))))
+				assert.Equal(1, promtest.CollectAndCount(metrics.request))
+				assert.Equal(float64(i), promtest.ToFloat64(metrics.request.WithLabelValues(tc.expectedStatusCode, strings.ToLower(tc.method))))
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gofrs/flock v0.8.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jarcoal/httpmock v1.2.0
@@ -79,6 +78,7 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect


### PR DESCRIPTION
### Proposed changes
The Gorilla toolkit is no longer [being maintained](https://github.com/gorilla#gorilla-toolkit).
To avoid dependencies on unmaintained software, this PR removes usage of the `gorilla/mux` package by replacing it with Go's default http mulitplexer.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
