### PR TITLE
fix: remove version label from webhook selector

### DIFF
--- a/charts/templates/marble-injector.yaml
+++ b/charts/templates/marble-injector.yaml
@@ -36,7 +36,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: marble-injector
       app.kubernetes.io/part-of: marblerun
-      app.kubernetes.io/version: {{ .Values.marbleInjector.version }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
The selector field of a Kubernetes deployment may not be updated.
For the `marble-injector` deployment, we currently use a `matchLabels` selector with `app.kubernetes.io/version`.
This label changes with each new release of MarbleRun.
This causes issues when upgrading an existing deployment using Helm.

### Proposed changes
- Remove the `app.kubernetes.io/version` label from the `marble-injector` selector.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Since this changes the selector of the `marble-injector` deployment, upgrading an existing deployment requires manual steps.
Before running `helm upgrade`, the existing `marble-injector` deployment has to be removed.
Since the deployment does not have state, this should not create any issues:

```shell
kubectl delete deployments -n <marblerun-namespace> marble-injector
helm upgrade ...
```


<!-- (uncomment if applicable)
### Screenshots

-->
