### PR TITLE
coordinator: update failure response structure for /api/v2/sign-quote endpoint

### DIFF
--- a/coordinator/server/handler/handler.go
+++ b/coordinator/server/handler/handler.go
@@ -89,9 +89,9 @@ func WriteJSONError(w http.ResponseWriter, errorString string, httpErrorCode int
 }
 
 // WriteJSONFailure writes a JSend failure response to the given http.ResponseWriter.
-func WriteJSONFailure(w http.ResponseWriter, v interface{}, httpErrorCode int) {
+func WriteJSONFailure(w http.ResponseWriter, v interface{}, message string, httpErrorCode int) {
 	w.Header().Set("Content-Type", "application/json")
-	dataToReturn := GeneralResponse{Status: "fail", Data: v}
+	dataToReturn := GeneralResponse{Status: "fail", Data: v, Message: message}
 	w.WriteHeader(httpErrorCode)
 	if err := json.NewEncoder(w).Encode(dataToReturn); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/docs/docs/reference/coordinator.md
+++ b/docs/docs/reference/coordinator.md
@@ -732,7 +732,10 @@ If the quote is invalid, the Coordinator will return a JSend fail response, whic
 ```JSON
 {
     "status": "fail",
-    "message": "quote verification failed: OE_QUOTE_VERIFICATION_ERROR",
+    "data": {
+        "sgxQuote": "quote verification failed: OE_QUOTE_VERIFICATION_ERROR"
+    },
+    "message": "quote verification failed",
 }
 ```
 


### PR DESCRIPTION
### Proposed changes
- By default, set the `Message` field for failure status responses
- On failure for `/api/v2/sign-quote`, set the `Data` field to `{"sgxQuote": "<verify error>"}`
