### PR TITLE
Only work on store transactions

### DIFF
--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -106,7 +107,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 		if err != nil {
 			log.Fatal("Cannot read startup manifest", zap.Error(err))
 		}
-		if _, err := clientServer.SetManifest(content); err != nil {
+		if _, err := clientServer.SetManifest(context.Background(), content); err != nil {
 			log.Fatal("Cannot set startup manifest", zap.Error(err))
 		}
 	}

--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -8,6 +8,7 @@
 package clientapi
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
@@ -49,7 +50,7 @@ type core interface {
 }
 
 type transactionHandle interface {
-	BeginTransaction() (store.Transaction, error)
+	BeginTransaction(context.Context) (store.Transaction, error)
 	SetEncryptionKey([]byte) error
 	SetRecoveryData([]byte)
 	LoadState() ([]byte, error)
@@ -105,7 +106,7 @@ func (a *ClientAPI) GetCertQuote() (cert string, certQuote []byte, err error) {
 		}
 	}()
 
-	txdata, rollback, _, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, _, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return "", nil, err
 	}
@@ -148,7 +149,7 @@ func (a *ClientAPI) GetCertQuote() (cert string, certQuote []byte, err error) {
 func (a *ClientAPI) GetManifestSignature() (manifestSignatureRootECDSA, manifestSignature, manifest []byte) {
 	a.log.Info("GetManifestSignature called")
 
-	txdata, rollback, _, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, _, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		a.log.Error("GetManifestSignature failed: initializing store transaction", zap.Error(err))
 		return nil, nil, nil
@@ -190,7 +191,7 @@ func (a *ClientAPI) GetSecrets(requestedSecrets []string, client *user.User) (ma
 		return nil, fmt.Errorf("user %s is not allowed to read one or more secrets of: %v", client.Name(), requestedSecrets)
 	}
 
-	txdata, rollback, _, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, _, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,7 @@ func (a *ClientAPI) GetUpdateLog() (string, error) {
 		return "", err
 	}
 
-	txdata, rollback, _, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, _, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return "", err
 	}
@@ -281,7 +282,7 @@ func (a *ClientAPI) Recover(encryptionKey []byte) (keysLeft int, err error) {
 		a.log.Error("Could not retrieve recovery data from state. Recovery will be unavailable", zap.Error(err))
 	}
 
-	txdata, rollback, _, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, _, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return -1, err
 	}
@@ -325,7 +326,7 @@ func (a *ClientAPI) SetManifest(rawManifest []byte) (recoverySecretMap map[strin
 		return nil, fmt.Errorf("checking manifest: %w", err)
 	}
 
-	txdata, rollback, commit, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, commit, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +494,7 @@ func (a *ClientAPI) UpdateManifest(rawUpdateManifest []byte, updater *user.User)
 		return fmt.Errorf("user %s is not allowed to update one or more packages of %v", updater.Name(), wantedPackages)
 	}
 
-	txdata, rollback, commit, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, commit, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return err
 	}
@@ -619,7 +620,7 @@ func (a *ClientAPI) UpdateManifest(rawUpdateManifest []byte, updater *user.User)
 
 // VerifyUser checks if a given client certificate matches the admin certificates specified in the manifest.
 func (a *ClientAPI) VerifyUser(clientCerts []*x509.Certificate) (*user.User, error) {
-	txdata, rollback, _, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, _, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +672,7 @@ func (a *ClientAPI) WriteSecrets(rawSecretManifest []byte, updater *user.User) (
 		return fmt.Errorf("unmarshaling secret manifest: %w", err)
 	}
 
-	txdata, rollback, commit, err := wrapper.WrapTransaction(a.txHandle)
+	txdata, rollback, commit, err := wrapper.WrapTransaction(context.TODO(), a.txHandle)
 	if err != nil {
 		return err
 	}

--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -73,7 +73,7 @@ type ClientAPI struct {
 }
 
 // New returns an initialized instance of the ClientAPI.
-func New(store transactionHandle, recovery recovery.Recovery, core core, log *zap.Logger,
+func New(txHandle transactionHandle, recovery recovery.Recovery, core core, log *zap.Logger,
 ) (*ClientAPI, error) {
 	updateLog, err := updatelog.New()
 	if err != nil {
@@ -83,7 +83,7 @@ func New(store transactionHandle, recovery recovery.Recovery, core core, log *za
 	return &ClientAPI{
 		core:      core,
 		recovery:  recovery,
-		txHandle:  store,
+		txHandle:  txHandle,
 		updateLog: updateLog,
 		log:       log,
 	}, nil

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -590,7 +590,11 @@ func (c *fakeCore) RequireState(states ...state.State) error {
 	return errors.New("core is not in expected state")
 }
 
-func (c *fakeCore) AdvanceState(newState state.State, _ store.Transaction) error {
+func (c *fakeCore) AdvanceState(newState state.State, _ interface {
+	PutState(state.State) error
+	GetState() (state.State, error)
+},
+) error {
 	if c.advanceStateErr != nil {
 		return c.advanceStateErr
 	}

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -143,7 +143,7 @@ func TestGetCertQuote(t *testing.T) {
 				require.NoError(err)
 			}
 
-			cert, quote, err := api.GetCertQuote()
+			cert, quote, err := api.GetCertQuote(context.Background())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -211,7 +211,7 @@ func TestGetManifestSignature(t *testing.T) {
 				manifestHash = h[:]
 			}
 
-			signature, hash, manifest := api.GetManifestSignature()
+			signature, hash, manifest := api.GetManifestSignature(context.Background())
 			if tc.wantErr {
 				assert.Nil(signature)
 				assert.Nil(hash)
@@ -338,7 +338,7 @@ func TestGetSecrets(t *testing.T) {
 			storedSecrets := testutil.GetSecretMap(t, tc.store)
 			require.NoError(err)
 
-			secrets, err := api.GetSecrets(tc.request, tc.user)
+			secrets, err := api.GetSecrets(context.Background(), tc.request, tc.user)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -382,7 +382,7 @@ func TestGetStatus(t *testing.T) {
 				log:  log,
 			}
 
-			status, _, err := api.GetStatus()
+			status, _, err := api.GetStatus(context.Background())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -526,7 +526,7 @@ func TestRecover(t *testing.T) {
 				log:      log,
 			}
 
-			keysLeft, err := api.Recover([]byte("recoveryKey"))
+			keysLeft, err := api.Recover(context.Background(), []byte("recoveryKey"))
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -579,7 +579,7 @@ func (c *fakeCore) Unlock() {
 	c.unlockCalled = true
 }
 
-func (c *fakeCore) RequireState(states ...state.State) error {
+func (c *fakeCore) RequireState(_ context.Context, states ...state.State) error {
 	if c.requireStateErr != nil {
 		return c.requireStateErr
 	}
@@ -608,7 +608,7 @@ func (c *fakeCore) AdvanceState(newState state.State, _ interface {
 	return nil
 }
 
-func (c *fakeCore) GetState() (state.State, string, error) {
+func (c *fakeCore) GetState(_ context.Context) (state.State, string, error) {
 	return c.state, c.getStateMsg, c.getStateErr
 }
 

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -18,9 +18,14 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/constants"
 	"github.com/edgelesssys/marblerun/coordinator/crypto"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
+	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/state"
 	"github.com/edgelesssys/marblerun/coordinator/store"
+	"github.com/edgelesssys/marblerun/coordinator/store/request"
+	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/store/wrapper"
+	"github.com/edgelesssys/marblerun/coordinator/user"
+	"github.com/edgelesssys/marblerun/test"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,55 +39,45 @@ func TestMain(m *testing.M) {
 
 func TestGetCertQuote(t *testing.T) {
 	someErr := errors.New("failed")
+	// these are not actually root and intermediate certs
+	// but we don't care for this test
+	rootCert, intermediateCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
+
+	prepareDefaultStore := func() store.Store {
+		s := stdstore.New(&seal.MockSealer{})
+		require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorRootCert, rootCert))
+		require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorIntermediateCert, intermediateCert))
+		return s
+	}
 
 	testCases := map[string]struct {
-		storeWrapper *stubStoreWrapper
-		core         *fakeCore
-		wantErr      bool
+		store   store.Store
+		core    *fakeCore
+		wantErr bool
 	}{
 		"success state accepting Marbles": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         {Raw: []byte("root")},
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
+			store: prepareDefaultStore(),
 			core: &fakeCore{
 				state: state.AcceptingMarbles,
 				quote: []byte("quote"),
 			},
 		},
 		"success state accepting manifest": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         {Raw: []byte("root")},
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
+			store: prepareDefaultStore(),
 			core: &fakeCore{
 				state: state.AcceptingManifest,
 				quote: []byte("quote"),
 			},
 		},
 		"success state recovery": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         {Raw: []byte("root")},
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
+			store: prepareDefaultStore(),
 			core: &fakeCore{
 				state: state.Recovery,
 				quote: []byte("quote"),
 			},
 		},
 		"unsupported state": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         {Raw: []byte("root")},
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
+			store: prepareDefaultStore(),
 			core: &fakeCore{
 				state: state.Uninitialized,
 				quote: []byte("quote"),
@@ -90,50 +85,19 @@ func TestGetCertQuote(t *testing.T) {
 			wantErr: true,
 		},
 		"error getting state": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         {Raw: []byte("root")},
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
+			store: prepareDefaultStore(),
 			core: &fakeCore{
 				requireStateErr: someErr,
 				quote:           []byte("quote"),
 			},
 			wantErr: true,
 		},
-		"empty root cert": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         nil,
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
-			core: &fakeCore{
-				state: state.AcceptingMarbles,
-				quote: []byte("quote"),
-			},
-			wantErr: true,
-		},
-		"empty intermediate cert": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert:         {Raw: []byte("root")},
-					constants.SKCoordinatorIntermediateCert: nil,
-				},
-			},
-			core: &fakeCore{
-				state: state.AcceptingMarbles,
-				quote: []byte("quote"),
-			},
-			wantErr: true,
-		},
 		"root certificate not set": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorIntermediateCert: {Raw: []byte("intermediate")},
-				},
-			},
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorIntermediateCert, intermediateCert))
+				return s
+			}(),
 			core: &fakeCore{
 				state: state.AcceptingMarbles,
 				quote: []byte("quote"),
@@ -141,14 +105,262 @@ func TestGetCertQuote(t *testing.T) {
 			wantErr: true,
 		},
 		"intermediate certificate not set": {
-			storeWrapper: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root")},
-				},
-			},
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorRootCert, rootCert))
+				return s
+			}(),
 			core: &fakeCore{
 				state: state.AcceptingMarbles,
 				quote: []byte("quote"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			log, err := zap.NewDevelopment()
+			require.NoError(err)
+			defer log.Sync()
+
+			api := &ClientAPI{
+				core:     tc.core,
+				txHandle: tc.store,
+				log:      log,
+			}
+
+			var intermediateCert, rootCert *x509.Certificate
+			if !tc.wantErr {
+				intermediateCert, err = wrapper.New(tc.store).GetCertificate(constants.SKCoordinatorIntermediateCert)
+				require.NoError(err)
+				rootCert, err = wrapper.New(tc.store).GetCertificate(constants.SKCoordinatorRootCert)
+				require.NoError(err)
+			}
+
+			cert, quote, err := api.GetCertQuote()
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+
+			require.NoError(err)
+			assert.Equal(tc.core.quote, quote)
+			assert.Equal(mustEncodeToPem(t, intermediateCert)+mustEncodeToPem(t, rootCert), cert)
+		})
+	}
+}
+
+func TestGetManifestSignature(t *testing.T) {
+	testCases := map[string]struct {
+		store   store.Store
+		wantErr bool
+	}{
+		"success": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, s.Put(request.Manifest, []byte("manifest")))
+				require.NoError(t, s.Put(request.ManifestSignature, []byte("signature")))
+				return s
+			}(),
+		},
+		"GetRawManifest fails": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, s.Put(request.ManifestSignature, []byte("signature")))
+				return s
+			}(),
+			wantErr: true,
+		},
+		"GetManifestSignature fails": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, s.Put(request.Manifest, []byte("manifest")))
+				return s
+			}(),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			log, err := zap.NewDevelopment()
+			require.NoError(err)
+			defer log.Sync()
+
+			api := &ClientAPI{
+				txHandle: tc.store,
+				log:      log,
+			}
+
+			var rawManifest, manifestSignature, manifestHash []byte
+			if !tc.wantErr {
+				rawManifest, err = wrapper.New(tc.store).GetRawManifest()
+				require.NoError(err)
+				manifestSignature, err = wrapper.New(tc.store).GetManifestSignature()
+				require.NoError(err)
+				h := sha256.Sum256(rawManifest)
+				manifestHash = h[:]
+			}
+
+			signature, hash, manifest := api.GetManifestSignature()
+			if tc.wantErr {
+				assert.Nil(signature)
+				assert.Nil(hash)
+				assert.Nil(manifest)
+				return
+			}
+			assert.Equal(rawManifest, manifest)
+			assert.Equal(manifestHash, hash)
+			assert.Equal(manifestSignature, signature)
+		})
+	}
+}
+
+func TestGetSecrets(t *testing.T) {
+	newUserWithPermissions := func(name string, secretNames ...string) *user.User {
+		u := user.NewUser(name, nil)
+		u.Assign(user.NewPermission(user.PermissionReadSecret, secretNames))
+		return u
+	}
+
+	testCases := map[string]struct {
+		store   store.Store
+		core    *fakeCore
+		request []string
+		user    *user.User
+		wantErr bool
+	}{
+		"success": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				require.NoError(t, wrapper.New(s).PutSecret("secret2", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				return s
+			}(),
+			core: &fakeCore{state: state.AcceptingMarbles},
+			request: []string{
+				"secret1",
+				"secret2",
+			},
+			user: newUserWithPermissions("test", "secret1", "secret2"),
+		},
+		"wrong state": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				require.NoError(t, wrapper.New(s).PutSecret("secret2", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				return s
+			}(),
+			core: &fakeCore{state: state.AcceptingManifest},
+			request: []string{
+				"secret1",
+				"secret2",
+			},
+			user:    newUserWithPermissions("test", "secret1", "secret2"),
+			wantErr: true,
+		},
+		"user is missing permissions": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				require.NoError(t, wrapper.New(s).PutSecret("secret2", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				return s
+			}(),
+			core: &fakeCore{state: state.AcceptingMarbles},
+			request: []string{
+				"secret1",
+				"secret2",
+			},
+			user:    newUserWithPermissions("test", "secret2"), // only permission for secret2
+			wantErr: true,
+		},
+		"secret does not exist": {
+			store: func() store.Store {
+				s := stdstore.New(&seal.MockSealer{})
+				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
+					Type:    manifest.SecretTypePlain,
+					Private: []byte("secret"),
+				}))
+				return s
+			}(),
+			core: &fakeCore{state: state.AcceptingMarbles},
+			request: []string{
+				"secret1",
+				"secret2",
+			},
+			user:    newUserWithPermissions("test", "secret1", "secret2"),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			log, err := zap.NewDevelopment()
+			require.NoError(err)
+			defer log.Sync()
+
+			api := &ClientAPI{
+				txHandle: tc.store,
+				core:     tc.core,
+				log:      log,
+			}
+
+			storedSecrets, err := wrapper.New(tc.store).GetSecretMap()
+			require.NoError(err)
+
+			secrets, err := api.GetSecrets(tc.request, tc.user)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			require.NoError(err)
+			for name, secret := range secrets {
+				assert.Equal(storedSecrets[name], secret)
+			}
+		})
+	}
+}
+
+func TestGetStatus(t *testing.T) {
+	testCases := map[string]struct {
+		core    *fakeCore
+		wantErr bool
+	}{
+		"success": {
+			core: &fakeCore{state: state.AcceptingManifest},
+		},
+		"error": {
+			core: &fakeCore{
+				state:       state.AcceptingManifest,
+				getStateErr: errors.New("failed"),
 			},
 			wantErr: true,
 		},
@@ -165,89 +377,18 @@ func TestGetCertQuote(t *testing.T) {
 
 			api := &ClientAPI{
 				core: tc.core,
-				data: tc.storeWrapper,
 				log:  log,
 			}
 
-			cert, quote, err := api.GetCertQuote()
+			status, _, err := api.GetStatus()
 			if tc.wantErr {
 				assert.Error(err)
 				return
 			}
-
 			require.NoError(err)
-			assert.Equal(tc.core.quote, quote)
-			intermediateCert := tc.storeWrapper.getCertificateList[constants.SKCoordinatorIntermediateCert]
-			rootCert := tc.storeWrapper.getCertificateList[constants.SKCoordinatorRootCert]
-			assert.Equal(mustEncodeToPem(t, intermediateCert)+mustEncodeToPem(t, rootCert), cert)
+			assert.Equal(tc.core.state, status)
 		})
 	}
