### PR TITLE
Move file saving from Sealer to StdStore

### DIFF
--- a/cmd/coordinator/enclavemain.go
+++ b/cmd/coordinator/enclavemain.go
@@ -24,7 +24,7 @@ func main() {
 	sealDirPrefix := filepath.Join(filepath.FromSlash("/edg"), "hostfs")
 	sealDir := util.Getenv(constants.SealDir, constants.SealDirDefault())
 	sealDir = filepath.Join(sealDirPrefix, sealDir)
-	sealer := seal.NewAESGCMSealer(sealDir)
+	sealer := seal.NewAESGCMSealer()
 	recovery := recovery.NewSinglePartyRecovery()
 	run(validator, issuer, sealDir, sealer, recovery)
 }

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -22,7 +22,7 @@ func main() {
 	validator := quote.NewFailValidator()
 	issuer := quote.NewFailIssuer()
 	sealDir := util.Getenv(constants.SealDir, constants.SealDirDefault())
-	sealer := seal.NewNoEnclaveSealer(sealDir)
+	sealer := seal.NewNoEnclaveSealer()
 	recovery := recovery.NewSinglePartyRecovery()
 	run(validator, issuer, sealDir, sealer, recovery)
 }

--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/spf13/afero"
 	"go.uber.org/zap"
 )
 
@@ -81,7 +82,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 		go server.RunPrometheusServer(promServerAddr, log, promRegistry, eventlog)
 	}
 
-	store := stdstore.New(sealer)
+	store := stdstore.New(sealer, afero.NewOsFs(), sealDir)
 
 	// creating core
 	log.Info("creating the Core object")

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/updatelog"
 	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/edgelesssys/marblerun/test"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -602,7 +603,7 @@ func setupAPI(t *testing.T) (*ClientAPI, wrapper.Wrapper) {
 	t.Helper()
 	require := require.New(t)
 
