### PR TITLE
cli: allow setting multiple DNS names or IPs using `--domain` flag in `marblerun install`

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -35,7 +35,7 @@ their default values.
 |:---------------------------------------------|:---------------|:---------------|:-------------------------------------|
 | `coordinator.clientServerHost`               | string         | Hostname of the client-api server | `"0.0.0.0"` |
 | `coordinator.clientServerPort`               | int            | Port of the client-api server configuration | `4433` |
-| `coordinator.hostname`                       | string         | DNS-Names for the coordinator certificate | `"localhost"` |
+| `coordinator.hostname`                       | string         | Additional DNS-Names or IPs for the coordinator TLS certificate |  |
 | `coordinator.image`                          | string         | Name of the coordinator container image | `"coordinator"` |
 | `coordinator.meshServerHost`                 | string         | Hostname of the mesh-api server | `"0.0.0.0"` |
 | `coordinator.meshServerPort`                 | int            | Port of the mesh-api server configuration | `2001` |

--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -45,7 +45,7 @@ spec:
           - name: EDG_COORDINATOR_CLIENT_ADDR
             value: "{{ .Values.coordinator.clientServerHost }}:{{ .Values.coordinator.clientServerPort }}"
           - name: EDG_COORDINATOR_DNS_NAMES
-            value: "{{ .Values.coordinator.hostname }},coordinator-mesh-api,coordinator-client-api,coordinator-mesh-api.{{ .Release.Namespace }},coordinator-client-api.{{ .Release.Namespace }},coordinator-mesh-api.{{ .Release.Namespace }}.svc.cluster.local,coordinator-client-api.{{ .Release.Namespace }}.svc.cluster.local"
+            value: "{{ if .Values.coordinator.hostname }}{{ .Values.coordinator.hostname }},{{ end }}localhost,coordinator-mesh-api,coordinator-client-api,coordinator-mesh-api.{{ .Release.Namespace }},coordinator-client-api.{{ .Release.Namespace }},coordinator-mesh-api.{{ .Release.Namespace }}.svc.cluster.local,coordinator-client-api.{{ .Release.Namespace }}.svc.cluster.local"
           - name: EDG_COORDINATOR_SEAL_DIR
             value: "{{ .Values.coordinator.sealDir }}"
           - name: OE_SIMULATION

--- a/charts/templates/webhookConfig.yaml
+++ b/charts/templates/webhookConfig.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   dnsNames:
   - 'marble-injector.{{ .Release.Namespace }}.svc'
-  - 'marble-injector.{{ .Release.Namespace }}.svc.{{ .Values.coordinator.hostname }}'
+  - 'marble-injector.{{ .Release.Namespace }}.svc.cluster.local'
   issuerRef:
     kind: Issuer
     name: marble-injector-selfsigned-issuer

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -70,8 +70,8 @@ coordinator:
   # clientServerPort needs to be configured to the same port as in your client tool stack
   clientServerHost: "0.0.0.0"
   clientServerPort: 4433
-  # hosName needs to match the host you expect the coordinator to run on
-  hostname: "localhost"
+  # hostname are additional DNS names or IPs to be added to the Coordinator's TLS certificate
+  hostname: ""
   # SEAL_DIR needs to be set according to persistent storage
   sealDir: "/coordinator/data/"
   # OE_SIMULATION needs be set to "1" when running on systems without SGX1+FLC capabilities

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -40,7 +40,7 @@ marblerun install --dcap-pccs-url https://pccs.example.com/sgx/certification/v4/
 		RunE: runInstall,
 	}
 
-	cmd.Flags().String("domain", "localhost", "Sets the CNAME for the Coordinator certificate")
+	cmd.Flags().StringSlice("domain", []string{}, "Sets additional DNS names and IPs for the Coordinator TLS certificate")
 	cmd.Flags().String("marblerun-chart-path", "", "Path to MarbleRun helm chart")
 	cmd.Flags().String("version", "", "Version of the Coordinator to install, latest by default")
 	cmd.Flags().String("resource-key", "", "Resource providing SGX, different depending on used device plugin. Use this to set tolerations/resources if your device plugin is not supported by MarbleRun")
@@ -272,7 +272,7 @@ func errorAndCleanup(ctx context.Context, err error, kubeClient kubernetes.Inter
 
 type installFlags struct {
 	chartPath        string
-	hostname         string
+	hostname         []string
 	version          string
 	resourceKey      string
 	pccsURL          string
@@ -290,7 +290,7 @@ func parseInstallFlags(cmd *cobra.Command) (installFlags, error) {
 	if err != nil {
 		return installFlags{}, err
 	}
-	hostname, err := cmd.Flags().GetString("domain")
+	hostname, err := cmd.Flags().GetStringSlice("domain")
 	if err != nil {
 		return installFlags{}, err
 	}

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -67,7 +67,7 @@ marblerun install --dcap-pccs-url https://pccs.example.com/sgx/certification/v4/
       --dcap-pccs-url string             Provisioning Certificate Caching Service (PCCS) server address. Defaults to Azure PCCS. (default "https://global.acccache.azure.net/sgx/certification/v4/")
       --dcap-secure-cert string          To accept insecure HTTPS certificate from the PCCS, set this option to FALSE (default "TRUE")
       --disable-auto-injection           Install MarbleRun without auto-injection webhook
-      --domain string                    Sets the CNAME for the Coordinator certificate (default "localhost")
+      --domain strings                   Sets additional DNS names and IPs for the Coordinator TLS certificate
       --enterprise-access-token string   Access token for Enterprise Coordinator. Leave empty for default installation
   -h, --help                             help for install
       --marblerun-chart-path string      Path to MarbleRun helm chart


### PR DESCRIPTION
### Proposed changes
- Update `--domain` flag to string slice instead of string
  - This allows setting more than one DNS name or IP for the Coordinator's TLS certificate
- Fix `--domain` flag description. It claimed to set the CNAME of the Coordinator certificate, when really it set additional DNS names
- Always set `localhost` in the Coordinator's helm chart
- Remove templating from the marble-injector deployment which would set its DNS name to `marble-injector.{{ .Release.Namespace }}.svc.{{ .Values.coordinator.hostname }}` when it should be `marble-injector.{{ .Release.Namespace }}.svc.cluster.local`
