### PR TITLE
Prepare release v1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(marblerun VERSION 1.4.1)
+project(marblerun VERSION 1.5.0)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.4.1
+appVersion: v1.5.0
 description: The control plane for confidential computing.
 home: https://edgeless.systems
 keywords:
@@ -9,7 +9,7 @@ kubeVersion: ">=1.13.0-0"
 name: marblerun
 sources:
 - https://github.com/edgelesssys/marblerun
-version: 1.4.1
+version: 1.5.0
 maintainers:
   - name: Edgeless Systems
     email: contact@edgeless.systems

--- a/charts/README.md
+++ b/charts/README.md
@@ -46,7 +46,7 @@ their default values.
 | `coordinator.sealDir`                        | string         | Path to the directory used for sealing data. Needs to be consistent with the persisten storage setup | `"/coordinator/data/"` |
 | `coordinator.simulation`                     | bool           | SGX simulation settings, set to `true` if your not running on an SGX capable cluster | `false` |
 | `coordinator.storageClass`                   | string         | Kubernetes [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) to use for creating the Coordinator PVC. Leave empty to use the default StorageClass | |
-| `coordinator.version`                        | string         | Version of the coordinator container image to pull | `"v1.4.1"` |
+| `coordinator.version`                        | string         | Version of the coordinator container image to pull | `"v1.5.0"` |
 | `global.coordinatorComponentLabel`           | string         | Control plane label. Do not edit | `"edgeless.systems/control-plane-component"` |
 | `global.coordinatorNamespaceLabel`           | string         | Control plane label. Do not edit | `"edgeless.systems/control-plane-ns"` |
 | `global.podAnnotations`                      | object         | Additional annotations to add to all pods | `{}`|
@@ -56,7 +56,7 @@ their default values.
 | `marbleInjector.start`                       | bool           | Start the marbleInjector webhook | `false` |
 | `marbleInjector.replicas`                    | int            | Replicas of the marbleInjector webhook | `1` |
 | `marbleInjector.repository`                  | string         | Name of the container registry to pull the marbleInjector image from | `"ghcr.io/edgelesssys/marblerun"` |
-| `marbleInjector.version`                     | string         | Version of the marbleInjector container image to pull | `"v1.4.1"` |
+| `marbleInjector.version`                     | string         | Version of the marbleInjector container image to pull | `"v1.5.0"` |
 | `marbleInjector.useCertManager`              | bool           | Set to use cert-manager for certificate provisioning. Required when using standalone helm chart for installation | `false` |
 | `marbleInjector.objectSelector`              | object         | ObjectSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector) for more information | `{matchExpressions:[{key:"marblerun/marbletype",operator:"Exists"}]}` |
 | `marbleInjector.namespaceSelector`           | object         | NamespaceSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector) for more information | `{}` |

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -29,7 +29,7 @@ marbleInjector:
   repository: ghcr.io/edgelesssys/marblerun
   image: marble-injector
   pullPolicy: IfNotPresent
-  version: v1.4.1
+  version: v1.5.0
 
   # Set to true to install the injection webhook
   start: false
@@ -61,7 +61,7 @@ coordinator:
   repository: ghcr.io/edgelesssys/marblerun
   image: coordinator
   pullPolicy: IfNotPresent
-  version: v1.4.1
+  version: v1.5.0
 
   # Environment configuration for the coordinator control-plane
   # meshServerPort needs to be configured to the same port as in the data-plane marbles

--- a/dockerfiles/Dockerfile.cli
+++ b/dockerfiles/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM ghcr.io/edgelesssys/marblerun/build-base-focal:v1.4.1 AS build
+FROM ghcr.io/edgelesssys/marblerun/build-base-focal:v1.5.0 AS build
 
 # don't run `apt-get update` because required packages are cached in build-base for reproducibility
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -12,9 +12,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   ninja-build \
   wget
 
-ARG erttag=v0.4.3
+ARG erttag=v0.4.4
 ARG mrtag=v1.5.0
-ARG goversion=1.21.8
+ARG goversion=1.21.11
 RUN wget -qO- https://go.dev/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
   && git clone -b $mrtag --depth=1 https://github.com/edgelesssys/marblerun \

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -1,4 +1,4 @@
-FROM ghcr.io/edgelesssys/marblerun/build-base:v1.4.1 AS build
+FROM ghcr.io/edgelesssys/marblerun/build-base:v1.5.0 AS build
 
 # don't run `apt-get update` because required packages are cached in build-base for reproducibility
 RUN apt-get install -y --no-install-recommends \
@@ -11,9 +11,9 @@ RUN apt-get install -y --no-install-recommends \
   ninja-build \
   wget
 
-ARG erttag=v0.4.3
+ARG erttag=v0.4.4
 ARG mrtag=v1.5.0
-ARG goversion=1.21.8
+ARG goversion=1.21.11
 RUN wget -qO- https://go.dev/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
   && git clone -b $mrtag --depth=1 https://github.com/edgelesssys/marblerun \
@@ -44,8 +44,8 @@ COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-22.04
 
 # the coordinator container image
 FROM ubuntu:jammy-20240530 AS release
-ARG PSW_VERSION=2.22.100.3-jammy1
-ARG DCAP_VERSION=1.19.100.3-jammy1
+ARG PSW_VERSION=2.24.100.3-jammy1
+ARG DCAP_VERSION=1.21.100.3-jammy1
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libcurl4 wget \
   && wget -qO /etc/apt/keyrings/intel-sgx-keyring.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
   && echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' > /etc/apt/sources.list.d/intel-sgx.list \


### PR DESCRIPTION
### Proposed changes
- Bump versions to v1.5.0
- Bump EdgelessRT version in docker image to v0.4.4
- Bump Go version in docker image to v1.21.11
- Bump Intel SGX driver psw version to 2.24.100.3-jammy1and dcap version to 1.21.100.3-jammy1
