### PR TITLE
Build premain on Ubuntu 20.04

### DIFF
--- a/dockerfiles/Dockerfile.cli
+++ b/dockerfiles/Dockerfile.cli
@@ -25,11 +25,11 @@ RUN cd edgelessrt && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /
   && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF /edgelessrt \
   && ninja install
 
-# build cli
+# build cli and premain
 RUN cd marblerun && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /mrbuild \
   && . /opt/edgelessrt/share/openenclave/openenclaverc \
   && cmake -DCMAKE_BUILD_TYPE=Release /marblerun \
-  && PATH=$PATH:/usr/local/go/bin make cli
+  && PATH=$PATH:/usr/local/go/bin make cli premain-libos
 
 # create AppImage
 RUN chmod +x linuxdeploy-x86_64.AppImage && touch marblerun.svg \
@@ -67,4 +67,4 @@ exec "${DIR}/usr/bin/marblerun" "$@"\n' \
 
 FROM scratch
 COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-20.04
-COPY --from=build /marblerun-x86_64.AppImage /
+COPY --from=build /mrbuild/premain-libos /marblerun-x86_64.AppImage /

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -38,7 +38,6 @@ COPY --from=build \
   /mrbuild/coordinator-config.json \
   /mrbuild/coordinator-noenclave \
   /mrbuild/marble-injector \
-  /mrbuild/premain-libos \
   /opt/edgelessrt/bin/erthost \
   /
 COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-22.04


### PR DESCRIPTION
premain built on 20.04 can run on 22.04 (and on other distros with a not too old glibc), but not the other way round. So we should build it on 20.04 (again).