### PR TITLE
Log TCB advisories if status is not UpToDate

### DIFF
--- a/api/attestation/attestation.go
+++ b/api/attestation/attestation.go
@@ -81,6 +81,14 @@ func verifyCertificate(
 		fmt.Fprintln(out, "Warning: TCB level invalid, but accepted by configuration:", report.TCBStatus)
 	}
 
+	if validity != tcb.ValidityUnconditional {
+		if report.TCBAdvisoriesErr != nil {
+			fmt.Fprintln(out, "Error: TCB Advisories:", err)
+		} else {
+			fmt.Fprintln(out, "TCB Advisories:", report.TCBAdvisories)
+		}
+	}
+
 	return nil
 }
 

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -42,12 +42,24 @@ func (v *ERTValidator) Validate(givenQuote []byte, cert []byte, pp quote.Package
 	if err != nil {
 		return err
 	}
+
+	if report.TCBAdvisoriesErr != nil {
+		v.log.Error("TCB Advisories", zap.Error(report.TCBAdvisoriesErr))
+	}
+	fmt.Println(report.TCBAdvisories)
+
 	switch validity {
 	case tcb.ValidityUnconditional:
 	case tcb.ValidityConditional:
-		v.log.Info("TCB level accepted by configuration", zap.String("packageProperties", pp.String()), zap.String("tcbStatus", report.TCBStatus.String()))
+		v.log.Info("TCB level accepted by configuration",
+			zap.String("packageProperties", pp.String()),
+			zap.String("tcbStatus", report.TCBStatus.String()),
+			zap.Strings("advisories", report.TCBAdvisories))
 	default:
-		v.log.Warn("TCB level invalid, but accepted by configuration", zap.String("packageProperties", pp.String()), zap.String("tcbStatus", report.TCBStatus.String()))
+		v.log.Warn("TCB level invalid, but accepted by configuration",
+			zap.String("packageProperties", pp.String()),
+			zap.String("tcbStatus", report.TCBStatus.String()),
+			zap.Strings("advisories", report.TCBAdvisories))
 	}
 
 	// Check that cert is equal

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -46,7 +46,6 @@ func (v *ERTValidator) Validate(givenQuote []byte, cert []byte, pp quote.Package
 	if report.TCBAdvisoriesErr != nil {
 		v.log.Error("TCB Advisories", zap.Error(report.TCBAdvisoriesErr))
 	}
-	fmt.Println(report.TCBAdvisories)
 
 	switch validity {
 	case tcb.ValidityUnconditional:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/cert-manager/cert-manager v1.15.3
-	github.com/edgelesssys/ego v1.5.5-0.20240918131954-75c1acbe8df9
+	github.com/edgelesssys/ego v1.5.5-0.20240918142856-71abc7e095e1
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/cert-manager/cert-manager v1.15.3
-	github.com/edgelesssys/ego v1.5.4
+	github.com/edgelesssys/ego v1.5.5-0.20240918131954-75c1acbe8df9
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
-github.com/edgelesssys/ego v1.5.5-0.20240918131954-75c1acbe8df9 h1:ItTFGMF343zccRyeE9KahVdX7Lpr4fmEBeX8JSN+F8g=
-github.com/edgelesssys/ego v1.5.5-0.20240918131954-75c1acbe8df9/go.mod h1:t10m29KSwG2hKwWFIq7/vuzfoKhPIdevOXx8nm636iU=
+github.com/edgelesssys/ego v1.5.5-0.20240918142856-71abc7e095e1 h1:dU4mOAkHJ0B+TylUsR4mc8U9YZjHC8VK+OVVJLVWTrM=
+github.com/edgelesssys/ego v1.5.5-0.20240918142856-71abc7e095e1/go.mod h1:t10m29KSwG2hKwWFIq7/vuzfoKhPIdevOXx8nm636iU=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=
 github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
-github.com/edgelesssys/ego v1.5.4 h1:ADc6t5j77mOfwwu+akZX/I41YzHoseYiBcM5aME+Hb0=
-github.com/edgelesssys/ego v1.5.4/go.mod h1:t10m29KSwG2hKwWFIq7/vuzfoKhPIdevOXx8nm636iU=
+github.com/edgelesssys/ego v1.5.5-0.20240918131954-75c1acbe8df9 h1:ItTFGMF343zccRyeE9KahVdX7Lpr4fmEBeX8JSN+F8g=
+github.com/edgelesssys/ego v1.5.5-0.20240918131954-75c1acbe8df9/go.mod h1:t10m29KSwG2hKwWFIq7/vuzfoKhPIdevOXx8nm636iU=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=
 github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=


### PR DESCRIPTION
### Proposed changes
- Log TCB advisory list in CLI and Coordinator so that a user can learn why the verified platform has a certain TCBStatus

### Related issue
- AB#4675
