### PR TITLE
fix: update edgeless blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the [documentation][docs] for details.
 * Got a question? Please get in touch via [Discord][discord] or file an [issue](https://github.com/edgelesssys/marblerun/issues).
 * If you see an error message or run into an issue, please make sure to create a [bug report](https://github.com/edgelesssys/marblerun/issues).
 * Get the latest news and announcements on [Twitter](https://twitter.com/EdgelessSystems), [LinkedIn](https://www.linkedin.com/company/edgeless-systems/) or sign up for our monthly [newsletter](https://www.edgeless.systems/#newsletter-signup).
-* Visit our [blog](https://blog.edgeless.systems/) for technical deep-dives and tutorials.
+* Visit our [blog](https://www.edgeless.systems/blog/) for technical deep-dives and tutorials.
 
 ## Contributing
 
@@ -59,7 +59,7 @@ See the [documentation][docs] for details.
 * [`BUILD.md`](BUILD.md) includes general information on how to work in this repo.
 * Pull requests are welcome! You need to agree to our [Contributor License Agreement](https://cla-assistant.io/edgelesssys/marblerun).
 * This project and everyone participating in it are governed by the [Code of Conduct](/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
-* Please report any security issue via a [private GitHub vulnerability report](https://github.com/edgelesssys/marblerun/security/advisories/new) or write to security@edgeless.systems.
+* Please report any security issue via a [private GitHub vulnerability report](https://github.com/edgelesssys/marblerun/security/advisories/new) or write to <security@edgeless.systems>.
 
 ## Examples
 
@@ -100,8 +100,5 @@ The popular [Linkerd][linkerd] service mesh uses the simple and scalable *emojiv
 [linkerd]: https://linkerd.io
 [marblerunsh]: https://marblerun.sh
 [occlum]: https://github.com/occlum/occlum
-[sgx-lkl]: https://github.com/lsds/sgx-lkl
-[slack]: https://join.slack.com/t/confidentialcloud/shared_invite/zt-ix8nzzr6-vVNb6IM76Ab8z9a_5NMJnQ
-[twitter]: https://twitter.com/EdgelessSystems
 [discord]: https://discord.gg/rH8QTH56JN
 [discord-badge]: https://img.shields.io/badge/chat-on%20Discord-blue

--- a/docs/docs/deployment/platforms/alibaba.md
+++ b/docs/docs/deployment/platforms/alibaba.md
@@ -6,16 +6,17 @@ Alibaba Cloud Container Service for Kubernetes (ACK) offers a popular deployment
 [ACK hosts Kubernetes pods in SGX-capable Alibaba VMs](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/tee-based-confidential-computing) and exposes the underlying SGX hardware.
 
 ### Prerequisites
+
 * Follow the instructions on the [ACK Confidential Computing Quick Start guide](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/create-an-ack-managed-cluster-for-confidential-computing) to provision an ACK cluster with Intel SGX-enabled worker nodes.
 
 ### Deploy MarbleRun
 
 See the [Kubernetes guide](../kubernetes.md) on installing MarbleRun in your ACK cluster.
 
-
 ## Alibaba Cloud Elastic Compute Service
+
 With 7th-generation [security-enhanced ECS instances](https://www.alibabacloud.com/help/en/ecs/user-guide/overview-25), users can use Intel SGX on Alibaba Cloud.
-You can follow the guide for creating a [g7t, c7t, or r7t](https://www.alibabacloud.com/help/en/elastic-compute-service/latest/create-security-enhanced-instances) instance.
+You can follow the guide for creating a [g7t, c7t, or r7t](https://www.alibabacloud.com/help/en/ecs/user-guide/create-a-security-enhanced-instance) instance.
 
 The description below uses a VM running Ubuntu 18.04.
 
@@ -24,12 +25,14 @@ The description below uses a VM running Ubuntu 18.04.
 1. Install Intel DCAP Quote Provider Library
 
     Add the Intel SGX APT repository:
+
     ```bash
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
     ```
 
     Download and install the QPL:
+
     ```bash
     sudo apt update
     sudo apt install libsgx-dcap-default-qpl
@@ -41,12 +44,14 @@ The description below uses a VM running Ubuntu 18.04.
     The configuration is set in `/etc/sgx_default_qcnl.conf`.
 
     * If your instance is assigned a public IP address, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE
         ```
 
     * If your instance is in a virtual private cloud and has only internal IP addresses, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE

--- a/docs/docs/deployment/platforms/on-prem.md
+++ b/docs/docs/deployment/platforms/on-prem.md
@@ -11,7 +11,7 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://software.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -29,7 +29,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://software.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)
@@ -42,7 +42,7 @@ Azure provides instructions on [how to install this driver](https://docs.microso
 
 ### SGX Data Center Attestation Primitives (DCAP)
 
-DCAP is the new attestation mechanism for SGX, [replacing EPID](https://software.intel.com/content/www/us/en/develop/blogs/an-update-on-3rd-party-attestation.html).
+DCAP is the new attestation mechanism for SGX, [replacing EPID](https://www.intel.com/content/www/us/en/developer/articles/technical/an-update-on-3rd-party-attestation.html).
 You can find an overview of DCAP in the [official Intel docs](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf).
 MarbleRun only supports DCAP and requires DCAP libraries installed and configured on your system.
 

--- a/docs/docs/deployment/platforms/on-prem.md
+++ b/docs/docs/deployment/platforms/on-prem.md
@@ -11,7 +11,6 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -29,7 +28,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/developer/articles/technical/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)

--- a/docs/docs/features/attestation.md
+++ b/docs/docs/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://software.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/docs/features/attestation.md
+++ b/docs/docs/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/developer/articles/guide/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/docs/getting-started/examples.md
+++ b/docs/docs/getting-started/examples.md
@@ -15,12 +15,13 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://blog.edgeless.systems/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
-
 ## Gramine-based examples
+
 We provide two examples for Gramine-based Marbles:
+
 * A [helloworld](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-hello) example to get you started. 🤓
 * An [nginx web server](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-nginx) for an example of converting an existing Gramine application to a Marble. :rocket:
 

--- a/docs/docs/getting-started/examples.md
+++ b/docs/docs/getting-started/examples.md
@@ -15,7 +15,7 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-ai/)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
 ## Gramine-based examples

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const lightCodeTheme = require('prism-react-renderer').themes.github;
+const darkCodeTheme = require('prism-react-renderer').themes.dracula;
 
 /** @type {import('@docusaurus/types').Config} */
 async function createConfig() {

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -144,7 +144,7 @@ async function createConfig() {
               items: [
                 {
                   label: 'Blog',
-                  href: 'https://blog.edgeless.systems/',
+                  href: 'https://www.edgeless.systems/blog/',
                 },
                 {
                   label: 'Twitter',

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -14,12 +14,16 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@cmfcmf/docusaurus-search-local": "^1.0.0",
-    "@docusaurus/core": "^2.1.0",
-    "@docusaurus/preset-classic": "^2.1.0",
-    "prism-react-renderer": "^1.3.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "@cmfcmf/docusaurus-search-local": "1.1.0",
+    "@docusaurus/core": "2.4.3",
+    "@docusaurus/preset-classic": "2.4.3",
+    "@mdx-js/react": "1.6.22",
+    "redocusaurus": "1.6.4",
+    "asciinema-player": "3.5.0",
+    "clsx": "1.2.1",
+    "prism-react-renderer": "2.0.6",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   },
   "browserslist": {
     "production": [

--- a/docs/versioned_docs/version-1.1/deployment/cloud.md
+++ b/docs/versioned_docs/version-1.1/deployment/cloud.md
@@ -29,12 +29,14 @@ The description below uses a VM running Ubuntu 18.04.
 1. Install Intel DCAP Quote Provider Library
 
     Add the Intel SGX APT repository:
+
     ```bash
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
     ```
 
     Download and install the QPL:
+
     ```bash
     sudo apt update
     sudo apt install libsgx-dcap-default-qpl
@@ -46,12 +48,14 @@ The description below uses a VM running Ubuntu 18.04.
     The configuration is set in `/etc/sgx_default_qcnl.conf`.
 
     * If your instance is assigned a public IP address, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE
         ```
 
     * If your instance is in a virtual private cloud and has only internal IP addresses, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE
@@ -59,7 +63,7 @@ The description below uses a VM running Ubuntu 18.04.
 
     :::note
 
-    Currently, the Alibaba Cloud SGX remote attestation service is only supported within [mainland China regions](https://www.alibabacloud.com/help/doc-detail/40654.htm#concept-2459516)
+    Currently, the Alibaba Cloud SGX remote attestation service is only supported within [mainland China regions](https://www.alibabacloud.com/help/en/beginner-guide/latest/regions-and-zones#concept-2459516)
 
     :::
 

--- a/docs/versioned_docs/version-1.1/deployment/on-prem.md
+++ b/docs/versioned_docs/version-1.1/deployment/on-prem.md
@@ -12,7 +12,7 @@ To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
 
-For more information read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/developer/articles/guide/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -30,7 +30,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/developer/articles/technical/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)

--- a/docs/versioned_docs/version-1.1/deployment/on-prem.md
+++ b/docs/versioned_docs/version-1.1/deployment/on-prem.md
@@ -12,7 +12,7 @@ To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
 
-For more information read this article on [detecting Intel Software Guard Extensions](https://software.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -30,7 +30,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://software.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)
@@ -43,7 +43,7 @@ Azure provides the instructions on [how to install this driver](https://docs.mic
 
 ### SGX Data Center Attestation Primitives (DCAP)
 
-DCAP is the new attestation mechanism for SGX [replacing EPID](https://software.intel.com/content/www/us/en/develop/blogs/an-update-on-3rd-party-attestation.html).
+DCAP is the new attestation mechanism for SGX [replacing EPID](https://www.intel.com/content/www/us/en/developer/articles/technical/an-update-on-3rd-party-attestation.html).
 You can find an overview of DCAP in the [official Intel docs](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf).
 MarbleRun only supports DCAP and requires DCAP libraries installed and configured on your system.
 

--- a/docs/versioned_docs/version-1.1/deployment/on-prem.md
+++ b/docs/versioned_docs/version-1.1/deployment/on-prem.md
@@ -12,8 +12,6 @@ To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
 
-For more information read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/developer/articles/guide/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
-
 #### BIOS
 
 BIOS support is required for Intel SGX to provide the capability to enable and configure the Intel SGX feature in the system.

--- a/docs/versioned_docs/version-1.1/examples.md
+++ b/docs/versioned_docs/version-1.1/examples.md
@@ -15,12 +15,13 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://blog.edgeless.systems/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
-
 ## Gramine-based examples
+
 We provide two examples for Gramine-based Marbles:
+
 * A [helloworld](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-hello) example to get you started. 🤓
 * An [nginx web server](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-nginx) for an example of converting an existing Gramine application to a Marble. :rocket:
 

--- a/docs/versioned_docs/version-1.1/examples.md
+++ b/docs/versioned_docs/version-1.1/examples.md
@@ -15,7 +15,7 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-ai/)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
 ## Gramine-based examples

--- a/docs/versioned_docs/version-1.1/features/attestation.md
+++ b/docs/versioned_docs/version-1.1/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://software.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/versioned_docs/version-1.1/features/attestation.md
+++ b/docs/versioned_docs/version-1.1/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/developer/articles/guide/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/versioned_docs/version-1.2/deployment/platforms/alibaba.md
+++ b/docs/versioned_docs/version-1.2/deployment/platforms/alibaba.md
@@ -6,16 +6,17 @@ Alibaba Cloud Container Service for Kubernetes (ACK) offers a popular deployment
 [ACK hosts Kubernetes pods in SGX-capable Alibaba VMs](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/tee-based-confidential-computing) and exposes the underlying SGX hardware.
 
 ### Prerequisites
+
 * Follow the instructions on the [ACK Confidential Computing Quick Start guide](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/create-an-ack-managed-cluster-for-confidential-computing) to provision an ACK cluster with Intel SGX-enabled worker nodes.
 
 ### Deploy MarbleRun
 
 See the [Kubernetes guide](../kubernetes.md) on installing MarbleRun in your ACK cluster.
 
-
 ## Alibaba Cloud Elastic Compute Service
+
 With 7th-generation [security-enhanced ECS instances](https://www.alibabacloud.com/help/en/ecs/user-guide/overview-25), users can use Intel SGX on Alibaba Cloud.
-You can follow the guide for creating a [g7t, c7t, or r7t](https://www.alibabacloud.com/help/en/elastic-compute-service/latest/create-security-enhanced-instances) instance.
+You can follow the guide for creating a [g7t, c7t, or r7t](https://www.alibabacloud.com/help/en/ecs/user-guide/create-a-security-enhanced-instance) instance.
 
 The description below uses a VM running Ubuntu 18.04.
 
@@ -24,12 +25,14 @@ The description below uses a VM running Ubuntu 18.04.
 1. Install Intel DCAP Quote Provider Library
 
     Add the Intel SGX APT repository:
+
     ```bash
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
     ```
 
     Download and install the QPL:
+
     ```bash
     sudo apt update
     sudo apt install libsgx-dcap-default-qpl
@@ -41,12 +44,14 @@ The description below uses a VM running Ubuntu 18.04.
     The configuration is set in `/etc/sgx_default_qcnl.conf`.
 
     * If your instance is assigned a public IP address, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE
         ```
 
     * If your instance is in a virtual private cloud and has only internal IP addresses, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE

--- a/docs/versioned_docs/version-1.2/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.2/deployment/platforms/on-prem.md
@@ -11,7 +11,7 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://software.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -29,7 +29,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://software.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)
@@ -42,7 +42,7 @@ Azure provides instructions on [how to install this driver](https://docs.microso
 
 ### SGX Data Center Attestation Primitives (DCAP)
 
-DCAP is the new attestation mechanism for SGX, [replacing EPID](https://software.intel.com/content/www/us/en/develop/blogs/an-update-on-3rd-party-attestation.html).
+DCAP is the new attestation mechanism for SGX, [replacing EPID](https://www.intel.com/content/www/us/en/developer/articles/technical/an-update-on-3rd-party-attestation.html).
 You can find an overview of DCAP in the [official Intel docs](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf).
 MarbleRun only supports DCAP and requires DCAP libraries installed and configured on your system.
 

--- a/docs/versioned_docs/version-1.2/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.2/deployment/platforms/on-prem.md
@@ -11,7 +11,6 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/developer/articles/guide/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 

--- a/docs/versioned_docs/version-1.2/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.2/deployment/platforms/on-prem.md
@@ -11,7 +11,7 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/developer/articles/guide/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -29,7 +29,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/developer/articles/technical/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)

--- a/docs/versioned_docs/version-1.2/features/attestation.md
+++ b/docs/versioned_docs/version-1.2/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://software.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/versioned_docs/version-1.2/features/attestation.md
+++ b/docs/versioned_docs/version-1.2/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/developer/articles/guide/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/versioned_docs/version-1.2/getting-started/examples.md
+++ b/docs/versioned_docs/version-1.2/getting-started/examples.md
@@ -15,12 +15,13 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://blog.edgeless.systems/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
-
 ## Gramine-based examples
+
 We provide two examples for Gramine-based Marbles:
+
 * A [helloworld](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-hello) example to get you started. 🤓
 * An [nginx web server](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-nginx) for an example of converting an existing Gramine application to a Marble. :rocket:
 

--- a/docs/versioned_docs/version-1.2/getting-started/examples.md
+++ b/docs/versioned_docs/version-1.2/getting-started/examples.md
@@ -15,7 +15,7 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-ai/)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
 ## Gramine-based examples

--- a/docs/versioned_docs/version-1.3/deployment/platforms/alibaba.md
+++ b/docs/versioned_docs/version-1.3/deployment/platforms/alibaba.md
@@ -6,16 +6,17 @@ Alibaba Cloud Container Service for Kubernetes (ACK) offers a popular deployment
 [ACK hosts Kubernetes pods in SGX-capable Alibaba VMs](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/tee-based-confidential-computing) and exposes the underlying SGX hardware.
 
 ### Prerequisites
+
 * Follow the instructions on the [ACK Confidential Computing Quick Start guide](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/user-guide/create-an-ack-managed-cluster-for-confidential-computing) to provision an ACK cluster with Intel SGX-enabled worker nodes.
 
 ### Deploy MarbleRun
 
 See the [Kubernetes guide](../kubernetes.md) on installing MarbleRun in your ACK cluster.
 
-
 ## Alibaba Cloud Elastic Compute Service
+
 With 7th-generation [security-enhanced ECS instances](https://www.alibabacloud.com/help/en/ecs/user-guide/overview-25), users can use Intel SGX on Alibaba Cloud.
-You can follow the guide for creating a [g7t, c7t, or r7t](https://www.alibabacloud.com/help/en/elastic-compute-service/latest/create-security-enhanced-instances) instance.
+You can follow the guide for creating a [g7t, c7t, or r7t](https://www.alibabacloud.com/help/en/ecs/user-guide/create-a-security-enhanced-instance) instance.
 
 The description below uses a VM running Ubuntu 18.04.
 
@@ -24,12 +25,14 @@ The description below uses a VM running Ubuntu 18.04.
 1. Install Intel DCAP Quote Provider Library
 
     Add the Intel SGX APT repository:
+
     ```bash
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
     ```
 
     Download and install the QPL:
+
     ```bash
     sudo apt update
     sudo apt install libsgx-dcap-default-qpl
@@ -41,12 +44,14 @@ The description below uses a VM running Ubuntu 18.04.
     The configuration is set in `/etc/sgx_default_qcnl.conf`.
 
     * If your instance is assigned a public IP address, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE
         ```
 
     * If your instance is in a virtual private cloud and has only internal IP addresses, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
+
         ```
         PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v3/
         USE_SECURE_CERT=TRUE

--- a/docs/versioned_docs/version-1.3/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.3/deployment/platforms/on-prem.md
@@ -11,7 +11,7 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://software.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -29,7 +29,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://software.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)
@@ -42,7 +42,7 @@ Azure provides instructions on [how to install this driver](https://docs.microso
 
 ### SGX Data Center Attestation Primitives (DCAP)
 
-DCAP is the new attestation mechanism for SGX, [replacing EPID](https://software.intel.com/content/www/us/en/develop/blogs/an-update-on-3rd-party-attestation.html).
+DCAP is the new attestation mechanism for SGX, [replacing EPID](https://www.intel.com/content/www/us/en/developer/articles/technical/an-update-on-3rd-party-attestation.html).
 You can find an overview of DCAP in the [official Intel docs](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf).
 MarbleRun only supports DCAP and requires DCAP libraries installed and configured on your system.
 

--- a/docs/versioned_docs/version-1.3/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.3/deployment/platforms/on-prem.md
@@ -11,7 +11,6 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/developer/articles/guide/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 

--- a/docs/versioned_docs/version-1.3/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.3/deployment/platforms/on-prem.md
@@ -11,7 +11,7 @@ This guide walks you through setting up MarbleRun for your on-premises deploymen
 To deploy MarbleRun with Intel SGX, the machine or VM has to support Intel SGX.
 Particularly, MarbleRun requires support for the SGX Data Center Attestation Primitives (DCAP).
 You can verify [if your CPU supports DCAP](https://www.intel.com/content/www/us/en/support/articles/000057420/software/intel-security-products.html).
-For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/develop/articles/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
+For more information, read this article on [detecting Intel Software Guard Extensions](https://www.intel.com/content/www/us/en/developer/articles/guide/properly-detecting-intel-software-guard-extensions-in-your-applications.html) in your applications.
 
 #### BIOS
 
@@ -29,7 +29,7 @@ If your BIOS/firmware is outdated, you will see errors as `Platform TCB (2) is n
 If you are using VMs for your MarbleRun deployment, you need to make sure your hypervisor has SGX enabled.
 Most of the popular hypervisors support SGX:
 
-* [QEMU/KVM](https://www.intel.com/content/www/us/en/develop/articles/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
+* [QEMU/KVM](https://www.intel.com/content/www/us/en/developer/articles/technical/virtualizing-intel-software-guard-extensions-with-kvm-and-qemu.html)
 * [XEN](https://wiki.xenproject.org/wiki/Xen_and_Intel_Hardware-Assisted_Virtualization_Security)
 * Hyper-V: Hyper-V will only expose SGX to Gen 2 VMs
 * [VMWare vSphere](https://blogs.vmware.com/vsphere/2020/04/vsphere-7-vsgx-secure-enclaves.html)

--- a/docs/versioned_docs/version-1.3/features/attestation.md
+++ b/docs/versioned_docs/version-1.3/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://software.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/versioned_docs/version-1.3/features/attestation.md
+++ b/docs/versioned_docs/version-1.3/features/attestation.md
@@ -2,7 +2,7 @@
 
 Hardware-rooted *remote attestation* is a key ingredient for distributed confidential apps. MarbleRun relies on the [*Data Center Attestation Primitives* (DCAP)](https://download.01.org/intel-sgx/sgx-dcap/1.11/linux/docs/DCAP_ECDSA_Orientation.pdf) of the latest SGX-enabled Intel Xeon processors.
 At the time of writing, only Microsoft Azure had a public DCAP service deployed in their data centers. Hence, our demos are mainly tested and deployed on Azure Kubernetes Service (AKS).
-However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/develop/articles/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
+However, MarbleRun works with any DCAP service complying with the SGX specification. You can read more about setting up your own DCAP infrastructure [in the Intel SGX development articles](https://www.intel.com/content/www/us/en/developer/articles/guide/intel-software-guard-extensions-data-center-attestation-primitives-quick-install-guide.html).
 
 ## Coordinator deployment
 

--- a/docs/versioned_docs/version-1.3/getting-started/examples.md
+++ b/docs/versioned_docs/version-1.3/getting-started/examples.md
@@ -15,12 +15,13 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://blog.edgeless.systems/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
-
 ## Gramine-based examples
+
 We provide two examples for Gramine-based Marbles:
+
 * A [helloworld](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-hello) example to get you started. 🤓
 * An [nginx web server](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-nginx) for an example of converting an existing Gramine application to a Marble. :rocket:
 

--- a/docs/versioned_docs/version-1.3/getting-started/examples.md
+++ b/docs/versioned_docs/version-1.3/getting-started/examples.md
@@ -15,7 +15,7 @@ The popular [Linkerd](https://linkerd.io) service mesh uses the simple and fun s
 
 We provide a hands-on example for a confidential multi-stakeholder inference service.
 
-* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-machine-learning-2292f842e95a)
+* Read the [blog post](https://www.edgeless.systems/blog/confidential-multi-stakeholder-ai/)
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
 ## Gramine-based examples


### PR DESCRIPTION
### Proposed changes
- Remove unused refs from `README.md`
- Update blog link from `blog.edgeless.systems` to `www.edgeless.systems/blog`
- Replace links to Intel and Alibaba websites that got redirected


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