-	store := stdstore.New(&seal.MockSealer{})
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	log, err := zap.NewDevelopment()
 	require.NoError(err)
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -149,7 +149,7 @@ func NewCore(
 		if !errors.As(loadErr, &keyErr) {
 			return nil, loadErr
 		}
-		// sealed state was found but couldnt be decrypted, go to recovery mode or reset manifest
+		// sealed state was found, but couldn't be decrypted, go to recovery mode or reset manifest
 		c.log.Error("Failed to decrypt sealed state. Processing with a new state. Use the /recover API endpoint to load an old state, or submit a new manifest to overwrite the old state. Look up the documentation for more information on how to proceed.")
 		if err := c.setCAData(dnsNames, transaction); err != nil {
 			return nil, err
@@ -179,7 +179,7 @@ func NewCore(
 	}
 
 	if err := commit(context.Background()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("committing state: %w", err)
 	}
 
 	err = c.GenerateQuote(rootCert.Raw)

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/google/uuid"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -57,8 +58,9 @@ func TestActivate(t *testing.T) {
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &seal.MockSealer{}
+	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -465,8 +467,9 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &seal.MockSealer{}
+	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -497,7 +500,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	spawner.newMarble(t, "frontend", "Azure", false)
 
 	// Use a new core and test if updated manifest persisted after restart
-	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
+	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	coreServer2State := testutil.GetState(t, coreServer2.txHandle)
 	coreServer2UpdatedPkg := testutil.GetPackage(t, coreServer2.txHandle, "frontend")
@@ -574,8 +577,9 @@ func TestActivateWithMissingParameters(t *testing.T) {
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &seal.MockSealer{}
+	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 

--- a/coordinator/core/openssl_test.go
+++ b/coordinator/core/openssl_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/google/uuid"
 	"github.com/spacemonkeygo/openssl"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -52,7 +53,7 @@ func TestOpenSSLVerify(t *testing.T) {
 	// create core
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
-	stor := stdstore.New(&seal.MockSealer{})
+	stor := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	recovery := recovery.NewSinglePartyRecovery()
 	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stor, recovery, zapLogger, nil, nil)
 	require.NoError(err)

--- a/coordinator/seal/mocksealer.go
+++ b/coordinator/seal/mocksealer.go
@@ -1,0 +1,37 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package seal
+
+// MockSealer is a mockup sealer.
+type MockSealer struct {
+	data            []byte
+	unencryptedData []byte
+	// mock unseal error
+	UnsealError error
+}
+
+// Unseal implements the Sealer interface.
+func (s *MockSealer) Unseal(_ []byte) ([]byte, []byte, error) {
+	return s.unencryptedData, s.data, s.UnsealError
+}
+
+// Seal implements the Sealer interface.
+func (s *MockSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte, error) {
+	s.unencryptedData = unencryptedData
+	s.data = toBeEncrypted
+	return toBeEncrypted, nil
+}
+
+// SetEncryptionKey implements the Sealer interface.
+func (s *MockSealer) SetEncryptionKey(_ []byte) ([]byte, error) {
+	return nil, nil
+}
+
+// UnsealEncryptionKey implements the Sealer interface.
+func (s *MockSealer) UnsealEncryptionKey(key []byte) ([]byte, error) {
+	return key, nil
+}

--- a/coordinator/seal/mocksealer.go
+++ b/coordinator/seal/mocksealer.go
@@ -26,10 +26,14 @@ func (s *MockSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte,
 	return toBeEncrypted, nil
 }
 
-// SetEncryptionKey implements the Sealer interface.
-func (s *MockSealer) SetEncryptionKey(_ []byte) ([]byte, error) {
-	return nil, nil
+// SealEncryptionKey implements the Sealer interface.
+// Since the MockSealer does not support sealing with an enclave key, it returns the key as is.
+func (s *MockSealer) SealEncryptionKey(key []byte) ([]byte, error) {
+	return key, nil
 }
+
+// SetEncryptionKey implements the Sealer interface.
+func (s *MockSealer) SetEncryptionKey(_ []byte) {}
 
 // UnsealEncryptionKey implements the Sealer interface.
 func (s *MockSealer) UnsealEncryptionKey(key []byte) ([]byte, error) {

--- a/coordinator/seal/noenclavesealer.go
+++ b/coordinator/seal/noenclavesealer.go
@@ -37,11 +37,7 @@ func (s *NoEnclaveSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
 	// Decrypt data with the unsealed encryption key and return it
 	decryptedData, err := ecrypto.Decrypt(cipherText, s.encryptionKey, nil)
 	if err != nil {
-		// NoEnclaveSealer needs to return EncryptionKeyError if decryption fails
-		// so that the Coordinator enters recovery mode.
-		// This is required for integration tests to work that corrupt the encryption key.
-		// (The AESGCMSealer already fails in UnsealEncryptionKey with this error.)
-		return unencryptedData, nil, fmt.Errorf("decrypting sealed data: %w", &EncryptionKeyError{Err: err})
+		return unencryptedData, nil, fmt.Errorf("decrypting sealed data: %w", err)
 	}
 
 	return unencryptedData, decryptedData, nil

--- a/coordinator/seal/noenclavesealer.go
+++ b/coordinator/seal/noenclavesealer.go
@@ -1,0 +1,38 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package seal
+
+// NoEnclaveSealer is a sealed for a -noenclave instance and does perform encryption with a fixed key.
+type NoEnclaveSealer struct {
+	encryptionKey []byte
+}
+
+// NewNoEnclaveSealer creates and initializes a new NoEnclaveSealer object.
+func NewNoEnclaveSealer() *NoEnclaveSealer {
+	return &NoEnclaveSealer{}
+}
+
+// Unseal reads the plaintext state from disk.
+func (s *NoEnclaveSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
+	return unsealData(sealedData, s.encryptionKey)
+}
+
+// Seal writes the given data encrypted and the used key as plaintext to the disk.
+func (s *NoEnclaveSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte, error) {
+	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey)
+}
+
+// SetEncryptionKey implements the Sealer interface.
+func (s *NoEnclaveSealer) SetEncryptionKey(key []byte) ([]byte, error) {
+	s.encryptionKey = key
+	return nil, nil
+}
+
+// UnsealEncryptionKey implements the Sealer interface.
+func (s *NoEnclaveSealer) UnsealEncryptionKey(key []byte) ([]byte, error) {
+	return key, nil
+}

--- a/coordinator/seal/noenclavesealer.go
+++ b/coordinator/seal/noenclavesealer.go
@@ -6,7 +6,13 @@
 
 package seal
 
-// NoEnclaveSealer is a sealed for a -noenclave instance and does perform encryption with a fixed key.
+import (
+	"fmt"
+
+	"github.com/edgelesssys/ego/ecrypto"
+)
+
+// NoEnclaveSealer is a sealer for a -noenclave instance and performs encryption with a fixed key.
 type NoEnclaveSealer struct {
 	encryptionKey []byte
 }
@@ -16,12 +22,30 @@ func NewNoEnclaveSealer() *NoEnclaveSealer {
 	return &NoEnclaveSealer{}
 }
 
-// Unseal reads the plaintext state from disk.
+// Unseal decrypts sealedData and returns the decrypted data,
+// as well as the prefixed unencrypted metadata of the cipher text.
 func (s *NoEnclaveSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
-	return unsealData(sealedData, s.encryptionKey)
+	unencryptedData, cipherText, err := prepareCipherText(sealedData)
+	if err != nil {
+		return unencryptedData, nil, err
+	}
+
+	if s.encryptionKey == nil {
+		return unencryptedData, nil, fmt.Errorf("decrypting sealed data: %w", ErrMissingEncryptionKey)
+	}
+
+	// Decrypt data with the unsealed encryption key and return it
+	decryptedData, err := ecrypto.Decrypt(cipherText, s.encryptionKey, nil)
+	if err != nil {
+		// NoEnclaveSealer needs to return EncryptionKeyError if decryption fails
+		// This is required for integration tests to work
+		return unencryptedData, nil, fmt.Errorf("decrypting sealed data: %w", &EncryptionKeyError{Err: err})
+	}
+
+	return unencryptedData, decryptedData, nil
 }
 
-// Seal writes the given data encrypted and the used key as plaintext to the disk.
+// Seal encrypts the given data using the sealer's key.
 func (s *NoEnclaveSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte, error) {
 	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey)
 }
@@ -29,7 +53,7 @@ func (s *NoEnclaveSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]
 // SetEncryptionKey implements the Sealer interface.
 func (s *NoEnclaveSealer) SetEncryptionKey(key []byte) ([]byte, error) {
 	s.encryptionKey = key
-	return nil, nil
+	return key, nil
 }
 
 // UnsealEncryptionKey implements the Sealer interface.

--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -103,7 +103,7 @@ func (s *AESGCMSealer) UnsealEncryptionKey(encryptedKey []byte) ([]byte, error) 
 	// Decrypt stored encryption key with seal key
 	encryptionKey, err := ecrypto.Unseal(encryptedKey, nil)
 	if err != nil {
-		return nil, &EncryptionKeyError{Err: err}
+		return nil, err
 	}
 
 	return encryptionKey, nil

--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -4,59 +4,101 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// Package seal implements sealing operations for the Coordinator.
 package seal
 
 import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
-	"os"
-	"path/filepath"
-	"time"
+	"fmt"
 
 	"github.com/edgelesssys/ego/ecrypto"
 )
 
-// SealedDataFname contains the file name in which the state is sealed on disk in seal_dir.
-const SealedDataFname string = "sealed_data"
+// EncryptionKeyError occurs if the encryption key cannot be unsealed.
+type EncryptionKeyError struct {
+	Err error
+}
 
-// SealedKeyFname contains the file name in which the key is sealed with the seal key on disk in seal_dir.
-const SealedKeyFname string = "sealed_key"
+func (e *EncryptionKeyError) Error() string {
+	return fmt.Sprintf("cannot unseal encryption key: %s", e.Err)
+}
 
-// ErrEncryptionKey occurs if unsealing the encryption key failed.
-var ErrEncryptionKey = errors.New("cannot unseal encryption key")
+func (e *EncryptionKeyError) Unwrap() error {
+	return e.Err
+}
+
+// ErrMissingEncryptionKey occurs if the encryption key is not set.
+var ErrMissingEncryptionKey = errors.New("encryption key not set")
 
 // Sealer is an interface for the Core object to seal information to the filesystem for persistence.
 type Sealer interface {
-	Seal(unencryptedData []byte, toBeEncrypted []byte) error
-	Unseal() (unencryptedData []byte, decryptedData []byte, err error)
-	SetEncryptionKey(key []byte) error
+	Seal(unencryptedData []byte, toBeEncrypted []byte) (encryptedData []byte, err error)
+	Unseal(encryptedData []byte) (unencryptedData []byte, decryptedData []byte, err error)
+	SetEncryptionKey(key []byte) (encryptedKey []byte, err error)
+	UnsealEncryptionKey(encryptedKey []byte) ([]byte, error)
 }
 
-// AESGCMSealer implements the Sealer interface using AES-GCM for confidentiallity and authentication.
+// AESGCMSealer implements the Sealer interface using AES-GCM for confidentiality and authentication.
 type AESGCMSealer struct {
-	sealDir       string
 	encryptionKey []byte
 }
 
 // NewAESGCMSealer creates and initializes a new AESGCMSealer object.
-func NewAESGCMSealer(sealDir string) *AESGCMSealer {
-	return &AESGCMSealer{sealDir: sealDir}
+func NewAESGCMSealer() *AESGCMSealer {
+	return &AESGCMSealer{}
 }
 
 // Unseal reads and decrypts stored information from the fs.
-func (s *AESGCMSealer) Unseal() ([]byte, []byte, error) {
-	// load from fs
-	sealedData, err := os.ReadFile(s.getFname(SealedDataFname))
+func (s *AESGCMSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
+	return unsealData(sealedData, s.encryptionKey)
+}
 
-	if os.IsNotExist(err) {
-		// No sealed data found, back up any existing seal keys
-		s.backupEncryptionKey()
-		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
+// Seal encrypts and stores information to the fs.
+func (s *AESGCMSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte, error) {
+	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey)
+}
+
+// SetEncryptionKey sets or restores an encryption key.
+func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) ([]byte, error) {
+	// Encrypt encryption key with seal key
+	encryptedKeyData, err := ecrypto.SealWithProductKey(encryptionKey, nil)
+	if err != nil {
+		return nil, err
 	}
 
+	s.encryptionKey = encryptionKey
+
+	return encryptedKeyData, nil
+}
+
+// UnsealEncryptionKey unseals the encryption key using the enclave's product key.
+func (s *AESGCMSealer) UnsealEncryptionKey(encryptedKey []byte) ([]byte, error) {
+	// Decrypt stored encryption key with seal key
+	encryptionKey, err := ecrypto.Unseal(encryptedKey, nil)
+	if err != nil {
+		return nil, &EncryptionKeyError{Err: err}
+	}
+
+	return encryptionKey, nil
+}
+
+// GenerateEncryptionKey generates a new random 16 byte encryption key.
+func GenerateEncryptionKey() ([]byte, error) {
+	encryptionKey := make([]byte, 16)
+
+	_, err := rand.Read(encryptionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return encryptionKey, nil
+}
+
+// unsealData decrypts the sealed data using the given key.
+// It returns the unencrypted metadata and the decrypted data.
+func unsealData(sealedData, encryptionKey []byte) (unencryptedData []byte, decryptedData []byte, err error) {
 	if len(sealedData) <= 4 {
 		return nil, nil, errors.New("sealed state is missing data")
 	}
@@ -69,19 +111,17 @@ func (s *AESGCMSealer) Unseal() ([]byte, []byte, error) {
 		return nil, nil, errors.New("sealed state is corrupted, embedded length does not fit the data")
 	}
 
-	var unencryptedData []byte
 	if encodedUnencryptDataLength != 0 {
 		unencryptedData = sealedData[4 : 4+encodedUnencryptDataLength]
 	}
 	ciphertext := sealedData[4+encodedUnencryptDataLength:]
 
-	// Decrypt generated encryption key with seal key, if needed
-	if err = s.unsealEncryptionKey(); err != nil {
-		return unencryptedData, nil, ErrEncryptionKey
+	if encryptionKey == nil {
+		return unencryptedData, nil, ErrMissingEncryptionKey
 	}
 
 	// Decrypt data with the unsealed encryption key and return it
-	decryptedData, err := ecrypto.Decrypt(ciphertext, s.encryptionKey, nil)
+	decryptedData, err = ecrypto.Decrypt(ciphertext, encryptionKey, nil)
 	if err != nil {
 		return unencryptedData, nil, err
 	}
@@ -89,22 +129,17 @@ func (s *AESGCMSealer) Unseal() ([]byte, []byte, error) {
 	return unencryptedData, decryptedData, nil
 }
 
-// Seal encrypts and stores information to the fs.
-func (s *AESGCMSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) error {
-	// If we don't have an AES key to encrypt the state, generate one
-	if err := s.unsealEncryptionKey(); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		if err := s.generateNewEncryptionKey(); err != nil {
-			return err
-		}
+// sealData encrypts data and seals it with the given key.
+// It returns the encrypted data prefixed with the unencrypted data and it's length.
+func sealData(unencryptedData, toBeEncrypted, encryptionKey []byte) ([]byte, error) {
+	if encryptionKey == nil {
+		return nil, ErrMissingEncryptionKey
 	}
 
 	// Encrypt data to seal with generated encryption key
-	encryptedData, err := ecrypto.Encrypt(toBeEncrypted, s.encryptionKey, nil)
+	encryptedData, err := ecrypto.Encrypt(toBeEncrypted, encryptionKey, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	unencryptDataLength := make([]byte, 4)
@@ -114,227 +149,5 @@ func (s *AESGCMSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) error 
 	// Append unencrypted data with encrypted data
 	encryptedData = append(unencryptedData, encryptedData...)
 
-	// store to fs
-	if err := os.WriteFile(s.getFname(SealedDataFname), encryptedData, 0o600); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *AESGCMSealer) getFname(basename string) string {
-	return filepath.Join(s.sealDir, basename)
-}
-
-func (s *AESGCMSealer) unsealEncryptionKey() error {
-	if s.encryptionKey != nil {
-		return nil
-	}
-
-	// Read from fs
-	sealedKeyData, err := os.ReadFile(s.getFname(SealedKeyFname))
-	if err != nil {
-		return err
-	}
-
-	// Decrypt stored encryption key with seal key
-	encryptionKey, err := ecrypto.Unseal(sealedKeyData, nil)
-	if err != nil {
-		return err
-	}
-
-	// Restore encryption key
-	s.encryptionKey = encryptionKey
-
-	return nil
-}
-
-// generateNewEncryptionKey generates a random 128 Bit (16 Byte) key to encrypt the state.
-func (s *AESGCMSealer) generateNewEncryptionKey() error {
-	encryptionKey := make([]byte, 16)
-
-	_, err := rand.Read(encryptionKey)
-	if err != nil {
-		return err
-	}
-
-	return s.SetEncryptionKey(encryptionKey)
-}
-
-// SetEncryptionKey sets or restores an encryption key.
-func (s *AESGCMSealer) SetEncryptionKey(encryptionKey []byte) error {
-	// If there already is an existing key file stored on disk, save it
-	s.backupEncryptionKey()
-
-	// Encrypt encryption key with seal key
-	encryptedKeyData, err := ecrypto.SealWithProductKey(encryptionKey, nil)
-	if err != nil {
-		return err
-	}
-
-	// Write the sealed encryption key to disk
-	if err = os.WriteFile(s.getFname(SealedKeyFname), encryptedKeyData, 0o600); err != nil {
-		return err
-	}
-
-	s.encryptionKey = encryptionKey
-
-	return nil
-}
-
-// backupEncryptionKey creates a backup of an existing seal key.
-func (s *AESGCMSealer) backupEncryptionKey() {
-	if sealedKeyData, err := os.ReadFile(s.getFname(SealedKeyFname)); err == nil {
-		t := time.Now()
-		newFileName := s.getFname(SealedKeyFname) + "_" + t.Format("20060102150405") + ".bak"
-		_ = os.WriteFile(newFileName, sealedKeyData, 0o600)
-	}
-}
-
-// MockSealer is a mockup sealer.
-type MockSealer struct {
-	data            []byte
-	unencryptedData []byte
-	// mock unseal error
-	UnsealError error
-}
-
-// Unseal implements the Sealer interface.
-func (s *MockSealer) Unseal() ([]byte, []byte, error) {
-	return s.unencryptedData, s.data, s.UnsealError
-}
-
-// Seal implements the Sealer interface.
-func (s *MockSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) error {
-	s.unencryptedData = unencryptedData
-	s.data = toBeEncrypted
-	return nil
-}
-
-// SetEncryptionKey implements the Sealer interface.
-func (s *MockSealer) SetEncryptionKey(key []byte) error {
-	return nil
-}
-
-// NoEnclaveSealer is a sealed for a -noenclave instance and does perform encryption with a fixed key.
-type NoEnclaveSealer struct {
-	sealDir       string
-	encryptionKey []byte
-}
-
-// NewNoEnclaveSealer creates and initializes a new NoEnclaveSealer object.
-func NewNoEnclaveSealer(sealDir string) *NoEnclaveSealer {
-	return &NoEnclaveSealer{sealDir: sealDir}
-}
-
-// Seal writes the given data encrypted and the used key as plaintext to the disk.
-func (s *NoEnclaveSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) error {
-	// generate aes key if we have non
-	if err := s.loadEncryptionKey(); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		if err := s.generateNewEncryptionKey(); err != nil {
-			return err
-		}
-	}
-
-	// Encrypt data
-	sealedData, err := ecrypto.Encrypt(toBeEncrypted, s.encryptionKey, nil)
-	if err != nil {
-		return err
-	}
-
-	unencryptDataLength := make([]byte, 4)
-	binary.LittleEndian.PutUint32(unencryptDataLength, uint32(len(unencryptedData)))
-	unencryptedData = append(unencryptDataLength, unencryptedData...)
-
-	// Append unencrypted data with encrypted data
-	sealedData = append(unencryptedData, sealedData...)
-
-	// Write encrypted data to disk
-	if err := os.WriteFile(s.getFname(SealedDataFname), sealedData, 0o600); err != nil {
-		return err
-	}
-
-	// Write key in plaintext to disk
-	if err := os.WriteFile(s.getFname(SealedKeyFname), s.encryptionKey, 0o600); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Unseal reads the plaintext state from disk.
-func (s *NoEnclaveSealer) Unseal() ([]byte, []byte, error) {
-	// Read sealed data from disk
-	sealedData, err := os.ReadFile(s.getFname(SealedDataFname))
-	if os.IsNotExist(err) {
-		return nil, nil, nil
-	} else if err != nil {
-		return nil, nil, err
-	}
-
-	// Read key in plaintext from disk
-	keyData, err := os.ReadFile(s.getFname(SealedKeyFname))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Retrieve recovery secret hash map
-	encodedUnencryptDataLength := binary.LittleEndian.Uint32(sealedData[:4])
-
-	// Check if we do not go out of bounds
-	if 4+int(encodedUnencryptDataLength) > len(sealedData) {
-		return nil, nil, errors.New("sealed state is corrupted, embedded length does not fit the data")
-	}
-
-	var unencryptedData []byte
-	if encodedUnencryptDataLength != 0 {
-		unencryptedData = sealedData[4 : 4+encodedUnencryptDataLength]
-	}
-	ciphertext := sealedData[4+encodedUnencryptDataLength:]
-
-	// Decrypt data with key from disk
-	decryptedData, err := ecrypto.Decrypt(ciphertext, keyData, nil)
-	if err != nil {
-		return unencryptedData, nil, ErrEncryptionKey
-	}
-
-	return unencryptedData, decryptedData, nil
-}
-
-// SetEncryptionKey implements the Sealer interface.
-func (s *NoEnclaveSealer) SetEncryptionKey(key []byte) error {
-	s.encryptionKey = key
-	return os.WriteFile(s.getFname(SealedKeyFname), s.encryptionKey, 0o600)
-}
-
-func (s *NoEnclaveSealer) getFname(basename string) string {
-	return filepath.Join(s.sealDir, basename)
-}
-
-func (s *NoEnclaveSealer) loadEncryptionKey() error {
-	if s.encryptionKey != nil {
-		return nil
-	}
-
-	encrytpionKey, err := os.ReadFile(s.getFname(SealedKeyFname))
-	if err != nil {
-		return err
-	}
-
-	s.encryptionKey = encrytpionKey
-	return nil
-}
-
-// generateNewEncryptionKey generates a random 128 Bit (16 Byte) key to encrypt the state.
-func (s *NoEnclaveSealer) generateNewEncryptionKey() error {
-	encryptionKey := make([]byte, 16)
-
-	_, err := rand.Read(encryptionKey)
-	if err != nil {
-		return err
-	}
-
-	return s.SetEncryptionKey(encryptionKey)
+	return encryptedData, nil
 }

--- a/coordinator/seal/seal_test.go
+++ b/coordinator/seal/seal_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package seal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareCipherText(t *testing.T) {
+	testCases := map[string]struct {
+		sealedData []byte
+		wantErr    bool
+	}{
+		"valid": {
+			sealedData: func() []byte {
+				data := []byte("data")
+				metadata := []byte("metadata")
+
+				metadataLen := make([]byte, 4)
+				binary.LittleEndian.PutUint32(metadataLen, uint32(len(metadata)))
+				metadata = append(metadataLen, metadata...)
+
+				return append(metadata, data...)
+			}(),
+		},
+		"invalid metadata length": {
+			sealedData: func() []byte {
+				data := []byte("data")
+				metadata := []byte("metadata")
+
+				metadataLen := make([]byte, 4)
+				binary.LittleEndian.PutUint32(metadataLen, uint32(10*len(metadata)))
+				metadata = append(metadataLen, metadata...)
+
+				return append(metadata, data...)
+			}(),
+			wantErr: true,
+		},
+		"missing metadata": {
+			sealedData: func() []byte {
+				data := []byte("data")
+
+				metadataLen := make([]byte, 4)
+				binary.LittleEndian.PutUint32(metadataLen, uint32(4096))
+
+				return append(metadataLen, data...)
+			}(),
+
+			wantErr: true,
+		},
+		"invalid format": {
+			sealedData: []byte("AB"),
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			_, _, err := prepareCipherText(tc.sealedData)
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestSealUnseal(t *testing.T) {
+	testCases := map[string]struct {
+		metadata, data, encryptionKey, decryptionKey []byte
+		wantSealErr, wantUnsealErr                   bool
+	}{
+		"valid": {
+			metadata:      []byte("metadata"),
+			data:          []byte("data"),
+			encryptionKey: bytes.Repeat([]byte{0x01}, 16),
+			decryptionKey: bytes.Repeat([]byte{0x01}, 16),
+		},
+		"missing encryption key": {
+			metadata:      []byte("metadata"),
+			data:          []byte("data"),
+			decryptionKey: bytes.Repeat([]byte{0x01}, 16),
+			wantSealErr:   true,
+		},
+		"invalid encryption key length": {
+			metadata:      []byte("metadata"),
+			data:          []byte("data"),
+			encryptionKey: bytes.Repeat([]byte{0x01}, 15),
+			decryptionKey: bytes.Repeat([]byte{0x01}, 16),
+			wantSealErr:   true,
+		},
+		"missing decryption key": {
+			metadata:      []byte("metadata"),
+			data:          []byte("data"),
+			encryptionKey: bytes.Repeat([]byte{0x01}, 16),
+			wantUnsealErr: true,
+		},
+		"invalid decryption key length": {
+			metadata:      []byte("metadata"),
+			data:          []byte("data"),
+			encryptionKey: bytes.Repeat([]byte{0x01}, 16),
+			decryptionKey: bytes.Repeat([]byte{0x01}, 15),
+			wantUnsealErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			sealer := NewAESGCMSealer()
+
+			sealer.encryptionKey = tc.encryptionKey
+			sealedData, err := sealer.Seal(tc.metadata, tc.data)
+			if tc.wantSealErr {
+				assert.Error(err)
+
+				if tc.encryptionKey == nil {
+					assert.ErrorIs(err, ErrMissingEncryptionKey)
+				}
+				return
+			}
+			assert.NoError(err)
+
+			sealer.encryptionKey = tc.decryptionKey
+			metadata, data, err := sealer.Unseal(sealedData)
+			if tc.wantUnsealErr {
+				assert.Error(err)
+
+				if tc.decryptionKey == nil {
+					assert.ErrorIs(err, ErrMissingEncryptionKey)
+				}
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tc.metadata, metadata)
+			assert.Equal(tc.data, data)
+		})
+	}
+}

--- a/coordinator/server/metrics_test.go
+++ b/coordinator/server/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -93,7 +94,7 @@ func newTestClientAPI(t *testing.T) *clientapi.ClientAPI {
 
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
-	store := stdstore.New(&seal.MockSealer{})
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	recovery := recovery.NewSinglePartyRecovery()
 	core, err := core.NewCore([]string{"localhost"}, validator, issuer, store, recovery, log, nil, nil)
 	require.NoError(err)

--- a/coordinator/store/stdstore/stdstore.go
+++ b/coordinator/store/stdstore/stdstore.go
@@ -128,7 +128,7 @@ func (s *StdStore) LoadState() ([]byte, error) {
 		// And retry unsealing the sealed data
 		if err := s.unsealEncryptionKey(); err != nil {
 			s.recoveryMode = true
-			return encodedRecoveryData, fmt.Errorf("unsealing encryption key: %w", err)
+			return encodedRecoveryData, &seal.EncryptionKeyError{Err: err}
 		}
 
 		encodedRecoveryData, stateRaw, err = s.sealer.Unseal(sealedData)

--- a/coordinator/store/stdstore/stdstore_test.go
+++ b/coordinator/store/stdstore/stdstore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/edgelesssys/marblerun/coordinator/seal"
 	"github.com/edgelesssys/marblerun/coordinator/store"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,7 @@ func TestStdStore(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	str := New(&seal.MockSealer{})
+	str := New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	_, err := str.LoadState()
 	assert.NoError(err)
 
@@ -54,7 +55,7 @@ func TestStdIterator(t *testing.T) {
 	assert := assert.New(t)
 
 	sealer := &seal.MockSealer{}
-	store := New(sealer)
+	store := New(sealer, afero.NewMemMapFs(), "")
 	store.data = map[string][]byte{
 		"test:1":    {0x00, 0x11},
 		"test:2":    {0x00, 0x11},
@@ -106,8 +107,10 @@ func TestStdIterator(t *testing.T) {
 func TestStdStoreSealing(t *testing.T) {
 	assert := assert.New(t)
 
+	fs := afero.NewMemMapFs()
 	sealer := &seal.MockSealer{}
-	store := New(sealer)
+
+	store := New(sealer, fs, "")
 	_, err := store.LoadState()
 	assert.NoError(err)
 
@@ -115,7 +118,7 @@ func TestStdStoreSealing(t *testing.T) {
 	assert.NoError(store.Put("test:input", testData1))
 
 	// Check sealing with a new store initialized with the sealed state
-	store2 := New(sealer)
+	store2 := New(sealer, fs, "")
 	_, err = store2.LoadState()
 	assert.NoError(err)
 	val, err := store2.Get("test:input")
@@ -127,7 +130,7 @@ func TestStdStoreRollback(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	store := New(&seal.MockSealer{})
+	store := New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	_, err := store.LoadState()
 	assert.NoError(err)
 
@@ -174,7 +177,7 @@ func TestStdStoreRollback(t *testing.T) {
 func TestStdStoreDelete(t *testing.T) {
 	assert := assert.New(t)
 
-	str := New(&seal.MockSealer{})
+	str := New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 
 	inputName := "test:input"
 	inputData := []byte("test data")

--- a/coordinator/store/wrapper/wrapper_test.go
+++ b/coordinator/store/wrapper/wrapper_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/edgelesssys/marblerun/test"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -33,7 +34,7 @@ func TestStoreWrapper(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	store := stdstore.New(&seal.MockSealer{})
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	rawManifest := []byte(test.ManifestJSON)
 	curState := state.AcceptingManifest
 	testSecret := manifest.Secret{
@@ -86,7 +87,7 @@ func TestStoreWrapperRollback(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	stor := stdstore.New(&seal.MockSealer{})
+	stor := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	data := New(stor)
 
 	startingState := state.AcceptingManifest

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -422,13 +422,9 @@ func (i IntegrationTest) TriggerRecovery(coordinatorCfg CoordinatorConfig, coord
 	log.Println("Killing the old instance")
 	i.require.NoError(coordinatorProc.Kill())
 
-	// Garble encryption key to trigger recovery state
-	log.Println("Purposely corrupt sealed key to trigger recovery state...")
-	pathToKeyFile := filepath.Join(coordinatorCfg.sealDir, stdstore.SealedKeyFname)
-	sealedKeyData, err := os.ReadFile(pathToKeyFile)
-	i.require.NoError(err)
-	sealedKeyData[0] ^= byte(0x42)
-	i.require.NoError(os.WriteFile(pathToKeyFile, sealedKeyData, 0o600))
+	// Remove sealed encryption key to trigger recovery state
+	log.Println("Deleting sealed key to trigger recovery state...")
+	os.Remove(filepath.Join(coordinatorCfg.sealDir, stdstore.SealedKeyFname))
 
 	// Restart server, we should be in recovery mode
 	log.Println("Restarting the old instance")

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/edgelesssys/marblerun/coordinator/constants"
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
-	"github.com/edgelesssys/marblerun/coordinator/seal"
+	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	mconfig "github.com/edgelesssys/marblerun/marble/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -424,7 +424,7 @@ func (i IntegrationTest) TriggerRecovery(coordinatorCfg CoordinatorConfig, coord
 
 	// Garble encryption key to trigger recovery state
 	log.Println("Purposely corrupt sealed key to trigger recovery state...")
-	pathToKeyFile := filepath.Join(coordinatorCfg.sealDir, seal.SealedKeyFname)
+	pathToKeyFile := filepath.Join(coordinatorCfg.sealDir, stdstore.SealedKeyFname)
 	sealedKeyData, err := os.ReadFile(pathToKeyFile)
 	i.require.NoError(err)
 	sealedKeyData[0] ^= byte(0x42)


### PR DESCRIPTION
### Proposed changes
- Refactor the `Sealer` used by the Coordinator for data encryption to not handle file saving itself
  - The existing logic heavily limited the usability of the interface, e.g. when implementing a custom store interface, one would most likely also have to implement a custom sealer if they wanted to persist the data differently
- Move file saving into `StdStore`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
