### PR TITLE
Allow adding additional IPs for Coordinator root cert

### DIFF
--- a/coordinator/crypto/crypto.go
+++ b/coordinator/crypto/crypto.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"math"
+	"net"
 	"time"
 
 	"github.com/edgelesssys/marblerun/util"
@@ -44,13 +45,23 @@ func GenerateCert(
 		return nil, nil, fmt.Errorf("generating serial number: %w", err)
 	}
 
+	var additionalDNSNames []string
+	var additionalIPs []net.IP
+	for _, name := range dnsNames {
+		if ip := net.ParseIP(name); ip != nil {
+			additionalIPs = append(additionalIPs, ip)
+		} else {
+			additionalDNSNames = append(additionalDNSNames, name)
+		}
+	}
+
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},
-		DNSNames:    dnsNames,
-		IPAddresses: util.DefaultCertificateIPAddresses,
+		DNSNames:    additionalDNSNames,
+		IPAddresses: append(util.DefaultCertificateIPAddresses, additionalIPs...),
 		NotBefore:   notBefore,
 		NotAfter:    notAfter,
 

--- a/docs/docs/architecture/coordinator.md
+++ b/docs/docs/architecture/coordinator.md
@@ -14,7 +14,7 @@ The Coordinator can be configured with several environment variables:
 
 * `EDG_COORDINATOR_MESH_ADDR`: The listener address for the gRPC server
 * `EDG_COORDINATOR_CLIENT_ADDR`: The listener address for the HTTP REST server
-* `EDG_COORDINATOR_DNS_NAMES`: The DNS names for the cluster's root certificate
+* `EDG_COORDINATOR_DNS_NAMES`: The DNS names and IPs for the cluster's root certificate
 * `EDG_COORDINATOR_SEAL_DIR`: The file path for storing sealed data
 
 When you use MarbleRun [with Kubernetes](../deployment/kubernetes.md), you can [scale the Coordinator to multiple instances](../features/recovery.md#distributed-coordinator) to increase availability and reduce the occurrence of events that require [manual recovery](../workflows/recover-coordinator.md).

--- a/docs/docs/deployment/standalone.md
+++ b/docs/docs/deployment/standalone.md
@@ -23,7 +23,7 @@ Per default, the Coordinator starts with the following default values. You can s
 | --- | --- | --- |
 | the listener address for the gRPC server | localhost:2001 |  EDG_COORDINATOR_MESH_ADDR |
 | the listener address for the HTTP server | localhost: 4433 | EDG_COORDINATOR_CLIENT_ADDR |
-| the DNS names for the cluster’s root certificate | localhost | EDG_COORDINATOR_DNS_NAMES |
+| the DNS names and IPs for the cluster’s root certificate | localhost | EDG_COORDINATOR_DNS_NAMES |
 | the file path for storing sealed data | $PWD/marblerun-coordinator-data | EDG_COORDINATOR_SEAL_DIR |
 
 :::tip
@@ -53,4 +53,4 @@ Per default, a Marble starts with the following default values. You can set your
 | network address of the Coordinator’s API for Marbles | `localhost:2001` |  EDG_MARBLE_COORDINATOR_ADDR |
 | reference on one entry from your manifest’s `Marbles` section | - (this needs to be set every time) | EDG_MARBLE_TYPE |
 | local file path where the Marble stores its UUID | `$PWD/uuid` | EDG_MARBLE_UUID_FILE |
-| DNS names the Coordinator will issue the Marble’s certificate for | `$EDG_MARBLE_TYPE` | EDG_MARBLE_DNS_NAMES |
+| DNS names and IPs the Coordinator will issue the Marble’s certificate for | `$EDG_MARBLE_TYPE` | EDG_MARBLE_DNS_NAMES |

--- a/docs/docs/workflows/add-service.md
+++ b/docs/docs/workflows/add-service.md
@@ -123,7 +123,7 @@ The environment variables have the following purposes.
 
 * `EDG_MARBLE_UUID_FILE` is the local file path where the Marble stores its UUID. Every instance of a Marble has its unique and public UUID. The file is needed to allow a Marble to restart under its UUID.
 
-* `EDG_MARBLE_DNS_NAMES` is the list of DNS names the Coordinator will issue the Marble's certificate for.
+* `EDG_MARBLE_DNS_NAMES` is the list of DNS names and IPs the Coordinator will issue the Marble's certificate for.
 
 ## **Step 4:** Deploy your service with Kubernetes
 

--- a/util/tls_test.go
+++ b/util/tls_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package util
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractIPsFromAltNames(t *testing.T) {
+	testCases := map[string]struct {
+		altNames     []string
+		wantIPs      []net.IP
+		wantDNSNames []string
+	}{
+		"empty": {
+			altNames:     []string{},
+			wantIPs:      []net.IP{},
+			wantDNSNames: []string{},
+		},
+		"only IPs": {
+			altNames:     []string{"192.0.2.1", "192.0.2.15"},
+			wantIPs:      []net.IP{net.ParseIP("192.0.2.1"), net.ParseIP("192.0.2.15")},
+			wantDNSNames: []string{},
+		},
+		"only DNS names": {
+			altNames:     []string{"foo.bar", "example.com"},
+			wantIPs:      []net.IP{},
+			wantDNSNames: []string{"foo.bar", "example.com"},
+		},
+		"mixed": {
+			altNames:     []string{"192.0.2.1", "foo.bar"},
+			wantIPs:      []net.IP{net.ParseIP("192.0.2.1")},
+			wantDNSNames: []string{"foo.bar"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			gotIPs, gotDNSNames := ExtractIPsFromAltNames(tc.altNames)
+			assert.ElementsMatch(tc.wantIPs, gotIPs)
+			assert.ElementsMatch(tc.wantDNSNames, gotDNSNames)
+		})
+	}
+}


### PR DESCRIPTION
### Proposed changes
- Allow adding additional IPs to the Coordinator root cert by correctly parsing them from the `EDG_COORDINATOR_DNS_NAMES` env variable

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Previously, IP addresses were incorrectly added as additional DNS names of the certificate. This means any generated Certificate was only signed for the IP adresses `127.0.0.1` and the ipv6 equivalent. This effectively made it required to provide a DNS name when exposing the client API publicly, e.g. when running the Coordinator in Kubernetes and using a Loadbalancer to assign a public IP to the client API.

<!-- (uncomment if applicable)
### Screenshots

-->
