### PR TITLE
Update gramine sample to v1.4

### DIFF
--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -5,6 +5,8 @@ uuid
 *.sig
 premain-libos
 install/
-nginx-1.16.1/
+nginx-1.*/
 *.manifest
 hello
+era-config.json
+marblerun.crt

--- a/samples/gramine-hello/Makefile
+++ b/samples/gramine-hello/Makefile
@@ -3,23 +3,17 @@ EDG_MARBLE_TYPE ?= hello
 all: sign
 .PHONY: clean all
 
-
 sign: hello.manifest hello premain-libos
 	gramine-sgx-sign --output hello.manifest.sgx --manifest hello.manifest --key enclave-key.pem
-	gramine-sgx-get-token --sig hello.sig --output hello.token
-
 
 clean:
 	rm -f *.sig *.token *.manifest.sgx hello hello.manifest uuid
 
-
 hello: hello.c
 	$(CC) -Os -o$@ $<
 
-
 hello.manifest: hello.manifest.template
 	gramine-manifest $< > $@
-
 
 premain-libos:
 	wget https://github.com/edgelesssys/marblerun/releases/latest/download/premain-libos

--- a/samples/gramine-hello/README.md
+++ b/samples/gramine-hello/README.md
@@ -4,7 +4,7 @@ This example shows how to run a [Gramine](https://github.com/gramineproject/gram
 
 ## Requirements
 
-First, install Gramine on [release v1.3](https://github.com/gramineproject/gramine/releases/tag/v1.3.1). You will need hardware with Intel SGX support.
+First, install Gramine on [release v1.4](https://github.com/gramineproject/gramine/releases/tag/v1.4). You will need hardware with Intel SGX support.
 
 Then, before you can run the example, make sure you got the prerequisites for ECDSA remote attestation installed on your system. You can collectively install them with the following command:
 
@@ -21,7 +21,7 @@ openssl genrsa -3 -out enclave-key.pem 3072
 make
 ```
 
-Then get `mr_enclave` from the build output and set it as `UniqueID` in `manifest.json`.
+Then get `Measurement` from the build output and set it as `UniqueID` in `manifest.json`.
 
 ## Run
 

--- a/samples/gramine-hello/hello.manifest.template
+++ b/samples/gramine-hello/hello.manifest.template
@@ -48,7 +48,7 @@ sgx.remote_attestation = "dcap"
 
 # enclave must have enough memory and threads
 sgx.enclave_size = "1024M"
-sgx.thread_num = 16
+sgx.max_threads = 16
 
 # create a debug enclave by default
 sgx.debug = true

--- a/samples/gramine-nginx/Makefile
+++ b/samples/gramine-nginx/Makefile
@@ -23,7 +23,7 @@ endif
 .PHONY: all
 all: $(INSTALL_DIR)/sbin/nginx nginx.manifest config testdata ssldata
 ifeq ($(SGX),1)
-all: nginx.manifest.sgx nginx.sig nginx.token
+all: nginx.manifest.sgx nginx.sig
 endif
 
 # Note that Gramine doesn't support eventfd() and PR_SET_DUMPABLE, so we manually
@@ -73,9 +73,6 @@ sgx_sign: nginx.manifest $(INSTALL_DIR)/sbin/nginx \
 		--key $(SGX_SIGNER_KEY) \
 		--output $<.sgx
 
-nginx.token: nginx.sig
-	gramine-sgx-get-token --output $@ --sig $<
-
 # Nginx configuration and test data
 .PHONY: config
 config: $(INSTALL_DIR)/conf/nginx-gramine.conf
@@ -84,7 +81,6 @@ $(INSTALL_DIR)/conf/nginx-gramine.conf: nginx-gramine.conf.template $(INSTALL_DI
 	sed -e 's|$$(LISTEN_PORT)|'"$(LISTEN_PORT)"'|g' \
 		-e 's|$$(LISTEN_SSL_PORT)|'"$(LISTEN_SSL_PORT)"'|g' \
 		-e 's|$$(LISTEN_HOST)|'"$(LISTEN_HOST)"'|g' \
-		-e 's|$$(INSTALL_DIR)|'"$(INSTALL_DIR)"'|g' \
 	$< > $@
 
 # HTTP docs: Generating random HTML files in $(INSTALL_DIR)/html/random
@@ -125,13 +121,10 @@ else
 GRAMINE = gramine-sgx
 endif
 
-.PHONY: start-gramine-server
-start-gramine-server: all
-	$(GRAMINE) ./nginx -c conf/nginx-gramine.conf
-
 .PHONY: clean
 clean:
 	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT result-* tmp
+	$(RM) -r uuid secrets/
 
 .PHONY: distclean
 distclean: clean

--- a/samples/gramine-nginx/README.md
+++ b/samples/gramine-nginx/README.md
@@ -2,7 +2,7 @@
 
 This example is a slightly modified variant of the [Gramine nginx example](https://github.com/gramineproject/gramine/tree/master/CI-Examples/nginx). These changes are required to run it with MarbleRun.
 
-*Prerequisite*: Gramine is installed on [release v1.3](https://github.com/gramineproject/gramine/releases/tag/v1.3.1) and the original nginx example is working. You will need hardware with Intel SGX support, and the Coordinator must not run in simulation mode.
+*Prerequisite*: Gramine is installed on [release v1.4](https://github.com/gramineproject/gramine/releases/tag/v1.4) and the original nginx example is working. You will need hardware with Intel SGX support, and the Coordinator must not run in simulation mode.
 
 To marbleize the example we edited [nginx.manifest.template](nginx.manifest.template). See comments starting with `MARBLERUN` for explanations of the required changes.
 
@@ -14,6 +14,8 @@ We now build the example as follows:
 openssl genrsa -3 -out enclave-key.pem 3072
 make SGX=1
 ```
+
+Then get `Measurement` from the build output and set it as `UniqueID` in `manifest.json`.
 
 Start the Coordinator in a SGX enclave:
 

--- a/samples/gramine-nginx/nginx.manifest.template
+++ b/samples/gramine-nginx/nginx.manifest.template
@@ -6,7 +6,7 @@ libos.entrypoint = "premain-libos"
 
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/local/lib:/usr/{{ arch_libdir }}"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
 # MARBLERUN: argv0 must be the path to the actual application
 loader.argv = [ "{{ install_dir }}/sbin/nginx" ]
@@ -30,7 +30,7 @@ fs.mounts = [
 ]
 
 sgx.debug = true
-sgx.nonpie_binary = true
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
 # MARBLERUN: enclave must have enough memory for Go runtime of premain
 sgx.enclave_size = "1024M"
 # MARBLERUN: enclave must have enough threads for Go runtime of premain

--- a/samples/gramine-redis/.gitignore
+++ b/samples/gramine-redis/.gitignore
@@ -1,3 +1,0 @@
-# MarbleRun files
-era-config.json
-marblerun.crt

--- a/samples/gramine-redis/Dockerfile
+++ b/samples/gramine-redis/Dockerfile
@@ -1,37 +1,28 @@
-# syntax=docker/dockerfile:experimental
-
 FROM alpine/git:latest AS pull_marblerun
-RUN git clone https://github.com/edgelesssys/marblerun.git /marblerun
+RUN git clone --depth=1 https://github.com/edgelesssys/marblerun.git /marblerun
 
 FROM alpine/git:latest AS pull_gramine
-RUN git clone --branch v1.3.1 https://github.com/gramineproject/gramine /gramine
+RUN git clone --depth=1 --branch v1.4 https://github.com/gramineproject/gramine /gramine
 
-FROM ghcr.io/edgelesssys/edgelessrt-dev AS build-premain
+FROM ghcr.io/edgelesssys/edgelessrt-dev:latest AS build-premain
 COPY --from=pull_marblerun /marblerun /premain
 WORKDIR /premain/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 RUN make premain-libos
 
-FROM ubuntu:20.04
-RUN apt update && \
-    apt install -y libssl-dev gnupg software-properties-common
-
-RUN apt-key adv --fetch-keys https://packages.microsoft.com/keys/microsoft.asc && \
-    apt-add-repository 'https://packages.microsoft.com/ubuntu/20.04/prod main' && \
-    apt-key adv --fetch-keys https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key && \
-    add-apt-repository 'https://download.01.org/intel-sgx/sgx_repo/ubuntu main' && \
-    apt-key adv --fetch-keys https://packages.gramineproject.io/gramine-keyring.gpg && \
-    apt-add-repository 'deb [arch=amd64] https://packages.gramineproject.io/ focal main'
+FROM gramineproject/gramine:v1.4 AS release
+RUN curl -fsSLo /usr/share/keyrings/microsoft.asc https://packages.microsoft.com/keys/microsoft.asc && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.asc] https://packages.microsoft.com/ubuntu/20.04/prod focal main" | \
+    tee /etc/apt/sources.list.d/msprod.list
 
 RUN apt-get update && apt-get install -y \
     az-dcap-client \
     wget \
+    libssl-dev \
     libsgx-quote-ex-dev \
-    libsgx-aesm-launch-plugin \
     build-essential \
     libprotobuf-c-dev \
-    gramine && \
-    apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y
+    && apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y
 
 COPY --from=pull_gramine /gramine /gramine
 COPY --from=build-premain /premain/build/premain-libos /gramine/CI-Examples/redis/

--- a/samples/gramine-redis/redis-server.manifest.template
+++ b/samples/gramine-redis/redis-server.manifest.template
@@ -1,9 +1,9 @@
 # Redis manifest file example
 
-################################## GRAMINE ###################################
+################################## GRAMINE ####################################
 
-# LibOS layer library of Gramine. There is currently only one implementation,
-# so it is always set to libsysdb.so.
+# PAL entrypoint (points to the LibOS layer library of Gramine). There is
+# currently only one implementation, so it is always set to libsysdb.so.
 loader.entrypoint = "file:{{ gramine.libos }}"
 
 # MARBLERUN: entrypoint must be premain-libos
@@ -23,8 +23,8 @@ loader.argv = ["redis-server"]
 ################################# ENV VARS ####################################
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
-# applies. Paths must be in-Gramine visible paths, not host-OS paths (i.e.,
-# paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).
+# applies. Paths must be in-Gramine visible paths, not host paths (i.e.,
+# paths must be taken from fs.mounts[...].path, not fs.mounts[...].uri).
 #
 # In case of Redis:
 # - /lib is searched for Glibc libraries (ld, libc, libpthread)
@@ -38,10 +38,11 @@ loader.env.EDG_MARBLE_DNS_NAMES = { passthrough = true }
 
 ################################## SIGNALS ####################################
 
-# Allow for injecting SIGTERM signal from the host.
+# Allow for injecting SIGTERM signal from the host. Without this option,
+# pressing `Ctrl + C` wouldn't terminate Redis.
 sys.enable_sigterm_injection = true
 
-################################# MOUNT FS  ###################################
+################################# MOUNT FS ####################################
 
 # General notes:
 # - All mount points are mounted using the default 'chroot' type.
@@ -83,8 +84,15 @@ sgx.debug = true
 # typical Redis workloads.
 sgx.enclave_size = "1024M"
 
+# Enable Enclave Dynamic Memory Management (EDMM) feature based on EDMM
+# environment variable. This allows for addition of pages to enclave in runtime,
+# instead of allocating them upfront at startup. If this feature is enabled,
+# `sgx.enclave_size` above describes a maximal enclave size and can usually be
+# increased without negative consequences (it does not impact startup time).
+sgx.edmm_enable = {{ 'true' if env.get('EDMM', '0') == '1' else 'false' }}
+
 # Set maximum number of in-enclave threads (somewhat arbitrarily) to 8. Recall
-# that SGX v1 requires to specify the maximum number of simulteneous threads at
+# that SGX v1 requires to specify the maximum number of simultaneous threads at
 # enclave creation time.
 #
 # Note that internally Gramine may spawn two additional threads, one for IPC
@@ -94,33 +102,26 @@ sgx.enclave_size = "1024M"
 # MARBLERUN: enclave must have enough threads for Go runtime of premain
 sgx.thread_num = 16
 
-# Redis executable is typically a PIE (Position Independent Executable) on most
-# modern OS distros (e.g., Ubuntu 18.04). However, on some OS distros (notably,
-# CentOS), Redis executable is built as non-PIE. We mark Redis as a non-PIE
-# binary for the SGX PAL unconditionally -- this makes it work on CentOS and
-# doesn't hurt on Ubuntu. (Note that the Linux PAL correctly distinguishes
-# between PIE and non-PIE binaries, but for SGX we need to prearrange enclave
-# memory layout, hence the below option.)
-sgx.nonpie_binary = true
-
 ############################# SGX: TRUSTED FILES ###############################
 
 # Specify all files used by Redis and its dependencies (including all libraries
 # which can be loaded at runtime via dlopen), as well as other static read-only
 # files (like configuration files).
 #
-# The paths to files are host-OS paths. These files will be searched for in
+# The paths to files are on-host paths. These files will be searched for in
 # in-Gramine visible paths according to mount points above.
 #
 # As part of the build process, Gramine-SGX script (`gramine-sgx-sign`) finds
 # each specified file, measures its hash, and adds it to the manifest entry for
 # that file (converting each entry to a table with "uri" and "sha256" keys).
-# Note that this happens on the developer machine or a build server.
+# Note that this happens on the developer machine or a build server. If a
+# directory is specified in the list below, then this directory is recursively
+# traversed and each found file is processed as described above.
 #
 # At runtime, during loading of each "trusted file", Gramine-SGX measures its
 # hash and compares with the "sha256" value in the corresponding manifest entry.
 # If hashes match, this file is trusted and allowed to be loaded and used. Note
-# that this happens on the client machine.
+# that this happens on the deployment machine.
 
 # MARBLERUN: must trust premain-libos
 sgx.trusted_files = [


### PR DESCRIPTION
### Proposed changes
- Update Gramine version in the samples to `v1.4`
  - Update the Makefiles to no longer create the deprecated SGX tokens
  - Update Gramine manifest templates for v1.4
- Use the official Gramine container base image for the redis sample
  - This should cause renovate to automatically alert us about new Gramine versions and propose an upgrade
- Make small improvements to the sample READMEs

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
