### PR TITLE
Explicitly add libcurl in dockerfiles

### DIFF
--- a/dockerfiles/Dockerfile.cli
+++ b/dockerfiles/Dockerfile.cli
@@ -47,6 +47,7 @@ RUN chmod +x linuxdeploy-x86_64.AppImage && touch marblerun.svg \
   -imarblerun.svg \
   -e/mrbuild/marblerun \
   -l/usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 \
+  -l/usr/lib/x86_64-linux-gnu/libcurl.so.4 \
   # workaround for hardcoded CA bundle path in libcurl
   && cd marblerun.AppDir/usr \
   && mkdir lib-fedora \

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -46,7 +46,7 @@ COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-22.04
 FROM ubuntu:jammy-20231128 AS release
 ARG PSW_VERSION=2.22.100.3-jammy1
 ARG DCAP_VERSION=1.19.100.3-jammy1
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libcurl4 wget \
   && wget -qO /etc/apt/keyrings/intel-sgx-keyring.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
   && echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' > /etc/apt/sources.list.d/intel-sgx.list \
   && apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
New DCAP library now uses dlopen instead of dynamic linking to load libcurl (apparently to support different libcurl versions).
* Install libcurl package in coordinator image
* Explicitly tell linuxdeploy to add libcurl (previously, it auto-detected it by following the dynamically linked libs).