### PR TITLE
Build CLI for Ubuntu 20.04, 22.04, and AppImage

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -21,8 +21,22 @@ MarbleRun is written entirely in Go and builds on Edgeless RT, which is written 
 
 ## Build
 
+### With Docker
+
+You can build the MarbleRun binaries with Docker by providing a signing key:
+
+```bash
+openssl genrsa -out private.pem -3 3072
+export DOCKER_BUILDKIT=1
+docker build --secret id=signingkey,src=private.pem --target export -o. - < dockerfiles/Dockerfile.coordinator
+docker build -o. - < dockerfiles/Dockerfile.cli
+```
+
+### In your environment
+
 *Prerequisites*:
 
+* Ubuntu 20.04 or 22.04
 * [Edgeless RT](https://github.com/edgelesssys/edgelessrt) is installed and sourced
 * Go 1.20 or newer
 

--- a/dockerfiles/Dockerfile.build-base
+++ b/dockerfiles/Dockerfile.build-base
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20230605
+FROM ubuntu:jammy-20230624
 RUN apt-get update && apt-get install -dy --no-install-recommends \
   build-essential \
   ca-certificates \

--- a/dockerfiles/Dockerfile.build-base-focal
+++ b/dockerfiles/Dockerfile.build-base-focal
@@ -1,0 +1,21 @@
+FROM alpine AS download
+RUN wget \
+  https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
+  https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
+  https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64
+
+FROM ubuntu:focal-20230801
+COPY --from=download /intel-sgx-deb.key /etc/apt/keyrings/intel-sgx-keyring.asc
+COPY --from=download /*-x86_64* /
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+  && echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' > /etc/apt/sources.list.d/intel-sgx.list \
+  && apt-get update && apt-get install -dy --no-install-recommends \
+  build-essential \
+  clang-11 \
+  cmake \
+  file \
+  git \
+  libsgx-dcap-default-qpl \
+  libssl-dev \
+  ninja-build \
+  wget

--- a/dockerfiles/Dockerfile.cli
+++ b/dockerfiles/Dockerfile.cli
@@ -1,0 +1,70 @@
+FROM ghcr.io/edgelesssys/marblerun/build-base-focal:v0.0.0 AS build
+
+# don't run `apt-get update` because required packages are cached in build-base for reproducibility
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  build-essential \
+  clang-11 \
+  cmake \
+  file \
+  git \
+  libsgx-dcap-default-qpl \
+  libssl-dev \
+  ninja-build \
+  wget
+
+ARG erttag=v0.4.1
+ARG mrtag=v1.2.0
+ARG goversion=1.20.6
+RUN wget -qO- https://go.dev/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
+  && git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
+  && git clone -b $mrtag --depth=1 https://github.com/edgelesssys/marblerun \
+  && mkdir ertbuild mrbuild
+
+# install ert
+RUN cd edgelessrt && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /ertbuild \
+  && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF /edgelessrt \
+  && ninja install
+
+# build cli
+RUN cd marblerun && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /mrbuild \
+  && . /opt/edgelessrt/share/openenclave/openenclaverc \
+  && cmake -DCMAKE_BUILD_TYPE=Release /marblerun \
+  && PATH=$PATH:/usr/local/go/bin make cli
+
+# create AppImage
+RUN chmod +x linuxdeploy-x86_64.AppImage && touch marblerun.svg \
+  # workaround for reproducibility based on https://github.com/AppImage/AppImageKit/issues/929#issuecomment-926001098
+  && /linuxdeploy-x86_64.AppImage --appimage-extract \
+  && cd squashfs-root/plugins/linuxdeploy-plugin-appimage/appimagetool-prefix/usr/lib/appimagekit \
+  && mv mksquashfs mksquashfs_orig \
+  && echo '$0_orig $(echo $* | sed -e "s/-mkfs-time 0//")' > mksquashfs \
+  && chmod +x mksquashfs \
+  && cd / \
+  # create AppDir
+  && squashfs-root/AppRun \
+  --appdir=marblerun.AppDir \
+  --create-desktop-file \
+  -imarblerun.svg \
+  -e/mrbuild/marblerun \
+  -l/usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 \
+  # workaround for hardcoded CA bundle path in libcurl
+  && cd marblerun.AppDir/usr \
+  && mkdir lib-fedora \
+  && cp lib/libcurl.so.4 lib-fedora \
+  && sed -i 's|/etc/ssl/certs/ca-certificates.crt|/./etc/pki/tls/certs/ca-bundle.crt|' lib-fedora/libcurl.so.4 \
+  && cd / \
+  && echo \
+  '#!/bin/sh\n\
+DIR=$(dirname "$(readlink -f "$0")")\n\
+[ ! -e /etc/ssl/certs/ca-certificates.crt ] && [ -e /etc/pki/tls/certs/ca-bundle.crt ] && export LD_LIBRARY_PATH="${DIR}/usr/lib-fedora:${DIR}/usr/lib"\n\
+exec "${DIR}/usr/bin/marblerun" "$@"\n' \
+  > AppRun \
+  # build AppImage
+  && SOURCE_DATE_EPOCH=$(git -C /marblerun log -1 --pretty=%ct) ARCH=x86_64 LDAI_RUNTIME_FILE=runtime-x86_64 squashfs-root/AppRun \
+  --appdir=marblerun.AppDir \
+  --custom-apprun=AppRun \
+  -oappimage
+
+FROM scratch
+COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-20.04
+COPY --from=build /marblerun-x86_64.AppImage /

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -1,7 +1,7 @@
-FROM ghcr.io/edgelesssys/marblerun/build-base:v1.2.0 AS build
+FROM ghcr.io/edgelesssys/marblerun/build-base:v0.0.0 AS build
 
 # don't run `apt-get update` because required packages are cached in build-base for reproducibility
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
   build-essential \
   ca-certificates \
   clang-11 \
@@ -11,10 +11,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   ninja-build \
   wget
 
-ARG erttag=v0.4.0
+ARG erttag=v0.4.1
 ARG mrtag=v1.2.0
-ARG goversion=1.20.5
-RUN wget -qO- https://golang.org/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
+ARG goversion=1.20.6
+RUN wget -qO- https://go.dev/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
   && git clone -b $mrtag --depth=1 https://github.com/edgelesssys/marblerun \
   && mkdir ertbuild mrbuild
@@ -37,21 +37,19 @@ COPY --from=build \
   /mrbuild/coordinator-enclave.signed \
   /mrbuild/coordinator-config.json \
   /mrbuild/coordinator-noenclave \
-  /mrbuild/marblerun \
   /mrbuild/marble-injector \
   /mrbuild/premain-libos \
   /opt/edgelessrt/bin/erthost \
   /
+COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-22.04
 
 # the coordinator container image
-FROM ubuntu:focal-20230605 AS release
-ARG PSW_VERSION=2.19.100.3-focal1
-ARG DCAP_VERSION=1.16.100.2-focal1
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg libcurl4 wget \
-  && wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add \
-  && echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' >> /etc/apt/sources.list \
-  && wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add \
-  && echo 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod focal main' >> /etc/apt/sources.list \
+FROM ubuntu:jammy-20230624 AS release
+ARG PSW_VERSION=2.20.100.4-jammy1
+ARG DCAP_VERSION=1.17.100.4-jammy1
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
+  && wget -qO /etc/apt/keyrings/intel-sgx-keyring.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
+  && echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' > /etc/apt/sources.list.d/intel-sgx.list \
   && apt-get update && apt-get install -y --no-install-recommends \
   libsgx-ae-id-enclave=$DCAP_VERSION \
   libsgx-ae-pce=$PSW_VERSION \


### PR DESCRIPTION
### Proposed changes
- Upgrade `Dockerfile.coordinator` to Ubuntu 22.04
  - Rename CLI produced by this Dockerfile to `marblerun-ubuntu-22.04`
- Add `Dockerfile.cli`
  - Builds the CLI for Ubuntu 20.04 and an AppImage of it
  - AppImages usually don't include libc and thus recommend to build on the lowest supported OS version, which is 20.04 because of OE
  - The AppImage includes the default QPL