### PR TITLE
Improve child process handling in integration test

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -198,7 +198,14 @@ func (i IntegrationTest) StartCommand(friendlyName string, cmd *exec.Cmd) chan e
 	waitErr := make(chan error)
 	go func() {
 		waitErr <- cmd.Wait()
+		close(waitErr)
 	}()
+
+	// On test end, wait until the process actually exited so that the next test can start cleanly.
+	i.t.Cleanup(func() {
+		_ = cmd.Cancel()
+		<-waitErr
+	})
 	return waitErr
 }
 


### PR DESCRIPTION
We see integration tests sporadically failing, but the output doesn't indicate a cause and it's hard to reproduce.
This PR improves handling of child processes regarding killing and output logging, which may help diagnosing the test failures. I suggest reviewing commits separately.