### PR TITLE
Fix: add missing YAML conversion to manifest verify

### DIFF
--- a/cli/internal/cmd/manifestSet.go
+++ b/cli/internal/cmd/manifestSet.go
@@ -93,9 +93,9 @@ func loadManifestFile(file *file.Handler) ([]byte, error) {
 
 	// if Valid is true the file was in JSON format and we can just return the data
 	if json.Valid(manifestData) {
-		return manifestData, err
+		return manifestData, nil
 	}
 
 	// otherwise we try to convert from YAML to json
-	return yaml.YAMLToJSON(manifestData)
+	return yaml.YAMLToJSONStrict(manifestData)
 }

--- a/cli/internal/cmd/manifestVerify.go
+++ b/cli/internal/cmd/manifestVerify.go
@@ -9,10 +9,11 @@ package cmd
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
-	"os"
 
+	"github.com/edgelesssys/marblerun/cli/internal/file"
 	"github.com/edgelesssys/marblerun/cli/internal/rest"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -51,7 +52,7 @@ func runManifestVerify(cmd *cobra.Command, args []string) error {
 // getSignatureFromString checks if a string is a file or a valid signature.
 func getSignatureFromString(manifest string, fs afero.Afero) (string, error) {
 	if _, err := fs.Stat(manifest); err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, afero.ErrFileNotFound) {
 			return "", err
 		}
 
@@ -67,7 +68,7 @@ func getSignatureFromString(manifest string, fs afero.Afero) (string, error) {
 	}
 
 	// manifest is an existing file -> return the signature of the file
-	rawManifest, err := fs.ReadFile(manifest)
+	rawManifest, err := loadManifestFile(file.New(manifest, fs))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Proposed changes

`marblerun manifest set` allows using a manifest in YAML format.
For this, the manifest is converted from YAML to JSON.
This conversion was missing in the `marblerun manifest verify` command, resulting in failed verification if the manifest is in YAML format.

This PR fixes the issue by using the same function to load the manifest in both `manifest set` and `manifest verify`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
