### PR TITLE
Retire usage of era in CLI functions

### DIFF
--- a/cli/internal/cmd/manifestVerify.go
+++ b/cli/internal/cmd/manifestVerify.go
@@ -99,6 +99,11 @@ func cliManifestVerify(cmd *cobra.Command, localSignature string, client getter)
 		return err
 	}
 	remoteSignature := gjson.GetBytes(resp, "ManifestSignature").String()
+
+	if remoteSignature == "" {
+		return errors.New("Coordinator returned no manifest signature. Is the Coordinator in the correct state?")
+	}
+
 	if remoteSignature != localSignature {
 		return fmt.Errorf("remote signature differs from local signature: %s != %s", remoteSignature, localSignature)
 	}

--- a/cli/internal/rest/rest.go
+++ b/cli/internal/rest/rest.go
@@ -239,6 +239,10 @@ func fetchLatestCoordinatorConfiguration(ctx context.Context, out io.Writer, k8s
 		return fmt.Errorf("writing era config file: %w", err)
 	}
 
-	fmt.Fprintf(out, "Got era config for version %s\n", coordinatorVersion)
+	if coordinatorVersion != "" {
+		fmt.Fprintf(out, "Got era config for version %s\n", coordinatorVersion)
+	} else {
+		fmt.Fprintln(out, "Got latest era config")
+	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/cert-manager/cert-manager v1.14.4
 	github.com/edgelesssys/ego v1.5.0
-	github.com/edgelesssys/era v0.3.3
 	github.com/gofrs/flock v0.8.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,6 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arX
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/edgelesssys/ego v1.5.0 h1:euwXc69GRGlxpklIaVZtyh0v27YXzf9ow3iODE7CrPc=
 github.com/edgelesssys/ego v1.5.0/go.mod h1:N58b0J+s3U4sxXeNUT5uiQV9Q9M/U2KsILC44Ku5dnw=
-github.com/edgelesssys/era v0.3.3 h1:EyZvkR/WJceMaV+15lt+CYI0h6mC8pUOFklbbKT8KwQ=
-github.com/edgelesssys/era v0.3.3/go.mod h1:yGYrnt8vxxFUsbMQCMwEBItNK9vNqS0f9YONvr78lBY=
 github.com/emicklei/go-restful/v3 v3.11.3 h1:yagOQz/38xJmcNeZJtrUcKjkHRltIaIFXKWeG1SkWGE=
 github.com/emicklei/go-restful/v3 v3.11.3/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -1,0 +1,203 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package attestation
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/edgelesssys/ego/attestation"
+	"github.com/edgelesssys/ego/attestation/tcbstatus"
+	"github.com/edgelesssys/ego/eclient"
+	"github.com/tidwall/gjson"
+)
+
+// Config is the expected attestation metadata of a MarbleRun Coordinator enclave.
+// It is used to verify the Coordinator's remote attestation report.
+// At minimum, either UniqueID or the tuple of SignerID, ProductID, and SecurityVersion must be provided.
+type Config struct {
+	SecurityVersion uint   `json:"SecurityVersion"`
+	UniqueID        string `json:"UniqueID"`
+	SignerID        string `json:"SignerID"`
+	ProductID       uint16 `json:"ProductID"`
+	Debug           bool   `json:"Debug"`
+}
+
+// ErrEmptyQuote defines an error type when no quote was received. This likely occurs when the host is running in OE Simulation mode.
+var ErrEmptyQuote = errors.New("no quote received")
+
+// GetCertificate gets the Coordinator's TLS certificate using remote attestation.
+// A config with the expected attestation metadata must be provided.
+// An optional nonce may be provided to force the Coordinator to generate a new quote for this request.
+// It returns the verified certificate chain in PEM format, the TCB status of the enclave, the quote, and an error, if any.
+func GetCertificate(ctx context.Context, host string, nonce []byte, config Config) ([]*pem.Block, tcbstatus.Status, []byte, error) {
+	return getCertificate(ctx, host, nonce, config, eclient.VerifyRemoteReport)
+}
+
+// InsecureGetCertificate gets the Coordinator's TLS certificate, but does not perform remote attestation.
+func InsecureGetCertificate(ctx context.Context, host string) ([]*pem.Block, []byte, error) {
+	certs, _, quote, err := getCertificate(ctx, host, nil, Config{}, nil)
+	return certs, quote, err
+}
+
+type verifyFunc func([]byte) (attestation.Report, error)
+
+func getCertificate(ctx context.Context, host string, nonce []byte, config Config, verifyRemoteReport verifyFunc) ([]*pem.Block, tcbstatus.Status, []byte, error) {
+	cert, quote, err := httpGetCertQuote(ctx, host, nonce)
+	if err != nil {
+		return nil, tcbstatus.Unknown, nil, err
+	}
+
+	var certs []*pem.Block
+	block, rest := pem.Decode([]byte(cert))
+	if block == nil {
+		return nil, tcbstatus.Unknown, nil, errors.New("could not parse certificate")
+	}
+	certs = append(certs, block)
+
+	// If we get more than one certificate, append it to the slice
+	for len(rest) > 0 {
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return nil, tcbstatus.Unknown, nil, errors.New("could not parse certificate chain")
+		}
+		certs = append(certs, block)
+	}
+
+	if verifyRemoteReport == nil {
+		return certs, tcbstatus.Unknown, quote, nil
+	}
+
+	if len(quote) == 0 {
+		return nil, tcbstatus.Unknown, quote, ErrEmptyQuote
+	}
+
+	report, verifyErr := verifyRemoteReport(quote)
+	if verifyErr != nil && verifyErr != attestation.ErrTCBLevelInvalid {
+		return nil, tcbstatus.Unknown, quote, verifyErr
+	}
+
+	// Use Root CA (last entry in certs) for attestation
+	certRaw := certs[len(certs)-1].Bytes
+
+	if err := verifyReport(report, certRaw, nonce, config); err != nil {
+		return nil, tcbstatus.Unknown, quote, err
+	}
+
+	return certs, report.TCBStatus, quote, verifyErr
+}
+
+// verifyReport checks the attestation report against the provided configuration.
+// The reports quote must match the hash of the certificate and (optional) nonce.
+func verifyReport(report attestation.Report, cert, nonce []byte, cfg Config) error {
+	hash := sha256.Sum256(append(cert, nonce...))
+	if !bytes.Equal(report.Data[:len(hash)], hash[:]) {
+		return errors.New("report data does not match the certificate's hash")
+	}
+
+	if cfg.UniqueID == "" {
+		if cfg.SecurityVersion == 0 {
+			return errors.New("missing SecurityVersion in config")
+		}
+		if cfg.ProductID == 0 {
+			return errors.New("missing ProductID in config")
+		}
+	}
+
+	if cfg.SecurityVersion != 0 && report.SecurityVersion < cfg.SecurityVersion {
+		return errors.New("invalid SecurityVersion")
+	}
+	if cfg.ProductID != 0 && binary.LittleEndian.Uint16(report.ProductID) != cfg.ProductID {
+		return errors.New("invalid ProductID")
+	}
+	if report.Debug && !cfg.Debug {
+		return errors.New("debug enclave not allowed")
+	}
+	if err := verifyID(cfg.UniqueID, report.UniqueID, "UniqueID"); err != nil {
+		return err
+	}
+	if err := verifyID(cfg.SignerID, report.SignerID, "SignerID"); err != nil {
+		return err
+	}
+	if cfg.UniqueID == "" && cfg.SignerID == "" {
+		fmt.Println("Warning: Configuration contains neither UniqueID nor SignerID!")
+	}
+
+	return nil
+}
+
+func verifyID(expected string, actual []byte, name string) error {
+	if expected == "" {
+		return nil
+	}
+	expectedBytes, err := hex.DecodeString(expected)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(expectedBytes, actual) {
+		return errors.New("invalid " + name)
+	}
+	return nil
+}
+
+// httpGetCertQuote requests the Coordinator's quote and certificate chain.
+func httpGetCertQuote(ctx context.Context, host string, nonce []byte) (string, []byte, error) {
+	client := http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+
+	url := url.URL{Scheme: "https", Host: host, Path: "quote"}
+	if nonce != nil {
+		url.Query().Add("nonce", hex.EncodeToString(nonce))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return "", nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		errorMessage := gjson.GetBytes(body, "message")
+		if errorMessage.Exists() {
+			return "", nil, errors.New(resp.Status + ": " + errorMessage.String())
+		}
+		return "", nil, errors.New(resp.Status + ": " + string(body))
+	}
+
+	var certQuote certQuoteResp
+	if err := json.Unmarshal([]byte(gjson.GetBytes(body, "data").String()), &certQuote); err != nil {
+		return "", nil, err
+	}
+	resp.Body.Close()
+	return certQuote.Cert, certQuote.Quote, nil
+}
+
+type certQuoteResp struct {
+	Cert  string
+	Quote []byte
+}

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -162,8 +163,8 @@ func httpGetCertQuote(ctx context.Context, host string, nonce []byte) (string, [
 	}
 
 	url := url.URL{Scheme: "https", Host: host, Path: "quote"}
-	if nonce != nil {
-		url.Query().Add("nonce", hex.EncodeToString(nonce))
+	if len(nonce) > 0 {
+		url.Query().Add("nonce", base64.URLEncoding.EncodeToString(nonce))
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
@@ -193,7 +194,6 @@ func httpGetCertQuote(ctx context.Context, host string, nonce []byte) (string, [
 	if err := json.Unmarshal([]byte(gjson.GetBytes(body, "data").String()), &certQuote); err != nil {
 		return "", nil, err
 	}
-	resp.Body.Close()
 	return certQuote.Cert, certQuote.Quote, nil
 }
 

--- a/internal/attestation/attestation_test.go
+++ b/internal/attestation/attestation_test.go
@@ -1,0 +1,317 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package attestation
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/ego/attestation"
+	"github.com/edgelesssys/ego/attestation/tcbstatus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type generalResponse struct {
+	Status  string      `json:"status"`
+	Data    interface{} `json:"data"`
+	Message string      `json:"message,omitempty"` // only used when status = "error"
+}
+
+func TestGetCertificate(t *testing.T) {
+	signerConfig := Config{
+		SecurityVersion: 2,
+		ProductID:       3,
+		SignerID:        "ABCD",
+	}
+
+	signerReport := &attestation.Report{
+		SecurityVersion: 2,
+		ProductID:       []byte{0x03, 0x00},
+		SignerID:        []byte{0xAB, 0xCD},
+	}
+
+	testCases := map[string]struct {
+		nonce      []byte
+		config     Config
+		report     *attestation.Report
+		verifyErr  error
+		wantErr    bool
+		wantTCBErr bool
+		tcbStatus  tcbstatus.Status
+	}{
+		"get certificate without quote validation": {},
+		"get certificate with quote validation": {
+			config: signerConfig,
+			report: signerReport,
+		},
+		"get certificate with quote validation and nonce": {
+			config: signerConfig,
+			report: signerReport,
+			nonce:  []byte{0x01, 0x02, 0x03},
+		},
+		"verify fails": {
+			config:    signerConfig,
+			report:    signerReport,
+			verifyErr: assert.AnError,
+			wantErr:   true,
+		},
+		"invalid hash": {
+			config: signerConfig,
+			report: &attestation.Report{
+				Data:            make([]byte, 64),
+				SecurityVersion: 2,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+			},
+			wantErr: true,
+		},
+		"invalid security version": {
+			config: signerConfig,
+			report: &attestation.Report{
+				SecurityVersion: 1,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+			},
+			wantErr: true,
+		},
+		"newer security version": {
+			config: signerConfig,
+			report: &attestation.Report{
+				SecurityVersion: 3,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+			},
+		},
+		"invalid product": {
+			config: signerConfig,
+			report: &attestation.Report{
+				SecurityVersion: 2,
+				ProductID:       []byte{0x04, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+			},
+			wantErr: true,
+		},
+		"invalid signer": {
+			config: signerConfig,
+			report: &attestation.Report{
+				SecurityVersion: 2,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCE},
+			},
+			wantErr: true,
+		},
+		"missing productID": {
+			config:  Config{SecurityVersion: 2, SignerID: "ABCD"},
+			report:  signerReport,
+			wantErr: true,
+		},
+		"missing securityVersion": {
+			config:  Config{ProductID: 3, SignerID: "ABCD"},
+			report:  signerReport,
+			wantErr: true,
+		},
+		"uniqeID": {
+			config: Config{UniqueID: "ABCD"},
+			report: &attestation.Report{
+				UniqueID: []byte{0xAB, 0xCD},
+			},
+		},
+		"invalid uniqeID": {
+			config: Config{UniqueID: "ABCD"},
+			report: &attestation.Report{
+				UniqueID: []byte{0xAB, 0xCE},
+			},
+			wantErr: true,
+		},
+		"debug enclave not allowed": {
+			config: Config{UniqueID: "ABCD"},
+			report: &attestation.Report{
+				UniqueID: []byte{0xAB, 0xCD},
+				Debug:    true,
+			},
+			wantErr: true,
+		},
+		"debug enclave allowed": {
+			config: Config{UniqueID: "ABCD", Debug: true},
+			report: &attestation.Report{
+				UniqueID: []byte{0xAB, 0xCD},
+				Debug:    true,
+			},
+		},
+		"tcb error": {
+			config: signerConfig,
+			report: &attestation.Report{
+				SecurityVersion: 2,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+				TCBStatus:       tcbstatus.OutOfDate,
+			},
+			verifyErr:  attestation.ErrTCBLevelInvalid,
+			wantTCBErr: true,
+			tcbStatus:  tcbstatus.OutOfDate,
+		},
+		"tcb error and invalid product": {
+			config: signerConfig,
+			report: &attestation.Report{
+				SecurityVersion: 2,
+				ProductID:       []byte{0x04, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+				TCBStatus:       tcbstatus.OutOfDate,
+			},
+			verifyErr: attestation.ErrTCBLevelInvalid,
+			wantErr:   true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			var quote []byte
+			var cert string
+
+			server, addr, expectedCert := newServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal("/quote", r.RequestURI)
+				writeJSON(w, certQuoteResp{cert, quote})
+			}))
+			defer server.Close()
+
+			cert = expectedCert
+			block, _ := pem.Decode([]byte(cert))
+			certRaw := block.Bytes
+			hash := sha256.Sum256(append(certRaw, tc.nonce...))
+			quote = hash[:]
+
+			var verify verifyFunc
+			if tc.report != nil {
+				verify = func(reportBytes []byte) (attestation.Report, error) {
+					assert.Equal(quote, reportBytes)
+					report := *tc.report
+					if report.Data == nil {
+						report.Data = hash[:]
+					}
+					return report, tc.verifyErr
+				}
+			}
+
+			actualCerts, tcbStatus, _, err := getCertificate(context.Background(), addr, tc.nonce, tc.config, verify)
+			if tc.wantTCBErr {
+				require.Equal(attestation.ErrTCBLevelInvalid, err)
+				assert.Equal(tc.tcbStatus, tcbStatus)
+			} else if tc.wantErr {
+				assert.Error(err)
+				assert.NotErrorIs(err, attestation.ErrTCBLevelInvalid)
+				return
+			} else {
+				require.NoError(err)
+			}
+
+			assert.EqualValues(expectedCert, pem.EncodeToMemory(actualCerts[0]))
+		})
+	}
+}
+
+func TestGetMultipleCertificates(t *testing.T) {
+	config := Config{
+		SecurityVersion: 2,
+		ProductID:       3,
+		SignerID:        "ABCD",
+	}
+
+	assert := assert.New(t)
+	var quote []byte
+	var certs string
+
+	server, addr, expectedCerts := newServerMultipleCertificates(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/quote", r.RequestURI)
+		writeJSON(w, certQuoteResp{certs, quote})
+	}))
+	certs = expectedCerts[0] + expectedCerts[1]
+	block, _ := pem.Decode([]byte(expectedCerts[1])) // last one is supposed to be root CA, which we use for quoting
+	certRaw := block.Bytes
+	hash := sha256.Sum256(certRaw)
+	quote = hash[:]
+
+	defer server.Close()
+
+	// get certificates without quote validation
+	actualCerts, _, _, err := getCertificate(context.Background(), addr, nil, Config{}, nil)
+	assert.NoError(err)
+	assert.EqualValues(expectedCerts[0], pem.EncodeToMemory(actualCerts[0]))
+	assert.EqualValues(expectedCerts[1], pem.EncodeToMemory(actualCerts[1]))
+
+	// get certificates with quote validation
+	actualCerts, _, _, err = getCertificate(context.Background(), addr, nil, config,
+		func(reportBytes []byte) (attestation.Report, error) {
+			assert.Equal(quote, reportBytes)
+			return attestation.Report{
+				Data:            hash[:],
+				SecurityVersion: 2,
+				ProductID:       []byte{0x03, 0x00},
+				SignerID:        []byte{0xAB, 0xCD},
+			}, nil
+		})
+	assert.NoError(err)
+	assert.EqualValues(expectedCerts[0], pem.EncodeToMemory(actualCerts[0]))
+	assert.EqualValues(expectedCerts[1], pem.EncodeToMemory(actualCerts[1]))
+}
+
+func newServer(handler http.Handler) (server *httptest.Server, addr string, cert string) {
+	s := httptest.NewTLSServer(handler)
+	return s, s.Listener.Addr().String(), toPEM(s.Certificate().Raw)
+}
+
+func newServerMultipleCertificates(handler http.Handler) (server *httptest.Server, addr string, certs []string) {
+	// Create a second test certificate
+	key, err := rsa.GenerateKey(rand.Reader, 3096)
+	if err != nil {
+		panic(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		IsCA:         false,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365),
+	}
+
+	testCertRaw, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+
+	s := httptest.NewTLSServer(handler)
+	expectedCerts := []string{toPEM(testCertRaw), toPEM(s.Certificate().Raw)}
+	return s, s.Listener.Addr().String(), expectedCerts
+}
+
+func toPEM(certificate []byte) string {
+	result := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate})
+	if len(result) <= 0 {
+		panic("EncodeToMemory failed")
+	}
+	return string(result)
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	dataToReturn := generalResponse{Status: "success", Data: v}
+	if err := json.NewEncoder(w).Encode(dataToReturn); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/internal/attestation/attestation_test.go
+++ b/internal/attestation/attestation_test.go
@@ -210,7 +210,7 @@ func TestGetCertificate(t *testing.T) {
 				}
 			}
 
