### PR TITLE
cli: require chart path when using enterprise access token

### DIFF
--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -96,7 +96,7 @@ func cliInstall(cmd *cobra.Command, helmClient *helm.Client, kubeClient kubernet
 		}
 	}
 
-	values, err := helmClient.UpdateValues(
+	values, err := helm.UpdateValues(
 		helm.Options{
 			Hostname:            flags.hostname,
 			DCAPQPL:             flags.dcapQPL,

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -76,7 +76,7 @@ func cliInstall(cmd *cobra.Command, helmClient *helm.Client, kubeClient kubernet
 		return fmt.Errorf("parsing install flags: %w", err)
 	}
 
-	chart, err := helmClient.GetChart(flags.chartPath, flags.version, (flags.accessToken != ""))
+	chart, err := helmClient.GetChart(flags.chartPath, flags.version)
 	if err != nil {
 		return fmt.Errorf("loading MarbleRun helm chart: %w", err)
 	}
@@ -317,6 +317,10 @@ func parseInstallFlags(cmd *cobra.Command) (installFlags, error) {
 	meshPort, err := cmd.Flags().GetInt("mesh-server-port")
 	if err != nil {
 		return installFlags{}, err
+	}
+
+	if accessToken != "" && chartPath == "" {
+		return installFlags{}, fmt.Errorf("--marblerun-chart-path is required when using an enterprise access token")
 	}
 
 	return installFlags{

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -67,7 +67,7 @@ func New() (*Client, error) {
 
 // GetChart loads the helm chart from the given path or from the edgeless helm repo.
 // This will add the edgeless helm repo if it is not already present on disk.
-func (c *Client) GetChart(chartPath, version string, enterpriseRelease bool) (*chart.Chart, error) {
+func (c *Client) GetChart(chartPath, version string) (*chart.Chart, error) {
 	if chartPath == "" {
 		// No chart was specified -> add or update edgeless helm repo
 		installer := action.NewInstall(c.config)
@@ -76,12 +76,6 @@ func (c *Client) GetChart(chartPath, version string, enterpriseRelease bool) (*c
 		err := c.getRepo(repoName, repoURI)
 		if err != nil {
 			return nil, fmt.Errorf("adding edgeless helm repo: %w", err)
-		}
-
-		// Enterprise chart is used if an access token is provided
-		chartName := chartName
-		if enterpriseRelease {
-			chartName = chartNameEnterprise
 		}
 
 		chartPath, err = installer.ChartPathOptions.LocateChart(chartName, c.settings)

--- a/cli/internal/helm/client_test.go
+++ b/cli/internal/helm/client_test.go
@@ -7,10 +7,12 @@
 package helm
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/edgelesssys/marblerun/util/k8sutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNeedsDeletion(t *testing.T) {
@@ -84,6 +86,68 @@ func TestNeedsDeletion(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.wantDeletion, needsDeletion(tc.existingKey, tc.sgxKey))
+		})
+	}
+}
+
+func TestUpdateValues(t *testing.T) {
+	testCases := map[string]struct {
+		opts      Options
+		chartVals map[string]interface{}
+		wantVals  func(*testing.T, map[string]interface{})
+		wantErr   bool
+	}{
+		"github PAT gets encoded": {
+			opts: Options{
+				SimulationMode: true,
+				AccessToken:    "ghp_foo",
+			},
+			chartVals: map[string]interface{}{
+				"coordinator": map[string]interface{}{
+					"repository": "myrepo",
+				},
+			},
+			wantVals: func(t *testing.T, vals map[string]interface{}) {
+				assert := assert.New(t)
+				require := require.New(t)
+				pullSecret, err := base64.StdEncoding.DecodeString(vals["pullSecret"].(map[string]interface{})["token"].(string))
+				require.NoError(err)
+				assert.EqualValues(`{"auths":{"myrepo":{"auth":"Z2hwX2ZvbzpnaHBfZm9v"}}}`, pullSecret)
+			},
+		},
+		"other token is taken unmodified": {
+			opts: Options{
+				SimulationMode: true,
+				AccessToken:    "foo",
+			},
+			chartVals: map[string]interface{}{
+				"coordinator": map[string]interface{}{
+					"repository": "myrepo",
+				},
+			},
+			wantVals: func(t *testing.T, vals map[string]interface{}) {
+				assert := assert.New(t)
+				require := require.New(t)
+				pullSecret, err := base64.StdEncoding.DecodeString(vals["pullSecret"].(map[string]interface{})["token"].(string))
+				require.NoError(err)
+				assert.EqualValues(`{"auths":{"myrepo":{"auth":"foo"}}}`, pullSecret)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			gotVals, err := UpdateValues(tc.opts, tc.chartVals)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			require.NoError(err)
+
+			tc.wantVals(t, gotVals)
 		})
 	}
 }

--- a/cli/internal/helm/helm.go
+++ b/cli/internal/helm/helm.go
@@ -13,7 +13,6 @@ const (
 	InjectorDeployment    = "marble-injector"
 	Namespace             = "marblerun"
 	chartName             = "edgeless/marblerun"
-	chartNameEnterprise   = "edgeless/marblerun-enterprise"
 	release               = "marblerun"
 	repoURI               = "https://helm.edgeless.systems/stable"
 	repoName              = "edgeless"


### PR DESCRIPTION
### Proposed changes
- Enterprise chart isn't included in the edgeless helm repo anymore, so make --marblerun-chart-path required for enterprise.
- Propose to let the cli do the base64(token:token) encoding. Not sure if this was left to the user on purpose or not. ~I can drop that commit if you have concerns (other auth secret formats?). Or I can add a simple heuristic, e.g., starting with ghp_~ Actually, I prefer accepting both inputs and convert the PAT automatically for convenience, so I've just added the check. Should be fine now. (Let me know if not.)