### PR TITLE
api: return JSend failure on malformed user requests

### DIFF
--- a/coordinator/server/v1/v1.go
+++ b/coordinator/server/v1/v1.go
@@ -248,12 +248,12 @@ func (s *ClientAPIServer) SecretsGet(w http.ResponseWriter, r *http.Request) {
 	// Secrets are requested via the query string in the form of ?s=<secretOne>&s=<secretTwo>&s=...
 	requestedSecrets := r.URL.Query()["s"]
 	if len(requestedSecrets) <= 0 {
-		handler.WriteJSONError(w, "invalid query", http.StatusBadRequest)
+		handler.WriteJSONError(w, "invalid query: endpoint requires at least one query parameter", http.StatusBadRequest)
 		return
 	}
 	for _, req := range requestedSecrets {
 		if len(req) <= 0 {
-			handler.WriteJSONError(w, "malformed query string", http.StatusBadRequest)
+			handler.WriteJSONError(w, "malformed query string: empty query parameter", http.StatusBadRequest)
 			return
 		}
 	}

--- a/coordinator/server/v2/v2.go
+++ b/coordinator/server/v2/v2.go
@@ -76,7 +76,7 @@ func (s *ClientAPIServer) QuoteGet(w http.ResponseWriter, r *http.Request) {
 		var err error
 		nonce, err = base64.URLEncoding.DecodeString(nonceB64)
 		if err != nil {
-			handler.WriteJSONError(w, fmt.Sprintf("bad nonce format: %s", err), http.StatusBadRequest)
+			handler.WriteJSONFailure(w, nil, fmt.Sprintf("invalid query: bad nonce format: %s", err), http.StatusBadRequest)
 			return
 		}
 	}
@@ -133,12 +133,12 @@ func (s *ClientAPIServer) SecretsGet(w http.ResponseWriter, r *http.Request) {
 	// Secrets are requested via the query string in the form of ?s=<secretOne>&s=<secretTwo>&s=...
 	requestedSecrets := r.URL.Query()["s"]
 	if len(requestedSecrets) <= 0 {
-		handler.WriteJSONError(w, "invalid query", http.StatusBadRequest)
+		handler.WriteJSONFailure(w, nil, "invalid query: endpoint requires at least one query parameter", http.StatusBadRequest)
 		return
 	}
 	for _, req := range requestedSecrets {
 		if len(req) <= 0 {
-			handler.WriteJSONFailure(w, nil, "malformed query string", http.StatusBadRequest)
+			handler.WriteJSONFailure(w, nil, "malformed query string: empty query parameter", http.StatusBadRequest)
 			return
 		}
 	}


### PR DESCRIPTION
### Proposed changes
- `GET /quote` and `GET /secrets` returned JSend errors on malformed user requests. They should return JSend failures instead

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
