### PR TITLE
Align capitalization of log messages

### DIFF
--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -85,7 +85,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 	store := stdstore.New(sealer, afero.NewOsFs(), sealDir)
 
 	// creating core
-	log.Info("creating the Core object")
+	log.Info("Creating the Core object")
 	if err := os.MkdirAll(sealDir, 0o700); err != nil {
 		log.Fatal("Cannot create or access sealdir. Please check the permissions for the specified path.", zap.Error(err))
 	}
@@ -114,7 +114,7 @@ func run(validator quote.Validator, issuer quote.Issuer, sealDir string, sealer 
 	}
 
 	// start client server
-	log.Info("starting the client server")
+	log.Info("Starting the client server")
 	mux := server.CreateServeMux(clientServer, promFactoryPtr)
 	clientServerTLSConfig, err := co.GetTLSConfig()
 	if err != nil {

--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -447,7 +447,7 @@ func (a *ClientAPI) SetManifest(ctx context.Context, rawManifest []byte) (recove
 		}
 	}
 
-	a.updateLog.Info("initial manifest set")
+	a.updateLog.Info("Initial manifest set")
 	if err := txdata.PutUpdateLog(a.updateLog.String()); err != nil {
 		return nil, fmt.Errorf("saving update log to store: %w", err)
 	}
@@ -721,7 +721,7 @@ func (a *ClientAPI) WriteSecrets(ctx context.Context, rawSecretManifest []byte, 
 		if err := txdata.PutSecret(secretName, secret); err != nil {
 			return fmt.Errorf("saving secret %q to store: %w", secretName, err)
 		}
-		a.updateLog.Info("secret set", zap.String("user", updater.Name()), zap.String("secret", secretName), zap.String("type", secret.Type))
+		a.updateLog.Info("Secret set", zap.String("user", updater.Name()), zap.String("secret", secretName), zap.String("type", secret.Type))
 	}
 	if err := txdata.AppendUpdateLog(a.updateLog.String()); err != nil {
 		return fmt.Errorf("saving update log to store: %w", err)

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -121,7 +121,7 @@ func NewCore(
 	}
 	c.metrics = newCoreMetrics(promFactory, c, "coordinator")
 
-	zapLogger.Info("loading state")
+	zapLogger.Info("Loading state")
 	recoveryData, loadErr := txHandle.LoadState()
 	if err := c.recovery.SetRecoveryData(recoveryData); err != nil {
 		c.log.Error("Could not retrieve recovery data from state. Recovery will be unavailable", zap.Error(err))
@@ -150,7 +150,7 @@ func NewCore(
 			return nil, loadErr
 		}
 		// sealed state was found, but couldn't be decrypted, go to recovery mode or reset manifest
-		c.log.Error("Failed to decrypt sealed state. Processing with a new state. Use the /recover API endpoint to load an old state, or submit a new manifest to overwrite the old state. Look up the documentation for more information on how to proceed.")
+		c.log.Error("Failed to decrypt sealed state. Proceeding with a new state. Use the /recover API endpoint to load an old state, or submit a new manifest to overwrite the old state. Look up the documentation for more information on how to proceed.")
 		if err := c.setCAData(dnsNames, transaction); err != nil {
 			return nil, err
 		}
@@ -286,7 +286,7 @@ func (c *Core) GetQuote() []byte {
 // If no quote can be generated due to the system not supporting SGX, no error is returned,
 // and the Coordinator proceeds to run in simulation mode.
 func (c *Core) GenerateQuote(cert []byte) error {
-	c.log.Info("generating quote")
+	c.log.Info("Generating quote")
 	quote, err := c.qi.Issue(cert)
 	if err != nil {
 		if err.Error() == "OE_UNSUPPORTED" {
@@ -366,7 +366,7 @@ func (c *Core) GenerateSecrets(
 			continue
 		}
 
-		c.log.Info("generating secret", zap.String("name", name), zap.String("type", secret.Type), zap.Uint("size", secret.Size))
+		c.log.Info("Generating secret", zap.String("name", name), zap.String("type", secret.Type), zap.Uint("size", secret.Size))
 		switch secret.Type {
 		// Raw = Symmetric Key
 		case manifest.SecretTypeSymmetricKey:

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -121,7 +121,7 @@ func RunClientServer(mux http.Handler, address string, tlsConfig *tls.Config, za
 		Handler:   mux,
 		TLSConfig: tlsConfig,
 	}
-	zapLogger.Info("starting client https server", zap.String("address", address))
+	zapLogger.Info("Starting client https server", zap.String("address", address))
 	err := server.ListenAndServeTLS("", "")
 	zapLogger.Warn(err.Error())
 }
@@ -131,7 +131,7 @@ func RunPrometheusServer(address string, zapLogger *zap.Logger, reg *prometheus.
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.InstrumentMetricHandler(reg, promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg})))
 	mux.Handle("/events", eventlog.Handler())
-	zapLogger.Info("starting prometheus /metrics endpoint", zap.String("address", address))
+	zapLogger.Info("Starting prometheus /metrics endpoint", zap.String("address", address))
 	err := http.ListenAndServe(address, mux)
 	zapLogger.Warn(err.Error())
 }


### PR DESCRIPTION
### Proposed changes
- Fix capitalization of some log messages: they were using lowercase, while the rest of the code started messages in uppercase
- Fix wording in a log message when entering recovery mode

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
