### PR TITLE
docs: fix incorrect key in sign-quote API reference

### DIFF
--- a/docs/docs/reference/coordinator.md
+++ b/docs/docs/reference/coordinator.md
@@ -776,7 +776,7 @@ Example response:
 {
     "status": "success",
     "data": {
-        "signature": "RUNEU0Ffc2lnbihyb290X3ByaXZfa2V5LCBTSEEyNTYoYmFzZTY0KFNHWF9xdW90ZSkgKyBzdHJpbmcoVENCX3N0YXR1cykpKQo=",
+        "verificationSignature": "RUNEU0Ffc2lnbihyb290X3ByaXZfa2V5LCBTSEEyNTYoYmFzZTY0KFNHWF9xdW90ZSkgKyBzdHJpbmcoVENCX3N0YXR1cykpKQo=",
         "tcbStatus": "UpToDate"
     }
 }

--- a/docs/versioned_docs/version-1.5/reference/coordinator.md
+++ b/docs/versioned_docs/version-1.5/reference/coordinator.md
@@ -776,7 +776,7 @@ Example response:
 {
     "status": "success",
     "data": {
-        "signature": "RUNEU0Ffc2lnbihyb290X3ByaXZfa2V5LCBTSEEyNTYoYmFzZTY0KFNHWF9xdW90ZSkgKyBzdHJpbmcoVENCX3N0YXR1cykpKQo=",
+        "verificationSignature": "RUNEU0Ffc2lnbihyb290X3ByaXZfa2V5LCBTSEEyNTYoYmFzZTY0KFNHWF9xdW90ZSkgKyBzdHJpbmcoVENCX3N0YXR1cykpKQo=",
         "tcbStatus": "UpToDate"
     }
 }


### PR DESCRIPTION
Our API reference claimed the Cooridnator returns `data.signature`, for the `/v2/sign-quote` endpoint, but it's actually `data.verificationSignature`.