### PR TITLE
docs: update dependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,15 +15,14 @@
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "1.1.0",
-    "@docusaurus/core": "2.4.3",
-    "@docusaurus/preset-classic": "2.4.3",
-    "@mdx-js/react": "1.6.22",
-    "redocusaurus": "1.6.4",
-    "asciinema-player": "3.6.3",
+    "@docusaurus/core": "3.0.0",
+    "@docusaurus/preset-classic": "3.0.0",
+    "redocusaurus": "2.0.0",
+    "@mdx-js/react": "3.0.0",
     "clsx": "2.0.0",
-    "prism-react-renderer": "2.2.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "prism-react-renderer": "2.3.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "browserslist": {
     "production": [
@@ -37,7 +36,12 @@
       "last 1 safari version"
     ]
   },
+  "overrides": {
+    "@cmfcmf/docusaurus-search-local": {
+      "@docusaurus/core": "3.0.0"
+    }
+  },
   "engines": {
-    "node": ">=16.14"
+    "node": ">=18.0"
   }
 }


### PR DESCRIPTION
### Proposed changes
- Update dependencies of docs packages to their latest versions
- Update node to v18
- Remove unused asciinema dependency

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- We are using a dependency override for `cmfcmf/docusaurus-search-local` for now, as there hasnt been a new release for docusaurus v3.0 yet. Once renovate alerts us to a new release we can remove it again.

<!-- (uncomment if applicable)
### Screenshots

-->
