### PR TITLE
remove context.TODO from CLI

### DIFF
--- a/cli/internal/cmd/check.go
+++ b/cli/internal/cmd/check.go
@@ -21,33 +21,39 @@ import (
 )
 
 func NewCheckCmd() *cobra.Command {
-	var timeout uint
-
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check the status of MarbleRun's control plane",
 		Long:  `Check the status of MarbleRun's control plane`,
 		Args:  cobra.NoArgs,
-		RunE: func(cobracmd *cobra.Command, args []string) error {
-			kubeClient, err := kube.NewClient()
-			if err != nil {
-				return err
-			}
-			return cliCheck(kubeClient, timeout)
-		},
+		RunE:  runCheck,
 	}
 
-	cmd.Flags().UintVar(&timeout, "timeout", 60, "Time to wait before aborting in seconds")
+	cmd.Flags().Uint("timeout", 60, "Time to wait before aborting in seconds")
 	return cmd
 }
 
-// cliCheck if MarbleRun control-plane deployments are ready to use.
-func cliCheck(kubeClient kubernetes.Interface, timeout uint) error {
-	if err := checkDeploymentStatus(kubeClient, helm.InjectorDeployment, helm.Namespace, timeout); err != nil {
+func runCheck(cmd *cobra.Command, args []string) error {
+	kubeClient, err := kube.NewClient()
+	if err != nil {
 		return err
 	}
 
-	if err := checkDeploymentStatus(kubeClient, helm.CoordinatorDeployment, helm.Namespace, timeout); err != nil {
+	timeout, err := cmd.Flags().GetUint("timeout")
+	if err != nil {
+		return err
+	}
+
+	return cliCheck(cmd, kubeClient, timeout)
+}
+
+// cliCheck if MarbleRun control-plane deployments are ready to use.
+func cliCheck(cmd *cobra.Command, kubeClient kubernetes.Interface, timeout uint) error {
+	if err := checkDeploymentStatus(cmd, kubeClient, helm.InjectorDeployment, helm.Namespace, timeout); err != nil {
+		return err
+	}
+
+	if err := checkDeploymentStatus(cmd, kubeClient, helm.CoordinatorDeployment, helm.Namespace, timeout); err != nil {
 		return err
 	}
 
@@ -57,13 +63,13 @@ func cliCheck(kubeClient kubernetes.Interface, timeout uint) error {
 // checkDeploymentStatus checks if a deployment is installed on the cluster.
 // If it is, this function will wait until all replicas have the "available" status (ready for at least minReadySeconds).
 // Current status is continuously printed on screen.
-func checkDeploymentStatus(kubeClient kubernetes.Interface, deploymentName string, namespace string, timeout uint) error {
-	_, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+func checkDeploymentStatus(cmd *cobra.Command, kubeClient kubernetes.Interface, deploymentName string, namespace string, timeout uint) error {
+	_, err := kubeClient.AppsV1().Deployments(namespace).Get(cmd.Context(), deploymentName, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 	if errors.IsNotFound(err) {
-		fmt.Printf("%s is not installed on this cluster\n", deploymentName)
+		cmd.Printf("%s is not installed on this cluster\n", deploymentName)
 	} else {
 		deploymentReady := false
 		var tries uint
@@ -74,11 +80,11 @@ func checkDeploymentStatus(kubeClient kubernetes.Interface, deploymentName strin
 		if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
 			isTTY = true
 			// save current cursor position
-			fmt.Print("\033[s")
+			cmd.Print("\033[s")
 		}
 
 		for !deploymentReady && tries < timeout {
-			deploymentReady, podsReady, err = deploymentIsReady(kubeClient, deploymentName, namespace)
+			deploymentReady, podsReady, err = deploymentIsReady(cmd.Context(), kubeClient, deploymentName, namespace)
 			if err != nil {
 				return err
 			}
@@ -86,16 +92,16 @@ func checkDeploymentStatus(kubeClient kubernetes.Interface, deploymentName strin
 			// if command was run from a terminal we can print continuous updates on the same line
 			if isTTY {
 				// return cursor and clear line
-				fmt.Print("\033[u\033[K")
-				fmt.Printf("%s pods ready: %s", deploymentName, podsReady)
+				cmd.Print("\033[u\033[K")
+				cmd.Printf("%s pods ready: %s", deploymentName, podsReady)
 			} else {
-				fmt.Printf("%s pods ready: %s\n", deploymentName, podsReady)
+				cmd.Printf("%s pods ready: %s\n", deploymentName, podsReady)
 			}
 
 			tries++
 			time.Sleep(1 * time.Second)
 		}
-		fmt.Println()
+		cmd.Println()
 
 		if tries == timeout {
 			return fmt.Errorf("deployment %s was not ready after %d seconds (%s pods available) ", deploymentName, timeout, podsReady)
@@ -106,8 +112,8 @@ func checkDeploymentStatus(kubeClient kubernetes.Interface, deploymentName strin
 }
 
 // deploymentIsReady checks on the status of a single deployment and returns the number of available pods in the form "available/total".
-func deploymentIsReady(kubeClient kubernetes.Interface, deploymentName string, namespace string) (bool, string, error) {
-	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+func deploymentIsReady(ctx context.Context, kubeClient kubernetes.Interface, deploymentName string, namespace string) (bool, string, error) {
+	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 	if err != nil {
 		return false, "", err
 	}

--- a/cli/internal/cmd/check_test.go
+++ b/cli/internal/cmd/check_test.go
@@ -67,7 +67,6 @@ func TestCheckDeploymentStatus(t *testing.T) {
 	testClient := fake.NewSimpleClientset()
 	ctx := context.Background()
 	cmd := &cobra.Command{}
-	cmd.SetContext(ctx)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 
@@ -98,7 +97,6 @@ func TestCliCheck(t *testing.T) {
 	testClient := fake.NewSimpleClientset()
 	ctx := context.Background()
 	cmd := &cobra.Command{}
-	cmd.SetContext(ctx)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 

--- a/cli/internal/cmd/check_test.go
+++ b/cli/internal/cmd/check_test.go
@@ -7,11 +7,13 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
 
 	"github.com/edgelesssys/marblerun/cli/internal/helm"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,8 +25,9 @@ func TestDeploymentIsReady(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	testClient := fake.NewSimpleClientset()
+	ctx := context.Background()
 
-	_, _, err := deploymentIsReady(testClient, helm.CoordinatorDeployment, helm.Namespace)
+	_, _, err := deploymentIsReady(ctx, testClient, helm.CoordinatorDeployment, helm.Namespace)
 	require.Error(err)
 
 	// create fake deployment with one non ready replica
@@ -39,20 +42,20 @@ func TestDeploymentIsReady(t *testing.T) {
 		},
 	}
 
-	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(err)
 
-	ready, status, err := deploymentIsReady(testClient, helm.CoordinatorDeployment, helm.Namespace)
+	ready, status, err := deploymentIsReady(ctx, testClient, helm.CoordinatorDeployment, helm.Namespace)
 	require.NoError(err)
 	assert.False(ready, "function returned true when deployment was not ready")
 	assert.Equal("0/1", status, fmt.Sprintf("expected 0/1 ready pods but got %s", status))
 
 	testDeployment.Status.UnavailableReplicas = 0
 	testDeployment.Status.AvailableReplicas = 1
-	_, err = testClient.AppsV1().Deployments(helm.Namespace).UpdateStatus(context.TODO(), testDeployment, metav1.UpdateOptions{})
+	_, err = testClient.AppsV1().Deployments(helm.Namespace).UpdateStatus(ctx, testDeployment, metav1.UpdateOptions{})
 	require.NoError(err)
 
-	ready, status, err = deploymentIsReady(testClient, helm.CoordinatorDeployment, helm.Namespace)
+	ready, status, err = deploymentIsReady(ctx, testClient, helm.CoordinatorDeployment, helm.Namespace)
 	require.NoError(err)
 	assert.True(ready, "function returned false when deployment was ready")
 	assert.Equal("1/1", status, fmt.Sprintf("expected 1/1 ready pods but got %s", status))
@@ -62,9 +65,14 @@ func TestCheckDeploymentStatus(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	testClient := fake.NewSimpleClientset()
+	ctx := context.Background()
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
 
 	// try without any deployments
-	err := checkDeploymentStatus(testClient, helm.CoordinatorDeployment, helm.Namespace, 10)
+	err := checkDeploymentStatus(cmd, testClient, helm.CoordinatorDeployment, helm.Namespace, 10)
 	assert.NoError(err)
 
 	// create a fake deployment with 1/1 available replicas
@@ -77,10 +85,10 @@ func TestCheckDeploymentStatus(t *testing.T) {
 			AvailableReplicas: 1,
 		},
 	}
-	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(err)
 
-	err = checkDeploymentStatus(testClient, helm.CoordinatorDeployment, helm.Namespace, 10)
+	err = checkDeploymentStatus(cmd, testClient, helm.CoordinatorDeployment, helm.Namespace, 10)
 	assert.NoError(err)
 }
 
@@ -88,9 +96,14 @@ func TestCliCheck(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	testClient := fake.NewSimpleClientset()
+	ctx := context.Background()
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
 
 	// try without any deployments
-	err := cliCheck(testClient, 10)
+	err := cliCheck(cmd, testClient, 10)
 	assert.NoError(err)
 
 	// create a fake deployment with 1/1 available replicas
@@ -103,13 +116,13 @@ func TestCliCheck(t *testing.T) {
 			AvailableReplicas: 1,
 		},
 	}
-	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(ctx, testDeployment, metav1.CreateOptions{})
 	require.NoError(err)
 
-	err = cliCheck(testClient, 10)
+	err = cliCheck(cmd, testClient, 10)
 	assert.NoError(err)
 
-	err = testClient.AppsV1().Deployments(helm.Namespace).Delete(context.TODO(), helm.CoordinatorDeployment, metav1.DeleteOptions{})
+	err = testClient.AppsV1().Deployments(helm.Namespace).Delete(ctx, helm.CoordinatorDeployment, metav1.DeleteOptions{})
 	require.NoError(err)
 
 	timeoutDeployment := &appsv1.Deployment{
@@ -121,9 +134,9 @@ func TestCliCheck(t *testing.T) {
 			UnavailableReplicas: 0,
 		},
 	}
-	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(context.TODO(), timeoutDeployment, metav1.CreateOptions{})
+	_, err = testClient.AppsV1().Deployments(helm.Namespace).Create(ctx, timeoutDeployment, metav1.CreateOptions{})
 	require.NoError(err)
 
-	err = cliCheck(testClient, 2)
+	err = cliCheck(cmd, testClient, 2)
 	assert.Error(err)
 }

--- a/cli/internal/cmd/csr_legay.go
+++ b/cli/internal/cmd/csr_legay.go
@@ -7,6 +7,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -75,7 +76,7 @@ func newCertificateLegacy() (*certificateLegacy, error) {
 }
 
 // get returns the signed certificate of the webhook server.
-func (crt *certificateLegacy) get() ([]byte, error) {
+func (crt *certificateLegacy) get(_ context.Context) ([]byte, error) {
 	certBytes := pem.EncodeToMemory(crt.serverCert)
 	return certBytes, nil
 }
@@ -91,7 +92,7 @@ func (crt *certificateLegacy) setCaBundle() ([]string, error) {
 }
 
 // signRequest signs the webhook certificate using the rootCA.
-func (crt *certificateLegacy) signRequest() error {
+func (crt *certificateLegacy) signRequest(_ context.Context) error {
 	serial, err := util.GenerateCertificateSerialNumber()
 	if err != nil {
 		return err

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -135,7 +135,7 @@ func installWebhook(cmd *cobra.Command, kubeClient kubernetes.Interface) ([]stri
 		return nil, err
 	}
 	cmd.Print(".")
-	if err := certificateHandler.signRequest(); err != nil {
+	if err := certificateHandler.signRequest(cmd.Context()); err != nil {
 		return nil, err
 	}
 	cmd.Print(".")
@@ -143,7 +143,7 @@ func installWebhook(cmd *cobra.Command, kubeClient kubernetes.Interface) ([]stri
 	if err != nil {
 		return nil, err
 	}
-	cert, err := certificateHandler.get()
+	cert, err := certificateHandler.get(cmd.Context())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Proposed changes
- Remove usage of context.TODO from CLI code in favor of using context from the command struct


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
