### PR TITLE
fix nightly build

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -68,6 +68,7 @@ jobs:
                                 "imagename":"marblerun/coordinator-debug",
                                 "tag":"nightly",
                                 "file": "dockerfiles/Dockerfile.coordinator",
+                                "args": "--build-arg erttag=master --build-arg mrtag=master",
                                 "target":"release"}}' \
           https://api.github.com/repos/edgelesssys/deployment/dispatches
 


### PR DESCRIPTION
We need to set the git tags that should be built. Otherwise, it always builds last release.