### PR TITLE
fix: return error on SetManifest if state cannot be committed

### DIFF
--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -459,6 +459,7 @@ func (a *ClientAPI) SetManifest(ctx context.Context, rawManifest []byte) (recove
 	a.txHandle.SetRecoveryData(recoveryData)
 	if err := commit(ctx); err != nil {
 		a.log.Error("sealing of state failed", zap.Error(err))
+		return nil, fmt.Errorf("sealing state: %w", err)
 	}
 
 	a.log.Info("SetManifest successful")

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestSetManifest_Legacy(t *testing.T) {
@@ -604,8 +604,7 @@ func setupAPI(t *testing.T) (*ClientAPI, wrapper.Wrapper) {
 	require := require.New(t)
 
 	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
-	log, err := zap.NewDevelopment()
-	require.NoError(err)
+	log := zaptest.NewLogger(t)
 
 	wrapper := wrapper.New(store)
 

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -116,7 +116,6 @@ func TestRecover(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	// setup mock zaplogger which can be passed to Core
 	zapLogger := zaptest.NewLogger(t)
 
 	validator := quote.NewMockValidator()

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestMain(m *testing.M) {
@@ -62,10 +62,7 @@ func TestSeal(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
@@ -120,9 +117,7 @@ func TestRecover(t *testing.T) {
 	ctx := context.Background()
 
 	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
@@ -301,9 +296,7 @@ func TestUnsetRestart(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &seal.MockSealer{}

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 )
@@ -49,10 +49,7 @@ func TestActivate(t *testing.T) {
 	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
 
-	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	// create core
 	validator := quote.NewMockValidator()
@@ -458,10 +455,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSONWithRecoveryKey), &manifest))
 
-	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	// create core
 	validator := quote.NewMockValidator()
@@ -568,10 +562,7 @@ func TestActivateWithMissingParameters(t *testing.T) {
 	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSONMissingParameters), &manifest))
 
-	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	// create core
 	validator := quote.NewMockValidator()

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestStoreWrapperMetrics(t *testing.T) {
@@ -34,9 +34,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
 	sealer := &seal.MockSealer{}
@@ -90,10 +88,7 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
 
-	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	// create core
 	validator := quote.NewMockValidator()

--- a/coordinator/core/openssl_test.go
+++ b/coordinator/core/openssl_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 )
@@ -45,10 +45,7 @@ func TestOpenSSLVerify(t *testing.T) {
 	var manifest manifest.Manifest
 	require.NoError(json.Unmarshal([]byte(test.ManifestJSON), &manifest))
 
-	// setup mock zaplogger which can be passed to Core
-	zapLogger, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer zapLogger.Sync()
+	zapLogger := zaptest.NewLogger(t)
 
 	// create core
 	validator := quote.NewMockValidator()

--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/edgelesssys/marblerun/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestFile(t *testing.T) {
@@ -264,15 +264,14 @@ func TestManifestCheck(t *testing.T) {
 	err := json.Unmarshal([]byte(test.ManifestJSONWithRecoveryKey), &manifest)
 	require.NoError(err)
 
-	zap, err := zap.NewDevelopment()
-	require.NoError(err)
-	err = manifest.Check(zap)
+	log := zaptest.NewLogger(t)
+	err = manifest.Check(log)
 	assert.NoError(err)
 
 	manifest.Users["anotherUser"] = User{
 		Certificate: manifest.Users["admin"].Certificate,
 	}
-	err = manifest.Check(zap)
+	err = manifest.Check(log)
 	assert.Error(err)
 }
 

--- a/coordinator/server/metrics_test.go
+++ b/coordinator/server/metrics_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestClientApiRequestMetrics(t *testing.T) {
@@ -88,9 +88,7 @@ func newTestClientAPI(t *testing.T) *clientapi.ClientAPI {
 	t.Helper()
 	require := require.New(t)
 
-	log, err := zap.NewDevelopment()
-	require.NoError(err)
-	defer log.Sync()
+	log := zaptest.NewLogger(t)
 
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.3 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect


### PR DESCRIPTION
### Proposed changes
- Return an error to the user if committing the new state after `SetManifest` fails
  - Previously, this only printed an error in the Coordinator's log.
  - Previously, users received a success message, even though committing the state failed, and the Coordinator remained in the `AcceptingManifest` state
- Use `zaptest.NewLogger(t)` in unit tests to set up logging, instead of `zap.NewDevelopment()`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