-}
-
-func TestGetManifestSignature(t *testing.T) {
-	someErr := errors.New("failed")
-
-	testCases := map[string]struct {
-		data    *stubStoreWrapper
-		wantErr bool
-	}{
-		"success": {
-			data: &stubStoreWrapper{
-				rawManifest:       []byte("manifest"),
-				manifestSignature: []byte("signature"),
-			},
-		},
-		"GetRawManifest fails": {
-			data: &stubStoreWrapper{
-				getRawManifestErr: someErr,
-				manifestSignature: []byte("signature"),
-			},
-			wantErr: true,
-		},
-		"GetManifestSignature fails": {
-			data: &stubStoreWrapper{
-				rawManifest:             []byte("manifest"),
-				getManifestSignatureErr: someErr,
-			},
-			wantErr: true,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-
-			log, err := zap.NewDevelopment()
-			require.NoError(err)
-			defer log.Sync()
-
-			api := &ClientAPI{
-				data: tc.data,
-				log:  log,
-			}
-
-			signature, hash, manifest := api.GetManifestSignature()
-			if tc.wantErr {
-				assert.Nil(signature)
-				assert.Nil(hash)
-				assert.Nil(manifest)
-				return
-			}
-			assert.Equal(tc.data.rawManifest, manifest)
-			expectedHash := sha256.Sum256(tc.data.rawManifest)
-			assert.Equal(expectedHash[:], hash)
-			assert.Equal(tc.data.manifestSignature, signature)
-		})
-	}
-}
-
-func TestGetSecrets(t *testing.T) {
-	t.Log("WARNING: Missing unit Test for GetSecrets")
-}
-
-func TestGetStatus(t *testing.T) {
-	t.Log("WARNING: Missing unit Test for GetStatus")
 }
 
 func TestGetUpdateLog(t *testing.T) {
@@ -256,33 +397,32 @@ func TestGetUpdateLog(t *testing.T) {
 
 func TestRecover(t *testing.T) {
 	someErr := errors.New("failed")
+	_, rootCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
+	defaultStore := func() store.Store {
+		s := stdstore.New(&seal.MockSealer{})
+		require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorRootCert, rootCert))
+		return s
+	}
 
 	testCases := map[string]struct {
-		data     *stubStoreWrapper
-		store    *stubStore
+		store    *fakeStore
 		recovery *stubRecovery
 		core     *fakeCore
 		wantErr  bool
 	}{
 		"success": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
+			store: &fakeStore{
+				store: defaultStore(),
 			},
-			store:    &stubStore{},
 			recovery: &stubRecovery{},
 			core: &fakeCore{
 				state: state.Recovery,
 			},
 		},
 		"more than one key required": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
+			store: &fakeStore{
+				store: defaultStore(),
 			},
-			store: &stubStore{},
 			recovery: &stubRecovery{
 				recoverKeysLeft: 1,
 			},
@@ -291,12 +431,9 @@ func TestRecover(t *testing.T) {
 			},
 		},
 		"SetRecoveryData fails does not result in error": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
+			store: &fakeStore{
+				store: defaultStore(),
 			},
-			store: &stubStore{},
 			recovery: &stubRecovery{
 				setRecoveryDataErr: someErr,
 			},
@@ -305,12 +442,9 @@ func TestRecover(t *testing.T) {
 			},
 		},
 		"Coordinator not in recovery state": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
+			store: &fakeStore{
+				store: defaultStore(),
 			},
