### PR TITLE
docs: enable broken anchor detection

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -12,6 +12,7 @@ async function createConfig() {
     baseUrl: '/marblerun/',
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'throw',
+    onBrokenAnchors: 'throw',
     favicon: 'img/favicon.png',
 
     // GitHub pages deployment config.


### PR DESCRIPTION
Enable docusaurus's broken anchor detection. (Currently detects none.)