### PR TITLE
Better error message on failed property validation

### DIFF
--- a/coordinator/quote/ert.go
+++ b/coordinator/quote/ert.go
@@ -8,6 +8,7 @@ package quote
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -84,6 +85,29 @@ func (required PackageProperties) IsCompliant(given PackageProperties) bool {
 		return false
 	}
 	return true
+}
+
+// String returns a string representation of the package properties.
+func (p PackageProperties) String() string {
+	values := []string{
+		fmt.Sprintf("Debug: %t", p.Debug),
+	}
+	if p.UniqueID != "" {
+		values = append(values, fmt.Sprintf("UniqueID: %q", p.UniqueID))
+	}
+	if p.SignerID != "" {
+		values = append(values, fmt.Sprintf("SignerID: %q", p.SignerID))
+	}
+	if p.ProductID != nil {
+		values = append(values, fmt.Sprintf("ProductID: %d", *p.ProductID))
+	}
+	if p.SecurityVersion != nil {
+		values = append(values, fmt.Sprintf("SecurityVersion: %d", *p.SecurityVersion))
+	}
+	if len(p.AcceptedTCBStatuses) > 0 {
+		values = append(values, fmt.Sprintf("AcceptedTCBStatuses: %v", p.AcceptedTCBStatuses))
+	}
+	return fmt.Sprintf("{%s}", strings.Join(values, ", "))
 }
 
 // Equal returns true if both infrastructures are equal.

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -58,7 +58,7 @@ func (m *ERTValidator) Validate(givenQuote []byte, cert []byte, pp quote.Package
 		SecurityVersion: &report.SecurityVersion,
 	}
 	if !pp.IsCompliant(reportedProps) {
-		return fmt.Errorf("PackageProperties not compliant:\n%v\n%v", reportedProps, pp)
+		return fmt.Errorf("PackageProperties not compliant:\nexpected: %s\ngot: %s", pp, reportedProps)
 	}
 
 	// TODO Verify InfrastructureProperties with information from OE Quote


### PR DESCRIPTION
The current error message use `%v` formatting directive resulting in a rather hard to read and interpret error message, especially since `PackageProperties.ProductID` and `PackageProperties.SecurityVersion` are pointers.

### Proposed changes
- Add a `String()` method to `PackageProperties` to generate a human readable presentation of the object
  - Prints the variable names along with their values
  - Pointers are dereferenced before printed
  - Omits any unset values
- Use the `String()` method to print a human readable error message when a package is not compliant to the configuration set by a manifest

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