-			store:    &stubStore{},
 			recovery: &stubRecovery{},
 			core: &fakeCore{
 				state: state.AcceptingManifest,
@@ -318,12 +452,9 @@ func TestRecover(t *testing.T) {
 			wantErr: true,
 		},
 		"RecoverKey fails": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
+			store: &fakeStore{
+				store: defaultStore(),
 			},
-			store: &stubStore{},
 			recovery: &stubRecovery{
 				recoverKeyErr: someErr,
 			},
@@ -333,12 +464,8 @@ func TestRecover(t *testing.T) {
 			wantErr: true,
 		},
 		"LoadState fails": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
-			},
-			store: &stubStore{
+			store: &fakeStore{
+				store:        defaultStore(),
 				loadStateErr: someErr,
 			},
 			recovery: &stubRecovery{},
@@ -348,12 +475,8 @@ func TestRecover(t *testing.T) {
 			wantErr: true,
 		},
 		"SetEncryptionKey fails": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
-			},
-			store: &stubStore{
+			store: &fakeStore{
+				store:               defaultStore(),
 				setEncryptionKeyErr: someErr,
 			},
 			recovery: &stubRecovery{},
@@ -363,10 +486,9 @@ func TestRecover(t *testing.T) {
 			wantErr: true,
 		},
 		"GetCertificate fails": {
-			data: &stubStoreWrapper{
-				getCertificateErr: someErr,
+			store: &fakeStore{
+				store: stdstore.New(&seal.MockSealer{}),
 			},
-			store:    &stubStore{},
 			recovery: &stubRecovery{},
 			core: &fakeCore{
 				state: state.Recovery,
@@ -374,12 +496,9 @@ func TestRecover(t *testing.T) {
 			wantErr: true,
 		},
 		"GenerateQuote fails": {
-			data: &stubStoreWrapper{
-				getCertificateList: map[string]*x509.Certificate{
-					constants.SKCoordinatorRootCert: {Raw: []byte("root cert")},
-				},
+			store: &fakeStore{
+				store: defaultStore(),
 			},
-			store:    &stubStore{},
 			recovery: &stubRecovery{},
 			core: &fakeCore{
 				state:            state.Recovery,
@@ -399,7 +518,6 @@ func TestRecover(t *testing.T) {
 			defer log.Sync()
 
 			api := &ClientAPI{
-				data:     tc.data,
 				txHandle: tc.store,
 				recovery: tc.recovery,
 				core:     tc.core,
@@ -488,7 +606,8 @@ func (c *fakeCore) GetState() (state.State, string, error) {
 	return c.state, c.getStateMsg, c.getStateErr
 }
 
-func (c *fakeCore) GenerateSecrets(newSecrets map[string]manifest.Secret, _ uuid.UUID, rootCert *x509.Certificate, privK *ecdsa.PrivateKey,
+func (c *fakeCore) GenerateSecrets(
+	newSecrets map[string]manifest.Secret, _ uuid.UUID, rootCert *x509.Certificate, privK *ecdsa.PrivateKey, _ *ecdsa.PrivateKey,
 ) (map[string]manifest.Secret, error) {
 	if c.generateSecretsErr != nil || c.generatedSecrets != nil {
 		return c.generatedSecrets, c.generateSecretsErr
@@ -534,53 +653,9 @@ func (c *fakeCore) GenerateQuote(quoteData []byte) error {
 	return nil
 }
 
-type stubStoreWrapper struct {
-	getCertificateList      map[string]*x509.Certificate
-	getCertificateErr       error
-	getPrivateKeyList       map[string]*ecdsa.PrivateKey
-	getPrivateKeyErr        error
-	rawManifest             []byte
-	getRawManifestErr       error
-	manifestSignature       []byte
-	getManifestSignatureErr error
-	wrapper.Wrapper
-}
-
-func (s *stubStoreWrapper) GetCertificate(certName string) (*x509.Certificate, error) {
-	if s.getCertificateErr != nil {
-		return nil, s.getCertificateErr
-	}
-
-	cert, ok := s.getCertificateList[certName]
-	if !ok {
-		return nil, errors.New("certificate not found")
-	}
-
-	return cert, nil
-}
-
-func (s *stubStoreWrapper) GetPrivateKey(keyName string) (*ecdsa.PrivateKey, error) {
-	if s.getPrivateKeyErr != nil {
-		return nil, s.getPrivateKeyErr
-	}
-
-	key, ok := s.getPrivateKeyList[keyName]
-	if !ok {
-		return nil, errors.New("private key not found")
-	}
-
-	return key, nil
-}
-
-func (s *stubStoreWrapper) GetRawManifest() ([]byte, error) {
-	return s.rawManifest, s.getRawManifestErr
-}
-
-func (s *stubStoreWrapper) GetManifestSignature() ([]byte, error) {
-	return s.manifestSignature, s.getManifestSignatureErr
-}
-
-type stubStore struct {
+type fakeStore struct {
+	store               store.Store
+	beginTransactionErr error
 	recoveryData        []byte
 	encryptionKey       []byte
 	setEncryptionKeyErr error
@@ -589,11 +664,14 @@ type stubStore struct {
 	loadCalled          bool
 }
 
-func (s *stubStore) BeginTransaction() (store.Transaction, error) {
-	return nil, nil
+func (s *fakeStore) BeginTransaction() (store.Transaction, error) {
+	if s.beginTransactionErr != nil {
+		return nil, s.beginTransactionErr
+	}
+	return s.store.BeginTransaction()
 }
 
-func (s *stubStore) SetEncryptionKey(key []byte) error {
+func (s *fakeStore) SetEncryptionKey(key []byte) error {
 	if s.setEncryptionKeyErr != nil {
 		return s.setEncryptionKeyErr
 	}
@@ -601,11 +679,11 @@ func (s *stubStore) SetEncryptionKey(key []byte) error {
 	return nil
 }
 
-func (s *stubStore) SetRecoveryData(recoveryData []byte) {
+func (s *fakeStore) SetRecoveryData(recoveryData []byte) {
 	s.recoveryData = recoveryData
 }
 
-func (s *stubStore) LoadState() ([]byte, error) {
+func (s *fakeStore) LoadState() ([]byte, error) {
 	s.loadCalled = true
 	return s.loadStateRes, s.loadStateErr
 }
@@ -623,15 +701,15 @@ type stubRecovery struct {
 	setRecoveryDataErr       error
 }
 
-func (s *stubRecovery) GenerateEncryptionKey(recoveryKeys map[string]string) ([]byte, error) {
+func (s *stubRecovery) GenerateEncryptionKey(_ map[string]string) ([]byte, error) {
 	return s.generateEncryptionKeyRes, s.generateEncryptionKeyErr
 }
 
-func (s *stubRecovery) GenerateRecoveryData(recoveryKeys map[string]string) (map[string][]byte, []byte, error) {
+func (s *stubRecovery) GenerateRecoveryData(_ map[string]string) (map[string][]byte, []byte, error) {
 	return s.generateRecoveryDataRes, nil, s.generateRecoveryDataErr
 }
 
-func (s *stubRecovery) RecoverKey(secret []byte) (int, []byte, error) {
+func (s *stubRecovery) RecoverKey(_ []byte) (int, []byte, error) {
 	return s.recoverKeysLeft, s.recoverKeyRes, s.recoverKeyErr
 }
 
@@ -639,7 +717,7 @@ func (s *stubRecovery) GetRecoveryData() ([]byte, error) {
 	return s.getRecoveryDataRes, s.getRecoveryDataErr
 }
 
-func (s *stubRecovery) SetRecoveryData(data []byte) error {
+func (s *stubRecovery) SetRecoveryData(_ []byte) error {
 	return s.setRecoveryDataErr
 }
 

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -138,9 +138,7 @@ func TestGetCertQuote(t *testing.T) {
 			var intermediateCert, rootCert *x509.Certificate
 			if !tc.wantErr {
 				intermediateCert = testutil.GetCertificate(t, tc.store, constants.SKCoordinatorIntermediateCert)
-				require.NoError(err)
 				rootCert = testutil.GetCertificate(t, tc.store, constants.SKCoordinatorRootCert)
-				require.NoError(err)
 			}
 
 			cert, quote, err := api.GetCertQuote(context.Background())
@@ -204,9 +202,7 @@ func TestGetManifestSignature(t *testing.T) {
 			var rawManifest, manifestSignature, manifestHash []byte
 			if !tc.wantErr {
 				rawManifest = testutil.GetRawManifest(t, tc.store)
-				require.NoError(err)
 				manifestSignature = testutil.GetManifestSignature(t, tc.store)
-				require.NoError(err)
 				h := sha256.Sum256(rawManifest)
 				manifestHash = h[:]
 			}
@@ -336,7 +332,6 @@ func TestGetSecrets(t *testing.T) {
 			}
 
 			storedSecrets := testutil.GetSecretMap(t, tc.store)
-			require.NoError(err)
 
 			secrets, err := api.GetSecrets(context.Background(), tc.request, tc.user)
 			if tc.wantErr {

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/store/request"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/store/wrapper"
+	"github.com/edgelesssys/marblerun/coordinator/store/wrapper/testutil"
 	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/google/uuid"
@@ -135,9 +136,9 @@ func TestGetCertQuote(t *testing.T) {
 
 			var intermediateCert, rootCert *x509.Certificate
 			if !tc.wantErr {
-				intermediateCert, err = wrapper.New(tc.store).GetCertificate(constants.SKCoordinatorIntermediateCert)
+				intermediateCert = testutil.GetCertificate(t, tc.store, constants.SKCoordinatorIntermediateCert)
 				require.NoError(err)
-				rootCert, err = wrapper.New(tc.store).GetCertificate(constants.SKCoordinatorRootCert)
+				rootCert = testutil.GetCertificate(t, tc.store, constants.SKCoordinatorRootCert)
 				require.NoError(err)
 			}
 
@@ -201,9 +202,9 @@ func TestGetManifestSignature(t *testing.T) {
 
 			var rawManifest, manifestSignature, manifestHash []byte
 			if !tc.wantErr {
-				rawManifest, err = wrapper.New(tc.store).GetRawManifest()
+				rawManifest = testutil.GetRawManifest(t, tc.store)
 				require.NoError(err)
-				manifestSignature, err = wrapper.New(tc.store).GetManifestSignature()
+				manifestSignature = testutil.GetManifestSignature(t, tc.store)
 				require.NoError(err)
 				h := sha256.Sum256(rawManifest)
 				manifestHash = h[:]
@@ -333,7 +334,7 @@ func TestGetSecrets(t *testing.T) {
 				log:      log,
 			}
 
-			storedSecrets, err := wrapper.New(tc.store).GetSecretMap()
+			storedSecrets := testutil.GetSecretMap(t, tc.store)
 			require.NoError(err)
 
 			secrets, err := api.GetSecrets(tc.request, tc.user)

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -8,6 +8,7 @@ package clientapi
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -669,11 +670,11 @@ type fakeStore struct {
 	loadCalled          bool
 }
 
-func (s *fakeStore) BeginTransaction() (store.Transaction, error) {
+func (s *fakeStore) BeginTransaction(ctx context.Context) (store.Transaction, error) {
 	if s.beginTransactionErr != nil {
 		return nil, s.beginTransactionErr
 	}
-	return s.store.BeginTransaction()
+	return s.store.BeginTransaction(ctx)
 }
 
 func (s *fakeStore) SetEncryptionKey(key []byte) error {

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -219,7 +219,7 @@ func TestGetSecret_Legacy(t *testing.T) {
 
 	secret1, err := data.GetSecret(symmetricSecret)
 	require.NoError(err)
-	secret2, err := c.data.GetSecret(certSecret)
+	secret2, err := data.GetSecret(certSecret)
 	require.NoError(err)
 	admin, err := data.GetUser("admin")
 	require.NoError(err)
@@ -614,7 +614,6 @@ func setupAPI(t *testing.T) (*ClientAPI, wrapper.Wrapper) {
 	require.NoError(err)
 
 	return &ClientAPI{
-		data: wrapper,
 		core: &fakeCore{
 			state:       state.AcceptingManifest,
 			getStateMsg: "status message",

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -7,6 +7,7 @@
 package clientapi
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -34,25 +35,26 @@ import (
 func TestSetManifest_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	rawManifest := []byte(test.ManifestJSON)
 	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal(rawManifest, &manifest))
 
 	c, getter := setupAPI(t)
-	_, err := c.SetManifest(rawManifest)
+	_, err := c.SetManifest(ctx, rawManifest)
 	assert.NoError(err, "SetManifest should succeed on first try")
 	cManifest, err := getter.GetManifest()
 	assert.NoError(err)
 	assert.Equal(manifest, cManifest, "Manifest should be set correctly")
 
-	_, err = c.SetManifest(rawManifest)
+	_, err = c.SetManifest(ctx, rawManifest)
 	assert.Error(err, "SetManifest should fail on the second try")
 	cManifest, err = getter.GetManifest()
 	assert.NoError(err)
 	assert.Equal(manifest, cManifest, "Manifest should still be set correctly")
 
-	_, err = c.SetManifest(rawManifest[:len(rawManifest)-1])
+	_, err = c.SetManifest(ctx, rawManifest[:len(rawManifest)-1])
 	assert.Error(err, "SetManifest should fail on broken json")
 	cManifest, err = getter.GetManifest()
 	assert.NoError(err)
@@ -60,14 +62,14 @@ func TestSetManifest_Legacy(t *testing.T) {
 
 	// use new core
 	c, _ = setupAPI(t)
-	_, err = c.SetManifest(rawManifest[:len(rawManifest)-1])
+	_, err = c.SetManifest(ctx, rawManifest[:len(rawManifest)-1])
 	assert.Error(err, "SetManifest should fail on broken json")
 
 	c, getter = setupAPI(t)
-	_, err = c.SetManifest([]byte(""))
+	_, err = c.SetManifest(ctx, []byte(""))
 	assert.Error(err, "empty string should not be accepted")
 
-	_, err = c.SetManifest(rawManifest)
+	_, err = c.SetManifest(ctx, rawManifest)
 	assert.NoError(err, "SetManifest should succed after failed tries")
 	cManifest, err = getter.GetManifest()
 	assert.NoError(err)
@@ -77,6 +79,7 @@ func TestSetManifest_Legacy(t *testing.T) {
 func TestSetManifestInvalid_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	newTestManifest := func() *manifest.Manifest {
 		rawManifest := []byte(test.ManifestJSON)
@@ -91,7 +94,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 
 		modRawManifest, err := json.Marshal(manifest)
 		require.NoError(err)
-		_, err = a.SetManifest(modRawManifest)
+		_, err = a.SetManifest(ctx, modRawManifest)
 		assert.NoError(err)
 
 		marblePackage.Debug = false
@@ -109,7 +112,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 	}
 	modRawManifest, err := json.Marshal(manifest)
 	require.NoError(err)
-	_, err = a.SetManifest(modRawManifest)
+	_, err = a.SetManifest(ctx, modRawManifest)
 	assert.ErrorContains(err, "manifest does not contain marble package foo")
 
 	// Try setting manifest with all values unset, no debug mode (this should fail)
@@ -126,7 +129,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 	manifest.Packages["backend"] = backendPackage
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
-	_, err = a.SetManifest(modRawManifest)
+	_, err = a.SetManifest(ctx, modRawManifest)
 	assert.ErrorContains(err, "manifest misses value for SignerID in package backend")
 
 	// Enable debug mode, should work now
@@ -139,7 +142,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
-	_, err = a.SetManifest(modRawManifest)
+	_, err = a.SetManifest(ctx, modRawManifest)
 	assert.ErrorContains(err, "manifest misses value for ProductID in package backend")
 
 	// Enable debug mode, should work now
@@ -153,7 +156,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
-	_, err = a.SetManifest(modRawManifest)
+	_, err = a.SetManifest(ctx, modRawManifest)
 	assert.ErrorContains(err, "manifest misses value for SecurityVersion in package backend")
 
 	// Enable debug mode, should work now
@@ -167,7 +170,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
-	_, err = a.SetManifest(modRawManifest)
+	_, err = a.SetManifest(ctx, modRawManifest)
 	assert.NoError(err)
 
 	// Reset & enable debug mode, should also work now
@@ -181,7 +184,7 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 
 	modRawManifest, err = json.Marshal(manifest)
 	require.NoError(err)
-	_, err = a.SetManifest(modRawManifest)
+	_, err = a.SetManifest(ctx, modRawManifest)
 	assert.ErrorContains(err, "manifest specifies both UniqueID *and* SignerID/ProductID/SecurityVersion in package backend")
 
 	// Enable debug mode, should work now
@@ -191,13 +194,14 @@ func TestSetManifestInvalid_Legacy(t *testing.T) {
 func TestGetManifestSignature_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	api, data := setupAPI(t)
 
-	_, err := api.SetManifest([]byte(test.ManifestJSON))
+	_, err := api.SetManifest(ctx, []byte(test.ManifestJSON))
 	assert.NoError(err)
 
-	sigECDSA, hash, manifest := api.GetManifestSignature()
+	sigECDSA, hash, manifest := api.GetManifestSignature(ctx)
 	expectedHash := sha256.Sum256([]byte(test.ManifestJSON))
 	assert.Equal(expectedHash[:], hash)
 
@@ -211,10 +215,11 @@ func TestGetSecret_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, data := setupAPI(t)
+	ctx := context.Background()
 
 	symmetricSecret := "symmetricKeyShared"
 	certSecret := "certShared"
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
 	secret1, err := data.GetSecret(symmetricSecret)
@@ -225,18 +230,18 @@ func TestGetSecret_Legacy(t *testing.T) {
 	require.NoError(err)
 
 	// requested secrets should be the same
-	reqSecrets, err := c.GetSecrets([]string{symmetricSecret, certSecret}, admin)
+	reqSecrets, err := c.GetSecrets(ctx, []string{symmetricSecret, certSecret}, admin)
 	require.NoError(err)
 	assert.True(len(reqSecrets) == 2)
 	assert.Equal(secret1, reqSecrets[symmetricSecret])
 	assert.Equal(secret2, reqSecrets[certSecret])
 
 	// request should fail if the user lacks permissions
-	_, err = c.GetSecrets([]string{symmetricSecret, "restrictedSecret"}, admin)
+	_, err = c.GetSecrets(ctx, []string{symmetricSecret, "restrictedSecret"}, admin)
 	assert.Error(err)
 
 	// requesting a secret should return an empty secret since it was not set
-	sec, err := c.GetSecrets([]string{"symmetricKeyUnset"}, admin)
+	sec, err := c.GetSecrets(ctx, []string{"symmetricKeyUnset"}, admin)
 	require.NoError(err)
 	assert.Empty(sec["symmetricKeyUnset"].Public)
 	assert.Empty(sec["symmetricKeyUnset"].Private)
@@ -246,17 +251,18 @@ func TestGetStatus_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, _ := setupAPI(t)
+	ctx := context.Background()
 
 	// Server should be ready to accept a manifest after initializing a mock core
-	statusCode, status, err := c.GetStatus()
+	statusCode, status, err := c.GetStatus(ctx)
 	assert.NoError(err, "GetStatus failed")
 	assert.EqualValues(state.AcceptingManifest, statusCode, "We should be ready to accept a manifest now, but GetStatus tells us we don't.")
 	assert.NotEmpty(status, "Status string was empty, but should not.")
 
 	// Set a manifest, state should change
-	_, err = c.SetManifest([]byte(test.ManifestJSON))
+	_, err = c.SetManifest(ctx, []byte(test.ManifestJSON))
 	require.NoError(err)
-	statusCode, status, err = c.GetStatus()
+	statusCode, status, err = c.GetStatus(ctx)
 	assert.NoError(err, "GetStatus failed")
 	assert.EqualValues(state.AcceptingMarbles, statusCode, "We should be ready to accept Marbles now, but GetStatus tells us we don't.")
 	assert.NotEmpty(status, "Status string was empty, but should not.")
@@ -265,13 +271,14 @@ func TestGetStatus_Legacy(t *testing.T) {
 func TestWriteSecrets_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	symmetricSecret := "symmetricKeyUnset"
 	certSecret := "certUnset"
 
 	c, data := setupAPI(t)
 
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
 	admin, err := data.GetUser("admin")
@@ -289,7 +296,7 @@ func TestWriteSecrets_Legacy(t *testing.T) {
 	assert.Empty(sec.Private)
 
 	// set a secret
-	err = c.WriteSecrets([]byte(test.UserSecrets), admin)
+	err = c.WriteSecrets(ctx, []byte(test.UserSecrets), admin)
 	require.NoError(err)
 	secret, err := data.GetSecret(symmetricSecret)
 	require.NoError(err)
@@ -304,7 +311,7 @@ func TestWriteSecrets_Legacy(t *testing.T) {
 			"Key": "` + base64.StdEncoding.EncodeToString([]byte("MarbleRun Unit Test")) + `"
 		}
 	}`)
-	err = c.WriteSecrets(genericSecret, admin)
+	err = c.WriteSecrets(ctx, genericSecret, admin)
 	require.NoError(err)
 	secret, err = data.GetSecret("genericSecret")
 	require.NoError(err)
@@ -316,7 +323,7 @@ func TestWriteSecrets_Legacy(t *testing.T) {
 			"Key": "` + base64.StdEncoding.EncodeToString([]byte{0x41, 0x41, 0x00, 0x41}) + `"
 		}
 	}`)
-	err = c.WriteSecrets(genericSecret, admin)
+	err = c.WriteSecrets(ctx, genericSecret, admin)
 	assert.Error(err)
 
 	// try to set a secret incorrect size
@@ -325,7 +332,7 @@ func TestWriteSecrets_Legacy(t *testing.T) {
 			"Key": "` + base64.StdEncoding.EncodeToString([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) + `"
 		}	
 	}`)
-	err = c.WriteSecrets(invalidSecret, admin)
+	err = c.WriteSecrets(ctx, invalidSecret, admin)
 	assert.Error(err)
 }
 
@@ -333,9 +340,10 @@ func TestUpdateManifest_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, data := setupAPI(t)
+	ctx := context.Background()
 
 	// Set manifest
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
 	admin, err := data.GetUser("admin")
@@ -352,7 +360,7 @@ func TestUpdateManifest_Legacy(t *testing.T) {
 	assert.NoError(err)
 
 	// Update manifest
-	err = c.UpdateManifest([]byte(test.UpdateManifest), admin)
+	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	// Get new certificates
@@ -405,7 +413,7 @@ func TestUpdateManifest_Legacy(t *testing.T) {
 	assert.NoError(err)
 
 	// updating the manifest should have produced an entry for "frontend" in the updatelog
-	updateLog, err := c.GetUpdateLog()
+	updateLog, err := c.GetUpdateLog(ctx)
 	assert.NoError(err)
 	assert.Contains(updateLog, `"package":"frontend"`)
 }
@@ -414,10 +422,11 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, data := setupAPI(t)
+	ctx := context.Background()
 
 	// Good update manifests
 	// Set manifest (frontend has SecurityVersion 3)
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 	cPackage, err := data.GetPackage("frontend")
 	assert.NoError(err)
@@ -425,14 +434,14 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 
 	// Try to update with unregistered user
 	someUser := user.NewUser("invalid", nil)
-	err = c.UpdateManifest([]byte(test.UpdateManifest), someUser)
+	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), someUser)
 	assert.Error(err)
 
 	admin, err := data.GetUser("admin")
 	assert.NoError(err)
 
 	// Try to update manifest (frontend's SecurityVersion should rise from 3 to 5)
-	err = c.UpdateManifest([]byte(test.UpdateManifest), admin)
+	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 	cUpdatedPackage, err := data.GetPackage("frontend")
 	assert.NoError(err)
@@ -446,7 +455,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["nonExisting"] = badUpdateManifest.Packages["frontend"]
 	badRawManifest, err := json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	delete(badUpdateManifest.Packages, "nonExisting")
@@ -457,7 +466,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	badModPackage.Debug = false
@@ -467,7 +476,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test if downgrading fails
@@ -477,7 +486,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test if downgrading fails
@@ -487,7 +496,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test if removing a package from a currently existing update manifest fails
@@ -495,14 +504,14 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	delete(badUpdateManifest.Packages, "frontend")
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test what happens if no packages are defined at all
 	badUpdateManifest.Packages = nil
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(badRawManifest, admin)
+	err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 }
 
@@ -540,10 +549,11 @@ func TestUpdateDebugMarble_Legacy(t *testing.T) {
 }`)
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	c, data := setupAPI(t)
 	// Set manifest
-	_, err := c.SetManifest(manifest)
+	_, err := c.SetManifest(ctx, manifest)
 	require.NoError(err)
 
 	admin, err := data.GetUser("admin")
@@ -554,7 +564,7 @@ func TestUpdateDebugMarble_Legacy(t *testing.T) {
 
 	// Try to update manifest
 	// frontend's security version, which was previously unset, should now be set to 5
-	err = c.UpdateManifest([]byte(test.UpdateManifest), admin)
+	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	updatedPackage, err := data.GetPackage("frontend")
@@ -566,11 +576,12 @@ func TestVerifyUser_Legacy(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	c, _ := setupAPI(t)
+	ctx := context.Background()
 
 	adminTestCert, otherTestCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
 
 	// Set a manifest containing an admin certificate
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
 	// Put certificates in slice, as Go's TLS library passes them in an HTTP request
@@ -578,12 +589,12 @@ func TestVerifyUser_Legacy(t *testing.T) {
 	otherTestCertSlice := []*x509.Certificate{otherTestCert}
 
 	// Check if the adminTest certificate is deemed valid (stored in core), and the freshly generated one is deemed false
-	user, err := c.VerifyUser(adminTestCertSlice)
+	user, err := c.VerifyUser(ctx, adminTestCertSlice)
 	assert.NoError(err)
 	assert.Equal(*user.Certificate(), *adminTestCert)
-	_, err = c.VerifyUser(otherTestCertSlice)
+	_, err = c.VerifyUser(ctx, otherTestCertSlice)
 	assert.Error(err)
-	_, err = c.VerifyUser(nil)
+	_, err = c.VerifyUser(ctx, nil)
 	assert.Error(err)
 }
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -66,7 +66,7 @@ type Core struct {
 func (c *Core) RequireState(states ...state.State) error {
 	c.mux.Lock()
 
-	getter, rollback, _, err := wrapper.WrapTransaction(c.txHandle)
+	getter, rollback, _, err := wrapper.WrapTransaction(context.TODO(), c.txHandle)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func NewCore(dnsNames []string, qv quote.Validator, qi quote.Issuer, stor store.
 		c.log.Error("Could not retrieve recovery data from state. Recovery will be unavailable", zap.Error(err))
 	}
 
-	transaction, rollback, commit, err := wrapper.WrapTransaction(c.txHandle)
+	transaction, rollback, commit, err := wrapper.WrapTransaction(context.Background(), c.txHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (c *Core) GetTLSConfig() (*tls.Config, error) {
 //
 // This function initializes a read transaction and should not be called from other functions with ongoing transactions.
 func (c *Core) GetTLSRootCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	data, rollback, _, err := wrapper.WrapTransaction(c.txHandle)
+	data, rollback, _, err := wrapper.WrapTransaction(clientHello.Context(), c.txHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (c *Core) GetTLSRootCertificate(clientHello *tls.ClientHelloInfo) (*tls.Cer
 //
 // This function initializes a read transaction and should not be called from other functions with ongoing transactions.
 func (c *Core) GetTLSMarbleRootCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	data, rollback, _, err := wrapper.WrapTransaction(c.txHandle)
+	data, rollback, _, err := wrapper.WrapTransaction(clientHello.Context(), c.txHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func getClientTLSCert(ctx context.Context) *x509.Certificate {
 
 // GetState returns the current state of the Coordinator.
 func (c *Core) GetState() (state.State, string, error) {
-	data, rollback, _, err := wrapper.WrapTransaction(c.txHandle)
+	data, rollback, _, err := wrapper.WrapTransaction(context.TODO(), c.txHandle)
 	if err != nil {
 		return -1, "Cannot determine coordinator status.", fmt.Errorf("initializing read transaction: %w", err)
 	}
@@ -591,5 +591,5 @@ func (e QuoteError) Error() string {
 }
 
 type transactionHandle interface {
-	BeginTransaction() (store.Transaction, error)
+	BeginTransaction(context.Context) (store.Transaction, error)
 }

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -63,10 +63,10 @@ type Core struct {
 
 // RequireState checks if the Coordinator is in one of the given states.
 // This function locks the Core's mutex and therefore should be paired with `defer c.mux.Unlock()`.
-func (c *Core) RequireState(states ...state.State) error {
+func (c *Core) RequireState(ctx context.Context, states ...state.State) error {
 	c.mux.Lock()
 
-	getter, rollback, _, err := wrapper.WrapTransaction(context.TODO(), c.txHandle)
+	getter, rollback, _, err := wrapper.WrapTransaction(ctx, c.txHandle)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func NewCore(dnsNames []string, qv quote.Validator, qi quote.Issuer, stor store.
 		return nil, err
 	}
 
-	if err := commit(); err != nil {
+	if err := commit(context.Background()); err != nil {
 		return nil, err
 	}
 
@@ -313,8 +313,8 @@ func getClientTLSCert(ctx context.Context) *x509.Certificate {
 }
 
 // GetState returns the current state of the Coordinator.
-func (c *Core) GetState() (state.State, string, error) {
-	data, rollback, _, err := wrapper.WrapTransaction(context.TODO(), c.txHandle)
+func (c *Core) GetState(ctx context.Context) (state.State, string, error) {
+	data, rollback, _, err := wrapper.WrapTransaction(ctx, c.txHandle)
 	if err != nil {
 		return -1, "Cannot determine coordinator status.", fmt.Errorf("initializing read transaction: %w", err)
 	}

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/state"
-	"github.com/edgelesssys/marblerun/coordinator/store"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/store/wrapper/testutil"
 	"github.com/edgelesssys/marblerun/test"
@@ -76,7 +75,7 @@ func TestSeal(t *testing.T) {
 	require.NoError(err)
 
 	// Set manifest. This will seal the state.
-	clientAPI, err := clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
+	clientAPI, err := clientapi.New(c.txHandle, c.recovery, c, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(ctx, []byte(test.ManifestJSON))
 	require.NoError(err)
@@ -92,7 +91,7 @@ func TestSeal(t *testing.T) {
 	// Check sealing with a new core initialized with the sealed state.
 	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
 	require.NoError(err)
-	clientAPI, err = clientapi.New(c2.txHandle.(store.Store), c2.recovery, c2, zapLogger)
+	clientAPI, err = clientapi.New(c2.txHandle, c2.recovery, c2, zapLogger)
 	require.NoError(err)
 	c2State := testutil.GetState(t, c2.txHandle)
 	assert.Equal(state.AcceptingMarbles, c2State)
@@ -130,7 +129,7 @@ func TestRecover(t *testing.T) {
 
 	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
 	require.NoError(err)
-	clientAPI, err := clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
+	clientAPI, err := clientapi.New(c.txHandle, c.recovery, c, zapLogger)
 	require.NoError(err)
 
 	// new core does not allow recover
@@ -151,7 +150,7 @@ func TestRecover(t *testing.T) {
 	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
 	sealer.UnsealError = nil
 	require.NoError(err)
-	clientAPI, err = clientapi.New(c2.txHandle.(store.Store), c2.recovery, c2, zapLogger)
+	clientAPI, err = clientapi.New(c2.txHandle, c2.recovery, c2, zapLogger)
 	require.NoError(err)
 	c2State := testutil.GetState(t, c2.txHandle)
 	require.Equal(state.Recovery, c2State)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -319,6 +319,5 @@ func TestUnsetRestart(t *testing.T) {
 	c2State := testutil.GetState(t, c2.txHandle)
 	assert.Equal(state.AcceptingManifest, c2State)
 	c2Cert := testutil.GetCertificate(t, c2.txHandle, constants.SKCoordinatorRootCert)
-
 	assert.NotEqual(*cCert, *c2Cert)
 }

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -61,7 +61,7 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (res *rpc.A
 	c.metrics.marbleAPI.activation.WithLabelValues(req.GetMarbleType(), req.GetUUID()).Inc()
 
 	defer c.mux.Unlock()
-	if err := c.RequireState(state.AcceptingMarbles); err != nil {
+	if err := c.RequireState(ctx, state.AcceptingMarbles); err != nil {
 		return nil, status.Error(codes.FailedPrecondition, "cannot accept marbles in current state")
 	}
 
@@ -166,7 +166,7 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (res *rpc.A
 			c.log.Error("Could not increment activations", zap.Error(err))
 			return nil, status.Errorf(codes.Internal, "incrementing marble activations: %s", err)
 		}
-		if err := commit(); err != nil {
+		if err := commit(ctx); err != nil {
 			c.log.Error("Committing store transaction failed", zap.Error(err))
 			return nil, status.Errorf(codes.Internal, "committing store transaction: %s", err)
 		}

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -78,7 +78,7 @@ func (c *Core) Activate(ctx context.Context, req *rpc.ActivationReq) (res *rpc.A
 		return nil, status.Error(codes.Unauthenticated, "couldn't get marble TLS certificate")
 	}
 
-	txdata, rollback, commit, err := wrapper.WrapTransaction(c.txHandle)
+	txdata, rollback, commit, err := wrapper.WrapTransaction(ctx, c.txHandle)
 	if err != nil {
 		c.log.Error("Initialize store transaction failed", zap.Error(err))
 		return nil, status.Errorf(codes.Internal, "initializing store transaction: %s", err)

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -78,7 +78,7 @@ func TestActivate(t *testing.T) {
 	// set manifest
 	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
-	_, err = clientAPI.SetManifest([]byte(test.ManifestJSON))
+	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSON))
 	require.NoError(err)
 
 	// activate first backend
@@ -146,7 +146,7 @@ func (ms *marbleSpawner) newMarble(t *testing.T, marbleType string, infraName st
 		},
 	}
 
-	ctx := peer.NewContext(context.TODO(), &peer.Peer{
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
 		AuthInfo: tlsInfo,
 	})
 
@@ -454,6 +454,7 @@ func TestParseSecrets(t *testing.T) {
 func TestSecurityLevelUpdate(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	// parse manifest
 	var manifest manifest.Manifest
@@ -484,7 +485,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	// set manifest
 	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
-	_, err = clientAPI.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err = clientAPI.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
 	admin := testutil.GetUser(t, coreServer.txHandle, "admin")
@@ -494,7 +495,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	spawner.newMarble(t, "frontend", "Azure", true)
 
 	// update manifest
-	err = clientAPI.UpdateManifest([]byte(test.UpdateManifest), admin)
+	err = clientAPI.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	// try to activate another first backend, should fail as required SecurityLevel is now higher after manifest update
@@ -536,7 +537,7 @@ func (ms *marbleSpawner) shortMarbleActivation(t *testing.T, marbleType string, 
 		},
 	}
 
-	ctx := peer.NewContext(context.TODO(), &peer.Peer{
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
 		AuthInfo: tlsInfo,
 	})
 
@@ -597,7 +598,7 @@ func TestActivateWithMissingParameters(t *testing.T) {
 	// set manifest
 	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
-	_, err = clientAPI.SetManifest([]byte(test.ManifestJSONMissingParameters))
+	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSONMissingParameters))
 	require.NoError(err)
 
 	spawner.shortMarbleActivation(t, "frontend", "Azure")

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -206,11 +206,8 @@ func (ms *marbleSpawner) newMarble(t *testing.T, marbleType string, infraName st
 	ms.assert.Equal(cert.IPAddresses, newLeafCert.IPAddresses)
 
 	rootCert := testutil.GetCertificate(t, ms.coreServer.txHandle, constants.SKCoordinatorRootCert)
-	ms.assert.NoError(err)
 	intermediateCert := testutil.GetCertificate(t, ms.coreServer.txHandle, constants.SKCoordinatorIntermediateCert)
-	ms.assert.NoError(err)
 	marbleRootCert := testutil.GetCertificate(t, ms.coreServer.txHandle, constants.SKMarbleRootCert)
-	ms.assert.NoError(err)
 	// Check Signature for both, intermediate certificate and leaf certificate
 	ms.assert.NoError(rootCert.CheckSignature(intermediateCert.SignatureAlgorithm, intermediateCert.RawTBSCertificate, intermediateCert.Signature))
 	ms.assert.NoError(newMarbleRootCert.CheckSignature(newMarbleRootCert.SignatureAlgorithm, newMarbleRootCert.RawTBSCertificate, newMarbleRootCert.Signature))
@@ -488,7 +485,6 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	require.NoError(err)
 
 	admin := testutil.GetUser(t, coreServer.txHandle, "admin")
-	assert.NoError(err)
 
 	// try to activate another first backend, should succeed as SecurityLevel matches the definition in the manifest
 	spawner.newMarble(t, "frontend", "Azure", true)
@@ -504,9 +500,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	coreServer2State := testutil.GetState(t, coreServer2.txHandle)
-	assert.NoError(err)
 	coreServer2UpdatedPkg := testutil.GetPackage(t, coreServer2.txHandle, "frontend")
-	assert.NoError(err)
 	assert.Equal(state.AcceptingMarbles, coreServer2State)
 	assert.EqualValues(5, *coreServer2UpdatedPkg.SecurityVersion)
 
@@ -554,7 +548,6 @@ func (ms *marbleSpawner) shortMarbleActivation(t *testing.T, marbleType string, 
 	params := resp.GetParameters()
 	// Get the marble from the manifest set on the coreServer since this one sets default values for empty values
 	coreServerManifest := testutil.GetManifest(t, ms.coreServer.txHandle)
-	ms.assert.NoError(err)
 	marble = coreServerManifest.Marbles[marbleType]
 	// Validate Files
 	for k, v := range marble.Parameters.Files {

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/state"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
+	"github.com/edgelesssys/marblerun/coordinator/store/wrapper"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/google/uuid"
@@ -204,11 +205,11 @@ func (ms *marbleSpawner) newMarble(marbleType string, infraName string, shouldSu
 	ms.assert.Equal(cert.DNSNames, newLeafCert.DNSNames)
 	ms.assert.Equal(cert.IPAddresses, newLeafCert.IPAddresses)
 
-	rootCert, err := ms.coreServer.data.GetCertificate(constants.SKCoordinatorRootCert)
+	rootCert, err := wrapper.New(ms.coreServer.store).GetCertificate(constants.SKCoordinatorRootCert)
 	ms.assert.NoError(err)
-	intermediateCert, err := ms.coreServer.data.GetCertificate(constants.SKCoordinatorIntermediateCert)
+	intermediateCert, err := wrapper.New(ms.coreServer.store).GetCertificate(constants.SKCoordinatorIntermediateCert)
 	ms.assert.NoError(err)
-	marbleRootCert, err := ms.coreServer.data.GetCertificate(constants.SKMarbleRootCert)
+	marbleRootCert, err := wrapper.New(ms.coreServer.store).GetCertificate(constants.SKMarbleRootCert)
 	ms.assert.NoError(err)
 	// Check Signature for both, intermediate certificate and leaf certificate
 	ms.assert.NoError(rootCert.CheckSignature(intermediateCert.SignatureAlgorithm, intermediateCert.RawTBSCertificate, intermediateCert.Signature))
@@ -485,7 +486,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	_, err = clientAPI.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 
-	admin, err := coreServer.data.GetUser("admin")
+	admin, err := wrapper.New(coreServer.store).GetUser("admin")
 	assert.NoError(err)
 
 	// try to activate another first backend, should succeed as SecurityLevel matches the definition in the manifest
@@ -501,9 +502,9 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	// Use a new core and test if updated manifest persisted after restart
 	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
 	require.NoError(err)
-	coreServer2State, err := coreServer2.data.GetState()
+	coreServer2State, err := wrapper.New(coreServer2.store).GetState()
 	assert.NoError(err)
-	coreServer2UpdatedPkg, err := coreServer2.data.GetPackage("frontend")
+	coreServer2UpdatedPkg, err := wrapper.New(coreServer2.store).GetPackage("frontend")
 	assert.NoError(err)
 	assert.Equal(state.AcceptingMarbles, coreServer2State)
 	assert.EqualValues(5, *coreServer2UpdatedPkg.SecurityVersion)
@@ -551,7 +552,7 @@ func (ms *marbleSpawner) shortMarbleActivation(marbleType string, infraName stri
 	// Validate response
 	params := resp.GetParameters()
 	// Get the marble from the manifest set on the coreServer since this one sets default values for empty values
-	coreServerManifest, err := ms.coreServer.data.GetManifest()
+	coreServerManifest, err := wrapper.New(ms.coreServer.store).GetManifest()
 	ms.assert.NoError(err)
 	marble = coreServerManifest.Marbles[marbleType]
 	// Validate Files

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/state"
-	"github.com/edgelesssys/marblerun/coordinator/store"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/store/wrapper/testutil"
 	"github.com/edgelesssys/marblerun/test"
@@ -76,7 +75,7 @@ func TestActivate(t *testing.T) {
 	spawner.newMarble(t, "backendFirst", "Azure", false)
 
 	// set manifest
-	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
+	clientAPI, err := clientapi.New(coreServer.txHandle, coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSON))
 	require.NoError(err)
@@ -483,7 +482,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 		coreServer: coreServer,
 	}
 	// set manifest
-	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
+	clientAPI, err := clientapi.New(coreServer.txHandle, coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(ctx, []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
@@ -596,7 +595,7 @@ func TestActivateWithMissingParameters(t *testing.T) {
 		coreServer: coreServer,
 	}
 	// set manifest
-	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
+	clientAPI, err := clientapi.New(coreServer.txHandle, coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSONMissingParameters))
 	require.NoError(err)

--- a/coordinator/core/metrics.go
+++ b/coordinator/core/metrics.go
@@ -7,6 +7,8 @@
 package core
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -33,7 +35,7 @@ func newCoreMetrics(factory *promauto.Factory, core *Core, namespace string) *co
 				Help:      "State of the Coordinator.",
 			},
 			func() float64 {
-				state, _, err := core.GetState()
+				state, _, err := core.GetState(context.Background())
 				if err != nil {
 					return float64(0)
 				}

--- a/coordinator/core/metrics.go
+++ b/coordinator/core/metrics.go
@@ -33,7 +33,7 @@ func newCoreMetrics(factory *promauto.Factory, core *Core, namespace string) *co
 				Help:      "State of the Coordinator.",
 			},
 			func() float64 {
-				state, err := core.data.GetState()
+				state, _, err := core.GetState()
 				if err != nil {
 					return float64(0)
 				}

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -76,7 +76,6 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	_, err = clientAPI.Recover(ctx, key)
 	require.NoError(err)
 	state := testutil.GetState(t, c.txHandle)
-	require.NoError(err)
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state), promtest.ToFloat64(c.metrics.coordinatorState))
 }

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/state"
 	"github.com/edgelesssys/marblerun/coordinator/store"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
-	"github.com/edgelesssys/marblerun/coordinator/store/wrapper"
+	"github.com/edgelesssys/marblerun/coordinator/store/wrapper/testutil"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -74,7 +74,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	key := make([]byte, 16)
 	_, err = clientAPI.Recover(key)
 	require.NoError(err)
-	state, err := wrapper.New(c.txHandle.(store.Store)).GetState()
+	state := testutil.GetState(t, c.txHandle)
 	require.NoError(err)
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state), promtest.ToFloat64(c.metrics.coordinatorState))
@@ -118,7 +118,7 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	}
 
 	// try to activate first backend marble prematurely before manifest is set
-	uuid := spawner.newMarble("backendFirst", "Azure", false)
+	uuid := spawner.newMarble(t, "backendFirst", "Azure", false)
 	promtest.CollectAndCount(metrics.activation)
 	promtest.CollectAndCount(metrics.activationSuccess)
 	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", uuid)))
@@ -131,14 +131,14 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	require.NoError(err)
 
 	// activate first backend
-	uuid = spawner.newMarble("backendFirst", "Azure", true)
+	uuid = spawner.newMarble(t, "backendFirst", "Azure", true)
 	promtest.CollectAndCount(metrics.activation)
 	promtest.CollectAndCount(metrics.activationSuccess)
 	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", uuid)))
 	assert.Equal(float64(1), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", uuid)))
 
 	// try to activate another first backend
-	uuid = spawner.newMarble("backendFirst", "Azure", false)
+	uuid = spawner.newMarble(t, "backendFirst", "Azure", false)
 	promtest.CollectAndCount(metrics.activation)
 	promtest.CollectAndCount(metrics.activationSuccess)
 	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", uuid)))

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/state"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
+	"github.com/edgelesssys/marblerun/coordinator/store/wrapper"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -72,7 +73,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	key := make([]byte, 16)
 	_, err = clientAPI.Recover(key)
 	require.NoError(err)
-	state, err := c.data.GetState()
+	state, err := wrapper.New(c.store).GetState()
 	require.NoError(err)
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state), promtest.ToFloat64(c.metrics.coordinatorState))

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/state"
-	"github.com/edgelesssys/marblerun/coordinator/store"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/store/wrapper/testutil"
 	"github.com/edgelesssys/marblerun/test"
@@ -51,7 +50,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state.AcceptingManifest), promtest.ToFloat64(c.metrics.coordinatorState))
 
-	clientAPI, err := clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
+	clientAPI, err := clientapi.New(c.txHandle, c.recovery, c, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(ctx, []byte(test.ManifestJSON))
 	require.NoError(err)
@@ -70,7 +69,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state.Recovery), promtest.ToFloat64(c.metrics.coordinatorState))
 
-	clientAPI, err = clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
+	clientAPI, err = clientapi.New(c.txHandle, c.recovery, c, zapLogger)
 	require.NoError(err)
 
 	key := make([]byte, 16)
@@ -127,7 +126,7 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	assert.Equal(float64(0), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", uuid)))
 
 	// set manifest
-	clientAPI, err := clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
+	clientAPI, err := clientapi.New(c.txHandle, c.recovery, c, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSON))
 	require.NoError(err)

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -7,6 +7,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -31,6 +32,7 @@ import (
 func TestStoreWrapperMetrics(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	ctx := context.Background()
 
 	zapLogger, err := zap.NewDevelopment()
 	require.NoError(err)
@@ -51,7 +53,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 
 	clientAPI, err := clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
 	require.NoError(err)
-	_, err = clientAPI.SetManifest([]byte(test.ManifestJSON))
+	_, err = clientAPI.SetManifest(ctx, []byte(test.ManifestJSON))
 	require.NoError(err)
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state.AcceptingMarbles), promtest.ToFloat64(c.metrics.coordinatorState))
@@ -72,7 +74,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	require.NoError(err)
 
 	key := make([]byte, 16)
-	_, err = clientAPI.Recover(key)
+	_, err = clientAPI.Recover(ctx, key)
 	require.NoError(err)
 	state := testutil.GetState(t, c.txHandle)
 	require.NoError(err)
@@ -127,7 +129,7 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	// set manifest
 	clientAPI, err := clientapi.New(c.txHandle.(store.Store), c.recovery, c, zapLogger)
 	require.NoError(err)
-	_, err = clientAPI.SetManifest([]byte(test.ManifestJSON))
+	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSON))
 	require.NoError(err)
 
 	// activate first backend

--- a/coordinator/core/openssl_test.go
+++ b/coordinator/core/openssl_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
+	"github.com/edgelesssys/marblerun/coordinator/store"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/edgelesssys/marblerun/util"
@@ -52,14 +53,14 @@ func TestOpenSSLVerify(t *testing.T) {
 	// create core
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
-	store := stdstore.New(&seal.MockSealer{})
+	stor := stdstore.New(&seal.MockSealer{})
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, store, recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stor, recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
 	// set manifest
-	clientAPI, err := clientapi.New(coreServer.store, coreServer.recovery, coreServer, zapLogger)
+	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest([]byte(test.ManifestJSON))
 	require.NoError(err)

--- a/coordinator/core/openssl_test.go
+++ b/coordinator/core/openssl_test.go
@@ -62,7 +62,7 @@ func TestOpenSSLVerify(t *testing.T) {
 	// set manifest
 	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
-	_, err = clientAPI.SetManifest([]byte(test.ManifestJSON))
+	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSON))
 	require.NoError(err)
 
 	// create marble
@@ -87,7 +87,7 @@ func TestOpenSSLVerify(t *testing.T) {
 		},
 	}
 
-	ctx := peer.NewContext(context.TODO(), &peer.Peer{
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
 		AuthInfo: tlsInfo,
 	})
 

--- a/coordinator/core/openssl_test.go
+++ b/coordinator/core/openssl_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/recovery"
 	"github.com/edgelesssys/marblerun/coordinator/rpc"
 	"github.com/edgelesssys/marblerun/coordinator/seal"
-	"github.com/edgelesssys/marblerun/coordinator/store"
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/edgelesssys/marblerun/util"
@@ -60,7 +59,7 @@ func TestOpenSSLVerify(t *testing.T) {
 	require.NotNil(coreServer)
 
 	// set manifest
-	clientAPI, err := clientapi.New(coreServer.txHandle.(store.Store), coreServer.recovery, coreServer, zapLogger)
+	clientAPI, err := clientapi.New(coreServer.txHandle, coreServer.recovery, coreServer, zapLogger)
 	require.NoError(err)
 	_, err = clientAPI.SetManifest(context.Background(), []byte(test.ManifestJSON))
 	require.NoError(err)

--- a/coordinator/server/client_api.go
+++ b/coordinator/server/client_api.go
@@ -86,7 +86,7 @@ type clientAPIServer struct {
 //	      200: StatusResponse
 //			 500: ErrorResponse
 func (s *clientAPIServer) statusGet(w http.ResponseWriter, r *http.Request) {
-	statusCode, status, err := s.api.GetStatus()
+	statusCode, status, err := s.api.GetStatus(r.Context())
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -130,7 +130,7 @@ func (s *clientAPIServer) statusGet(w http.ResponseWriter, r *http.Request) {
 //	      200: ManifestResponse
 //			 500: ErrorResponse
 func (s *clientAPIServer) manifestGet(w http.ResponseWriter, r *http.Request) {
-	signatureRootECDSA, signature, manifest := s.api.GetManifestSignature()
+	signatureRootECDSA, signature, manifest := s.api.GetManifestSignature(r.Context())
 	writeJSON(w, ManifestSignatureResp{
 		ManifestSignatureRootECDSA: signatureRootECDSA,
 		ManifestSignature:          hex.EncodeToString(signature),
@@ -161,7 +161,7 @@ func (s *clientAPIServer) manifestPost(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	recoverySecretMap, err := s.api.SetManifest(manifest)
+	recoverySecretMap, err := s.api.SetManifest(r.Context(), manifest)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -217,7 +217,7 @@ func (s *clientAPIServer) manifestPost(w http.ResponseWriter, r *http.Request) {
 //	      200: CertQuoteResponse
 //			 500: ErrorResponse
 func (s *clientAPIServer) quoteGet(w http.ResponseWriter, r *http.Request) {
-	cert, quote, err := s.api.GetCertQuote()
+	cert, quote, err := s.api.GetCertQuote(r.Context())
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -250,7 +250,7 @@ func (s *clientAPIServer) recoverPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Perform recover and receive amount of remaining secrets (for multi-party recovery)
-	remaining, err := s.api.Recover(key)
+	remaining, err := s.api.Recover(r.Context(), key)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -277,7 +277,7 @@ func (s *clientAPIServer) recoverPost(w http.ResponseWriter, r *http.Request) {
 //	      200: UpdateLogResponse
 //			 500: ErrorResponse
 func (s *clientAPIServer) updateGet(w http.ResponseWriter, r *http.Request) {
-	updateLog, err := s.api.GetUpdateLog()
+	updateLog, err := s.api.GetUpdateLog(r.Context())
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -311,7 +311,7 @@ func (s *clientAPIServer) updatePost(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	err = s.api.UpdateManifest(updateManifest, user)
+	err = s.api.UpdateManifest(r.Context(), updateManifest, user)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -362,7 +362,7 @@ func (s *clientAPIServer) secretsGet(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	response, err := s.api.GetSecrets(requestedSecrets, user)
+	response, err := s.api.GetSecrets(r.Context(), requestedSecrets, user)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -402,7 +402,7 @@ func (s *clientAPIServer) secretsPost(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if err := s.api.WriteSecrets(secretManifest, user); err != nil {
+	if err := s.api.WriteSecrets(r.Context(), secretManifest, user); err != nil {
 		writeJSONError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -433,7 +433,7 @@ func (s *clientAPIServer) verifyUser(w http.ResponseWriter, r *http.Request) *us
 		writeJSONError(w, "no client certificate provided", http.StatusUnauthorized)
 		return nil
 	}
-	verifiedUser, err := s.api.VerifyUser(r.TLS.PeerCertificates)
+	verifiedUser, err := s.api.VerifyUser(r.Context(), r.TLS.PeerCertificates)
 	if err != nil {
 		writeJSONError(w, "unauthorized user", http.StatusUnauthorized)
 		return nil

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -8,6 +8,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net"
@@ -32,16 +33,16 @@ import (
 )
 
 type clientAPI interface {
-	SetManifest(rawManifest []byte) (recoverySecretMap map[string][]byte, err error)
-	GetCertQuote() (cert string, certQuote []byte, err error)
-	GetManifestSignature() (manifestSignatureRootECDSA, manifestSignature, manifest []byte)
-	GetSecrets(requestedSecrets []string, requestUser *user.User) (map[string]manifest.Secret, error)
-	GetStatus() (statusCode state.State, status string, err error)
-	GetUpdateLog() (updateLog string, err error)
-	Recover(encryptionKey []byte) (int, error)
-	VerifyUser(clientCerts []*x509.Certificate) (*user.User, error)
-	UpdateManifest(rawUpdateManifest []byte, updater *user.User) error
-	WriteSecrets(rawSecretManifest []byte, updater *user.User) error
+	SetManifest(ctx context.Context, rawManifest []byte) (recoverySecretMap map[string][]byte, err error)
+	GetCertQuote(context.Context) (cert string, certQuote []byte, err error)
+	GetManifestSignature(context.Context) (manifestSignatureRootECDSA, manifestSignature, manifest []byte)
+	GetSecrets(ctx context.Context, requestedSecrets []string, requestUser *user.User) (map[string]manifest.Secret, error)
+	GetStatus(context.Context) (statusCode state.State, status string, err error)
+	GetUpdateLog(context.Context) (updateLog string, err error)
+	Recover(ctx context.Context, encryptionKey []byte) (int, error)
+	VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.User, error)
+	UpdateManifest(ctx context.Context, rawUpdateManifest []byte, updater *user.User) error
+	WriteSecrets(ctx context.Context, rawSecretManifest []byte, updater *user.User) error
 }
 
 // RunMarbleServer starts a gRPC with the given Coordinator core.

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -56,7 +57,7 @@ func TestManifest(t *testing.T) {
 	mux.ServeHTTP(resp, req)
 	require.Equal(http.StatusOK, resp.Code)
 
-	sigRootECDSA, sig, manifest := c.GetManifestSignature()
+	sigRootECDSA, sig, manifest := c.GetManifestSignature(context.Background())
 	assert.JSONEq(`{"status":"success","data":{"ManifestSignatureRootECDSA":"`+base64.StdEncoding.EncodeToString(sigRootECDSA)+`","ManifestSignature":"`+hex.EncodeToString(sig)+`","Manifest":"`+base64.StdEncoding.EncodeToString(manifest)+`"}}`, resp.Body.String())
 
 	// try setting manifest again, should fail
@@ -103,7 +104,7 @@ func TestGetUpdateLog(t *testing.T) {
 
 	// Setup mock core and set a manifest
 	c := newTestClientAPI(t)
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(context.Background(), []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 	mux := CreateServeMux(c, nil)
 
@@ -120,7 +121,7 @@ func TestUpdate(t *testing.T) {
 
 	// Setup mock core and set a manifest
 	c := newTestClientAPI(t)
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(context.Background(), []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 	mux := CreateServeMux(c, nil)
 
@@ -137,7 +138,7 @@ func TestReadSecret(t *testing.T) {
 
 	// Setup mock core and set a manifest
 	c := newTestClientAPI(t)
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(context.Background(), []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 	mux := CreateServeMux(c, nil)
 
@@ -154,7 +155,7 @@ func TestSetSecret(t *testing.T) {
 
 	// Setup mock core and set a manifest
 	c := newTestClientAPI(t)
-	_, err := c.SetManifest([]byte(test.ManifestJSONWithRecoveryKey))
+	_, err := c.SetManifest(context.Background(), []byte(test.ManifestJSONWithRecoveryKey))
 	require.NoError(err)
 	mux := CreateServeMux(c, nil)
 

--- a/coordinator/store/stdstore/stdstore.go
+++ b/coordinator/store/stdstore/stdstore.go
@@ -7,6 +7,7 @@
 package stdstore
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -57,7 +58,7 @@ func (s *StdStore) Put(request string, requestData []byte) error {
 	if err := tx.Put(request, requestData); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return tx.Commit(context.Background())
 }
 
 // Delete removes a value from StdStore.
@@ -70,7 +71,7 @@ func (s *StdStore) Delete(request string) error {
 	if err := tx.Delete(request); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return tx.Commit(context.Background())
 }
 
 // Iterator returns an iterator for keys saved in StdStore with a given prefix.
@@ -87,7 +88,7 @@ func (s *StdStore) Iterator(prefix string) (store.Iterator, error) {
 }
 
 // BeginTransaction starts a new transaction.
-func (s *StdStore) BeginTransaction() (store.Transaction, error) {
+func (s *StdStore) BeginTransaction(_ context.Context) (store.Transaction, error) {
 	return s.beginTransaction()
 }
 
@@ -199,7 +200,7 @@ func (t *StdTransaction) Iterator(prefix string) (store.Iterator, error) {
 }
 
 // Commit ends a transaction and persists the changes.
-func (t *StdTransaction) Commit() error {
+func (t *StdTransaction) Commit(_ context.Context) error {
 	if err := t.store.commit(t.data); err != nil {
 		return err
 	}

--- a/coordinator/store/stdstore/stdstore_test.go
+++ b/coordinator/store/stdstore/stdstore_test.go
@@ -7,6 +7,7 @@
 package stdstore
 
 import (
+	"context"
 	"testing"
 
 	"github.com/edgelesssys/marblerun/coordinator/seal"
@@ -16,6 +17,7 @@ import (
 
 func TestStdStore(t *testing.T) {
 	assert := assert.New(t)
+	ctx := context.Background()
 
 	str := New(&seal.MockSealer{})
 	_, err := str.LoadState()
@@ -29,11 +31,11 @@ func TestStdStore(t *testing.T) {
 	assert.Error(err)
 
 	// test Put method
-	tx, err := str.BeginTransaction()
+	tx, err := str.BeginTransaction(ctx)
 	assert.NoError(err)
 	assert.NoError(tx.Put("test:input", testData1))
 	assert.NoError(tx.Put("another:input", testData2))
-	assert.NoError(tx.Commit())
+	assert.NoError(tx.Commit(ctx))
 
 	// make sure values have been set
 	val, err := str.Get("test:input")
@@ -123,6 +125,7 @@ func TestStdStoreSealing(t *testing.T) {
 
 func TestStdStoreRollback(t *testing.T) {
 	assert := assert.New(t)
+	ctx := context.Background()
 
 	store := New(&seal.MockSealer{})
 	_, err := store.LoadState()
@@ -133,13 +136,13 @@ func TestStdStoreRollback(t *testing.T) {
 	testData3 := []byte("and even more data")
 
 	// save data to store and seal
-	tx, err := store.BeginTransaction()
+	tx, err := store.BeginTransaction(ctx)
 	assert.NoError(err)
 	assert.NoError(tx.Put("test:input", testData1))
-	assert.NoError(tx.Commit())
+	assert.NoError(tx.Commit(ctx))
 
 	// save more data to store
-	tx, err = store.BeginTransaction()
+	tx, err = store.BeginTransaction(ctx)
 	assert.NoError(err)
 	assert.NoError(tx.Put("another:input", testData2))
 
@@ -152,10 +155,10 @@ func TestStdStoreRollback(t *testing.T) {
 	assert.Error(err)
 
 	// save something new
-	tx, err = store.BeginTransaction()
+	tx, err = store.BeginTransaction(ctx)
 	assert.NoError(err)
 	assert.NoError(tx.Put("last:input", testData3))
-	assert.NoError(tx.Commit())
+	assert.NoError(tx.Commit(ctx))
 
 	// verify values
 	val, err = store.Get("test:input")

--- a/coordinator/store/store.go
+++ b/coordinator/store/store.go
@@ -14,12 +14,6 @@ import (
 type Store interface {
 	// BeginTransaction starts a new transaction.
 	BeginTransaction() (Transaction, error)
-	// Get returns a value from store by key.
-	Get(string) ([]byte, error)
-	// Put saves a value to store by key.
-	Put(string, []byte) error
-	// Iterator returns an Iterator for a given prefix.
-	Iterator(string) (Iterator, error)
 	// SetEncryptionKey sets the encryption key for the store.
 	SetEncryptionKey([]byte) error
 	// SetRecoveryData sets recovery data for the store.

--- a/coordinator/store/store.go
+++ b/coordinator/store/store.go
@@ -7,13 +7,14 @@
 package store
 
 import (
+	"context"
 	"errors"
 )
 
 // Store is the interface for persistence.
 type Store interface {
 	// BeginTransaction starts a new transaction.
-	BeginTransaction() (Transaction, error)
+	BeginTransaction(context.Context) (Transaction, error)
 	// SetEncryptionKey sets the encryption key for the store.
 	SetEncryptionKey([]byte) error
 	// SetRecoveryData sets recovery data for the store.
@@ -33,7 +34,7 @@ type Transaction interface {
 	// Iterator returns an Iterator for a given prefix
 	Iterator(string) (Iterator, error)
 	// Commit ends a transaction and persists the changes
-	Commit() error
+	Commit(context.Context) error
 	// Rollback aborts a transaction. Noop if already committed.
 	Rollback()
 }

--- a/coordinator/store/wrapper/testutil/testutil.go
+++ b/coordinator/store/wrapper/testutil/testutil.go
@@ -1,0 +1,125 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package testutil provides utility functions to access store values in unit tests.
+package testutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"testing"
+
+	"github.com/edgelesssys/marblerun/coordinator/manifest"
+	"github.com/edgelesssys/marblerun/coordinator/quote"
+	"github.com/edgelesssys/marblerun/coordinator/state"
+	"github.com/edgelesssys/marblerun/coordinator/store"
+	"github.com/edgelesssys/marblerun/coordinator/store/wrapper"
+	"github.com/edgelesssys/marblerun/coordinator/user"
+	"github.com/stretchr/testify/require"
+)
+
+type transactionHandle interface {
+	BeginTransaction() (store.Transaction, error)
+}
+
+// GetState returns the current state of the store.
+func GetState(t *testing.T, txHandle transactionHandle) state.State {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	state, err := tx.GetState()
+	require.NoError(t, err)
+	return state
+}
+
+// GetCertificate returns the certificate with the given name.
+func GetCertificate(t *testing.T, txHandle transactionHandle, name string) *x509.Certificate {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	cert, err := tx.GetCertificate(name)
+	require.NoError(t, err)
+	return cert
+}
+
+// GetPrivateKey returns the private key with the given name.
+func GetPrivateKey(t *testing.T, txHandle transactionHandle, name string) *ecdsa.PrivateKey {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	privKey, err := tx.GetPrivateKey(name)
+	require.NoError(t, err)
+	return privKey
+}
+
+// GetSecretMap returns a map of all secrets in the store.
+func GetSecretMap(t *testing.T, txHandle transactionHandle) map[string]manifest.Secret {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	secretMap, err := tx.GetSecretMap()
+	require.NoError(t, err)
+	return secretMap
+}
+
+// GetUser returns the user with the given name.
+func GetUser(t *testing.T, txHandle transactionHandle, name string) *user.User {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	user, err := tx.GetUser(name)
+	require.NoError(t, err)
+	return user
+}
+
+// GetPackage returns the package with the given name.
+func GetPackage(t *testing.T, txHandle transactionHandle, name string) quote.PackageProperties {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	pkg, err := tx.GetPackage(name)
+	require.NoError(t, err)
+	return pkg
+}
+
+// GetManifest returns the manifest.
+func GetManifest(t *testing.T, txHandle transactionHandle) manifest.Manifest {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	manifest, err := tx.GetManifest()
+	require.NoError(t, err)
+	return manifest
+}
+
+// GetRawManifest returns the raw manifest.
+func GetRawManifest(t *testing.T, txHandle transactionHandle) []byte {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	manifest, err := tx.GetRawManifest()
+	require.NoError(t, err)
+	return manifest
+}
+
+// GetManifestSignature returns the manifest signature.
+func GetManifestSignature(t *testing.T, txHandle transactionHandle) []byte {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	sig, err := tx.GetManifestSignature()
+	require.NoError(t, err)
+	return sig
+}

--- a/coordinator/store/wrapper/testutil/testutil.go
+++ b/coordinator/store/wrapper/testutil/testutil.go
@@ -59,6 +59,17 @@ func GetPrivateKey(t *testing.T, txHandle transactionHandle, name string) *ecdsa
 	return privKey
 }
 
+// GetSecret returns the secret with the given name.
+func GetSecret(t *testing.T, txHandle transactionHandle, name string) manifest.Secret {
+	t.Helper()
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
+	require.NoError(t, err)
+	defer rollback()
+	secret, err := tx.GetSecret(name)
+	require.NoError(t, err)
+	return secret
+}
+
 // GetSecretMap returns a map of all secrets in the store.
 func GetSecretMap(t *testing.T, txHandle transactionHandle) map[string]manifest.Secret {
 	t.Helper()

--- a/coordinator/store/wrapper/testutil/testutil.go
+++ b/coordinator/store/wrapper/testutil/testutil.go
@@ -26,112 +26,117 @@ type transactionHandle interface {
 	BeginTransaction(context.Context) (store.Transaction, error)
 }
 
-// GetState returns the current state of the store.
-func GetState(t *testing.T, txHandle transactionHandle) state.State {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	state, err := tx.GetState()
-	require.NoError(t, err)
-	return state
+// GetActivations returns the number of activations for a given Marble.
+func GetActivations(t *testing.T, txHandle transactionHandle, name string) uint {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (uint, error) {
+		return tx.GetActivations(name)
+	})
 }
 
 // GetCertificate returns the certificate with the given name.
 func GetCertificate(t *testing.T, txHandle transactionHandle, name string) *x509.Certificate {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	cert, err := tx.GetCertificate(name)
-	require.NoError(t, err)
-	return cert
+	return get(t, txHandle, func(tx wrapper.Wrapper) (*x509.Certificate, error) {
+		return tx.GetCertificate(name)
+	})
 }
 
-// GetPrivateKey returns the private key with the given name.
-func GetPrivateKey(t *testing.T, txHandle transactionHandle, name string) *ecdsa.PrivateKey {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	privKey, err := tx.GetPrivateKey(name)
-	require.NoError(t, err)
-	return privKey
+// GetInfrastructure returns infrastructure information.
+func GetInfrastructure(t *testing.T, txHandle transactionHandle, name string) quote.InfrastructureProperties {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (quote.InfrastructureProperties, error) {
+		return tx.GetInfrastructure(name)
+	})
 }
 
-// GetSecret returns the secret with the given name.
-func GetSecret(t *testing.T, txHandle transactionHandle, name string) manifest.Secret {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	secret, err := tx.GetSecret(name)
-	require.NoError(t, err)
-	return secret
-}
-
-// GetSecretMap returns a map of all secrets in the store.
-func GetSecretMap(t *testing.T, txHandle transactionHandle) map[string]manifest.Secret {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	secretMap, err := tx.GetSecretMap()
-	require.NoError(t, err)
-	return secretMap
-}
-
-// GetUser returns the user with the given name.
-func GetUser(t *testing.T, txHandle transactionHandle, name string) *user.User {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	user, err := tx.GetUser(name)
-	require.NoError(t, err)
-	return user
+// GetMarble returns the marble with the given name.
+func GetMarble(t *testing.T, txHandle transactionHandle, name string) manifest.Marble {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (manifest.Marble, error) {
+		return tx.GetMarble(name)
+	})
 }
 
 // GetPackage returns the package with the given name.
 func GetPackage(t *testing.T, txHandle transactionHandle, name string) quote.PackageProperties {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	pkg, err := tx.GetPackage(name)
-	require.NoError(t, err)
-	return pkg
+	return get(t, txHandle, func(tx wrapper.Wrapper) (quote.PackageProperties, error) {
+		return tx.GetPackage(name)
+	})
+}
+
+// GetPrivateKey returns the private key with the given name.
+func GetPrivateKey(t *testing.T, txHandle transactionHandle, name string) *ecdsa.PrivateKey {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (*ecdsa.PrivateKey, error) {
+		return tx.GetPrivateKey(name)
+	})
 }
 
 // GetManifest returns the manifest.
 func GetManifest(t *testing.T, txHandle transactionHandle) manifest.Manifest {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	manifest, err := tx.GetManifest()
-	require.NoError(t, err)
-	return manifest
+	return get(t, txHandle, func(tx wrapper.Wrapper) (manifest.Manifest, error) {
+		return tx.GetManifest()
+	})
 }
 
 // GetRawManifest returns the raw manifest.
 func GetRawManifest(t *testing.T, txHandle transactionHandle) []byte {
-	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
-	require.NoError(t, err)
-	defer rollback()
-	manifest, err := tx.GetRawManifest()
-	require.NoError(t, err)
-	return manifest
+	return get(t, txHandle, func(tx wrapper.Wrapper) ([]byte, error) {
+		return tx.GetRawManifest()
+	})
 }
 
 // GetManifestSignature returns the manifest signature.
 func GetManifestSignature(t *testing.T, txHandle transactionHandle) []byte {
+	return get(t, txHandle, func(tx wrapper.Wrapper) ([]byte, error) {
+		return tx.GetManifestSignature()
+	})
+}
+
+// GetSecret returns the secret with the given name.
+func GetSecret(t *testing.T, txHandle transactionHandle, name string) manifest.Secret {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (manifest.Secret, error) {
+		return tx.GetSecret(name)
+	})
+}
+
+// GetSecretMap returns a map of all secrets in the store.
+func GetSecretMap(t *testing.T, txHandle transactionHandle) map[string]manifest.Secret {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (map[string]manifest.Secret, error) {
+		return tx.GetSecretMap()
+	})
+}
+
+// GetState returns the current state of the store.
+func GetState(t *testing.T, txHandle transactionHandle) state.State {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (state.State, error) {
+		return tx.GetState()
+	})
+}
+
+// GetTLS returns the TLS config with the given name.
+func GetTLS(t *testing.T, txHandle transactionHandle, name string) manifest.TLStag {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (manifest.TLStag, error) {
+		return tx.GetTLS(name)
+	})
+}
+
+// GetUpdateLog returns the update log.
+func GetUpdateLog(t *testing.T, txHandle transactionHandle) string {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (string, error) {
+		return tx.GetUpdateLog()
+	})
+}
+
+// GetUser returns the user with the given name.
+func GetUser(t *testing.T, txHandle transactionHandle, name string) *user.User {
+	return get(t, txHandle, func(tx wrapper.Wrapper) (*user.User, error) {
+		return tx.GetUser(name)
+	})
+}
+
+func get[T any](t *testing.T, txHandle transactionHandle, getter func(wrapper.Wrapper) (T, error)) T {
 	t.Helper()
 	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
-	sig, err := tx.GetManifestSignature()
+	val, err := getter(tx)
 	require.NoError(t, err)
-	return sig
+	return val
 }

--- a/coordinator/store/wrapper/testutil/testutil.go
+++ b/coordinator/store/wrapper/testutil/testutil.go
@@ -8,6 +8,7 @@
 package testutil
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"testing"
@@ -22,13 +23,13 @@ import (
 )
 
 type transactionHandle interface {
-	BeginTransaction() (store.Transaction, error)
+	BeginTransaction(context.Context) (store.Transaction, error)
 }
 
 // GetState returns the current state of the store.
 func GetState(t *testing.T, txHandle transactionHandle) state.State {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	state, err := tx.GetState()
@@ -39,7 +40,7 @@ func GetState(t *testing.T, txHandle transactionHandle) state.State {
 // GetCertificate returns the certificate with the given name.
 func GetCertificate(t *testing.T, txHandle transactionHandle, name string) *x509.Certificate {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	cert, err := tx.GetCertificate(name)
@@ -50,7 +51,7 @@ func GetCertificate(t *testing.T, txHandle transactionHandle, name string) *x509
 // GetPrivateKey returns the private key with the given name.
 func GetPrivateKey(t *testing.T, txHandle transactionHandle, name string) *ecdsa.PrivateKey {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	privKey, err := tx.GetPrivateKey(name)
@@ -61,7 +62,7 @@ func GetPrivateKey(t *testing.T, txHandle transactionHandle, name string) *ecdsa
 // GetSecretMap returns a map of all secrets in the store.
 func GetSecretMap(t *testing.T, txHandle transactionHandle) map[string]manifest.Secret {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	secretMap, err := tx.GetSecretMap()
@@ -72,7 +73,7 @@ func GetSecretMap(t *testing.T, txHandle transactionHandle) map[string]manifest.
 // GetUser returns the user with the given name.
 func GetUser(t *testing.T, txHandle transactionHandle, name string) *user.User {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	user, err := tx.GetUser(name)
@@ -83,7 +84,7 @@ func GetUser(t *testing.T, txHandle transactionHandle, name string) *user.User {
 // GetPackage returns the package with the given name.
 func GetPackage(t *testing.T, txHandle transactionHandle, name string) quote.PackageProperties {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	pkg, err := tx.GetPackage(name)
@@ -94,7 +95,7 @@ func GetPackage(t *testing.T, txHandle transactionHandle, name string) quote.Pac
 // GetManifest returns the manifest.
 func GetManifest(t *testing.T, txHandle transactionHandle) manifest.Manifest {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	manifest, err := tx.GetManifest()
@@ -105,7 +106,7 @@ func GetManifest(t *testing.T, txHandle transactionHandle) manifest.Manifest {
 // GetRawManifest returns the raw manifest.
 func GetRawManifest(t *testing.T, txHandle transactionHandle) []byte {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	manifest, err := tx.GetRawManifest()
@@ -116,7 +117,7 @@ func GetRawManifest(t *testing.T, txHandle transactionHandle) []byte {
 // GetManifestSignature returns the manifest signature.
 func GetManifestSignature(t *testing.T, txHandle transactionHandle) []byte {
 	t.Helper()
-	tx, rollback, _, err := wrapper.WrapTransaction(txHandle)
+	tx, rollback, _, err := wrapper.WrapTransaction(context.Background(), txHandle)
 	require.NoError(t, err)
 	defer rollback()
 	sig, err := tx.GetManifestSignature()

--- a/coordinator/store/wrapper/wrapper.go
+++ b/coordinator/store/wrapper/wrapper.go
@@ -22,6 +22,24 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/user"
 )
 
+// WrapTransaction initializes a transaction using the given handle,
+// and returns a wrapper for the transaction, as well as rollback and commit functions.
+func WrapTransaction(txHandle transactionHandle,
+) (wrapper Wrapper, rollback func(), commit func() error, err error) {
+	tx, err := txHandle.BeginTransaction()
+	if err != nil {
+		return Wrapper{}, nil, nil, err
+	}
+	wrapper = New(tx)
+	rollback = func() {
+		tx.Rollback()
+	}
+	commit = func() error {
+		return tx.Commit()
+	}
+	return wrapper, rollback, commit, nil
+}
+
 // Wrapper wraps store functions to provide a more convenient interface,
 // and provides a type-safe way to access the store.
 type Wrapper struct {
@@ -317,4 +335,8 @@ type dataStore interface {
 	Put(string, []byte) error
 	// Iterator returns an Iterator for a given prefix
 	Iterator(string) (store.Iterator, error)
+}
+
+type transactionHandle interface {
+	BeginTransaction() (store.Transaction, error)
 }

--- a/coordinator/store/wrapper/wrapper.go
+++ b/coordinator/store/wrapper/wrapper.go
@@ -31,14 +31,7 @@ func WrapTransaction(ctx context.Context, txHandle transactionHandle,
 	if err != nil {
 		return Wrapper{}, nil, nil, err
 	}
-	wrapper = New(tx)
-	rollback = func() {
-		tx.Rollback()
-	}
-	commit = func(ctx context.Context) error {
-		return tx.Commit(ctx)
-	}
-	return wrapper, rollback, commit, nil
+	return New(tx), tx.Rollback, tx.Commit, nil
 }
 
 // Wrapper wraps store functions to provide a more convenient interface,

--- a/coordinator/store/wrapper/wrapper.go
+++ b/coordinator/store/wrapper/wrapper.go
@@ -7,6 +7,7 @@
 package wrapper
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/json"
@@ -24,9 +25,9 @@ import (
 
 // WrapTransaction initializes a transaction using the given handle,
 // and returns a wrapper for the transaction, as well as rollback and commit functions.
-func WrapTransaction(txHandle transactionHandle,
+func WrapTransaction(ctx context.Context, txHandle transactionHandle,
 ) (wrapper Wrapper, rollback func(), commit func() error, err error) {
-	tx, err := txHandle.BeginTransaction()
+	tx, err := txHandle.BeginTransaction(ctx)
 	if err != nil {
 		return Wrapper{}, nil, nil, err
 	}
@@ -35,7 +36,7 @@ func WrapTransaction(txHandle transactionHandle,
 		tx.Rollback()
 	}
 	commit = func() error {
-		return tx.Commit()
+		return tx.Commit(ctx)
 	}
 	return wrapper, rollback, commit, nil
 }
@@ -338,5 +339,5 @@ type dataStore interface {
 }
 
 type transactionHandle interface {
-	BeginTransaction() (store.Transaction, error)
+	BeginTransaction(context.Context) (store.Transaction, error)
 }

--- a/coordinator/store/wrapper/wrapper.go
+++ b/coordinator/store/wrapper/wrapper.go
@@ -26,7 +26,7 @@ import (
 // WrapTransaction initializes a transaction using the given handle,
 // and returns a wrapper for the transaction, as well as rollback and commit functions.
 func WrapTransaction(ctx context.Context, txHandle transactionHandle,
-) (wrapper Wrapper, rollback func(), commit func() error, err error) {
+) (wrapper Wrapper, rollback func(), commit func(context.Context) error, err error) {
 	tx, err := txHandle.BeginTransaction(ctx)
 	if err != nil {
 		return Wrapper{}, nil, nil, err
@@ -35,7 +35,7 @@ func WrapTransaction(ctx context.Context, txHandle transactionHandle,
 	rollback = func() {
 		tx.Rollback()
 	}
-	commit = func() error {
+	commit = func(ctx context.Context) error {
 		return tx.Commit(ctx)
 	}
 	return wrapper, rollback, commit, nil


### PR DESCRIPTION
### Proposed changes
- Stop embedding store Wrappers in the Coordinator parts
- Only read data from transactions to make sure all information obtained during one call comes from the same state
- Marble Activation: Only commit state if MaxActivations is something we care about, dismiss state changes otherwise.
  - This reduces the amount of state updates we need to perform once MarbleRun is properly set up and running.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