-			actualCerts, tcbStatus, _, err := getCertificate(context.Background(), addr, tc.nonce, tc.config, verify)
+			actualCerts, tcbStatus, actualQuote, err := getCertificate(context.Background(), addr, tc.nonce, tc.config, verify)
 			if tc.wantTCBErr {
 				require.Equal(attestation.ErrTCBLevelInvalid, err)
 				assert.Equal(tc.tcbStatus, tcbStatus)
@@ -223,6 +223,7 @@ func TestGetCertificate(t *testing.T) {
 			}
 
 			assert.EqualValues(expectedCert, pem.EncodeToMemory(actualCerts[0]))
+			assert.Equal(quote, actualQuote)
 		})
 	}
 }

--- a/internal/tcb/tcb.go
+++ b/internal/tcb/tcb.go
@@ -9,10 +9,10 @@ package tcb
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/edgelesssys/ego/attestation"
 	"github.com/edgelesssys/ego/attestation/tcbstatus"
-	"github.com/edgelesssys/era/util"
 )
 
 // Validity is the validity of a TCB level.
@@ -44,7 +44,7 @@ func CheckStatus(status tcbstatus.Status, tcbErr error, accepted []string) (Vali
 	} else if status == tcbstatus.UpToDate {
 		return ValidityInvalid, fmt.Errorf("unexpected: TCB level invalid: %v", status)
 	}
-	if !util.StringSliceContains(accepted, status.String()) {
+	if !slices.Contains(accepted, status.String()) {
 		return ValidityInvalid, fmt.Errorf("TCB level invalid: %v", status)
 	}
 	if invalid {


### PR DESCRIPTION
### Proposed changes
- Adapt [era](https://github.com/edgelesssys/era) code and move it to MarbleRun directly instead of having it as external dependency
- Fix log message when fetching latest era config from GitHub
- Use better error message when trying to verify a manifest on a Coordinator which has no manifest set (e.g. is in recovery mode / waiting for manifest)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
