### PR TITLE
Update samples to Gramine v1.7

### DIFF
--- a/samples/gramine-hello/README.md
+++ b/samples/gramine-hello/README.md
@@ -4,7 +4,7 @@ This example shows how to run a [Gramine](https://github.com/gramineproject/gram
 
 ## Requirements
 
-First, install Gramine on [release v1.5](https://github.com/gramineproject/gramine/releases/tag/v1.5). You will need hardware with Intel SGX support.
+First, [install Gramine](https://github.com/gramineproject/gramine/releases). You will need hardware with Intel SGX support.
 
 Then, before you can run the example, make sure you got the prerequisites for ECDSA remote attestation installed on your system. You can collectively install them with the following command:
 

--- a/samples/gramine-nginx/README.md
+++ b/samples/gramine-nginx/README.md
@@ -2,7 +2,7 @@
 
 This example is a slightly modified variant of the [Gramine nginx example](https://github.com/gramineproject/gramine/tree/master/CI-Examples/nginx). These changes are required to run it with MarbleRun.
 
-*Prerequisite*: Gramine is installed on [release v1.5](https://github.com/gramineproject/gramine/releases/tag/v1.5) and the original nginx example is working. You will need hardware with Intel SGX support, and the Coordinator must not run in simulation mode.
+*Prerequisite*: [Gramine is installed](https://github.com/gramineproject/gramine/releases) and the [original nginx example](https://github.com/gramineproject/gramine/tree/master/CI-Examples/nginx) is working. You will need hardware with Intel SGX support, and the Coordinator must not run in simulation mode.
 
 To marbleize the example we edited [nginx.manifest.template](nginx.manifest.template). See comments starting with `MARBLERUN` for explanations of the required changes.
 

--- a/samples/gramine-redis/Dockerfile
+++ b/samples/gramine-redis/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /premain/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 RUN make premain-libos
 
-FROM gramineproject/gramine:v1.5 AS release
+FROM gramineproject/gramine:1.7-jammy AS release
 RUN apt-get update && apt-get install -y \
     wget \
     libssl-dev \
@@ -24,7 +24,7 @@ COPY --from=pull_gramine /gramine /gramine
 COPY --from=build-premain /premain/build/premain-libos /gramine/CI-Examples/redis/
 COPY ./redis-server.manifest.template ./start.sh /gramine/CI-Examples/redis/
 WORKDIR /gramine/CI-Examples/redis/
-ENV BUILD_TLS yes
+ENV BUILD_TLS=yes
 RUN --mount=type=secret,id=signingkey,dst=/root/.config/gramine/enclave-key.pem,required=true \
-    make clean && make SGX=1
+    make clean && make SGX=1 && chmod +x start.sh
 ENTRYPOINT [ "/gramine/CI-Examples/redis/start.sh" ]

--- a/samples/gramine-redis/README.md
+++ b/samples/gramine-redis/README.md
@@ -38,7 +38,7 @@ First, we are installing MarbleRun on your cluster.
 * Check Coordinator's status, this should return status `2: ready to accept manifest`.
 
     ```bash
-    marblerun status $MARBLERUN
+    marblerun status $MARBLERUN --insecure
     ```
 
 * Set the [manifest](manifest.json)


### PR DESCRIPTION
Gramine released v1.7 a while ago, but this wasn't picked up by renovate since they also changed the tag format used for the images.

### Proposed changes
- Update samples to use Gramine v1.7
  - Run chmod on `start.sh` to fix potential issue when building container image
  - Use `--insecure` flag to check status of Coordinator before manifest is set
- Remove mention of exact Gramine version in sample Readmes, we test against the latest Gramine version in our CI anyways

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Tested changes manually on Gramine v1.7
- New redis image needs to be build after this PR is merged

<!-- (uncomment if applicable)
### Screenshots

-->
