### PR TITLE
docs: move "supported platforms" to subpage

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -111,8 +111,15 @@ const sidebars = {
         {
           type: 'category',
           label: 'Platforms',
-          link: { type: 'doc', id: 'deployment/platforms/platforms' },
+          link: {
+            type: 'generated-index',
+          },
           items: [
+            {
+              type: 'doc',
+              label: 'Supported platforms',
+              id: 'deployment/platforms/platforms',
+            },
             {
               type: 'doc',
               label: 'Azure',

--- a/docs/versioned_sidebars/version-1.2-sidebars.json
+++ b/docs/versioned_sidebars/version-1.2-sidebars.json
@@ -94,10 +94,14 @@
           "type": "category",
           "label": "Platforms",
           "link": {
-            "type": "doc",
-            "id": "deployment/platforms/platforms"
+            "type": "generated-index"
           },
           "items": [
+            {
+              "type": "doc",
+              "label": "Supported platforms",
+              "id": "deployment/platforms/platforms"
+            },
             {
               "type": "doc",
               "label": "Azure",

--- a/docs/versioned_sidebars/version-1.3-sidebars.json
+++ b/docs/versioned_sidebars/version-1.3-sidebars.json
@@ -94,10 +94,14 @@
           "type": "category",
           "label": "Platforms",
           "link": {
-            "type": "doc",
-            "id": "deployment/platforms/platforms"
+            "type": "generated-index"
           },
           "items": [
+            {
+              "type": "doc",
+              "label": "Supported platforms",
+              "id": "deployment/platforms/platforms"
+            },
             {
               "type": "doc",
               "label": "Azure",

--- a/docs/versioned_sidebars/version-1.4-sidebars.json
+++ b/docs/versioned_sidebars/version-1.4-sidebars.json
@@ -94,10 +94,14 @@
           "type": "category",
           "label": "Platforms",
           "link": {
-            "type": "doc",
-            "id": "deployment/platforms/platforms"
+            "type": "generated-index"
           },
           "items": [
+            {
+              "type": "doc",
+              "label": "Supported platforms",
+              "id": "deployment/platforms/platforms"
+            },
             {
               "type": "doc",
               "label": "Azure",

--- a/docs/versioned_sidebars/version-1.5-sidebars.json
+++ b/docs/versioned_sidebars/version-1.5-sidebars.json
@@ -94,10 +94,14 @@
           "type": "category",
           "label": "Platforms",
           "link": {
-            "type": "doc",
-            "id": "deployment/platforms/platforms"
+            "type": "generated-index"
           },
           "items": [
+            {
+              "type": "doc",
+              "label": "Supported platforms",
+              "id": "deployment/platforms/platforms"
+            },
             {
               "type": "doc",
               "label": "Azure",


### PR DESCRIPTION
A category page should not provide essential information because it can easily be overlooked.

### Proposed changes
- move "supported platforms" to subpage