### PR TITLE
Fix Recover call not properly resetting store's recovery mode

### DIFF
--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -278,6 +278,7 @@ func (a *ClientAPI) Recover(ctx context.Context, encryptionKey []byte) (keysLeft
 		return -1, fmt.Errorf("loading state: %w", err)
 	}
 
+	a.txHandle.SetRecoveryData(recoveryData)
 	if err := a.recovery.SetRecoveryData(recoveryData); err != nil {
 		a.log.Error("Could not retrieve recovery data from state. Recovery will be unavailable", zap.Error(err))
 	}

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -535,6 +535,7 @@ func TestRecover(t *testing.T) {
 				assert.False(tc.store.loadCalled)
 				return
 			}
+			assert.True(tc.store.setRecoveryDataCalled)
 			assert.True(tc.store.loadCalled)
 			assert.NotNil(tc.core.quote)
 		})
@@ -656,14 +657,15 @@ func (c *fakeCore) GenerateQuote(quoteData []byte) error {
 }
 
 type fakeStore struct {
-	store               store.Store
-	beginTransactionErr error
-	recoveryData        []byte
-	encryptionKey       []byte
-	setEncryptionKeyErr error
-	loadStateRes        []byte
-	loadStateErr        error
-	loadCalled          bool
+	store                 store.Store
+	beginTransactionErr   error
+	setRecoveryDataCalled bool
+	recoveryData          []byte
+	encryptionKey         []byte
+	setEncryptionKeyErr   error
+	loadStateRes          []byte
+	loadStateErr          error
+	loadCalled            bool
 }
 
 func (s *fakeStore) BeginTransaction(ctx context.Context) (store.Transaction, error) {
@@ -682,6 +684,7 @@ func (s *fakeStore) SetEncryptionKey(key []byte) error {
 }
 
 func (s *fakeStore) SetRecoveryData(recoveryData []byte) {
+	s.setRecoveryDataCalled = true
 	s.recoveryData = recoveryData
 }
 


### PR DESCRIPTION
### The issue
A Coordinator's store will remain in recovery mode after a successful recovery until the manifest is updated.
This means changes to the secrets of the Coordinator by a user will not be persisted to disk until a call to `UpdateManifest` is performed.

### Cause and fix
`ClientAPI.Recover` was missing a call to `txHandle.SetRecoveryData(recoveryData)`, adding the call fixes the issue.
`UpdateManifest` also has a call to `txHandle.SetRecoveryData(recoveryData)`, so the recovery mode was removed from the store if the manifest is updated.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
