### PR TITLE
docs: fix search

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "1.2.0",
-    "@docusaurus/core": "3.4.0",
-    "@docusaurus/preset-classic": "3.4.0",
+    "@docusaurus/core": "3.3.2",
+    "@docusaurus/preset-classic": "3.3.2",
     "redocusaurus": "2.0.2",
     "@mdx-js/react": "3.0.1",
     "clsx": "2.1.1",
@@ -38,7 +38,7 @@
   },
   "overrides": {
     "@cmfcmf/docusaurus-search-local": {
-      "@docusaurus/core": "3.4.0"
+      "@docusaurus/core": "3.3.2"
     }
   },
   "engines": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,6 +39,10 @@
   "overrides": {
     "@cmfcmf/docusaurus-search-local": {
       "@docusaurus/core": "3.3.2"
+    },
+    "redocusaurus": {
+      "@docusaurus/theme-common": "3.3.2",
+      "@docusaurus/utils": "3.3.2"
     }
   },
   "engines": {


### PR DESCRIPTION
Search plugin doesn't work with docusaurus 3.4.0. It generates wrong URLs. Downgrade until cmfcmf/docusaurus-search-local#205 is resolved.