### PR TITLE
Derive marble private secrets using marble type in addition to UUID

### DIFF
--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -50,7 +50,7 @@ type core interface {
 	}) error
 	GetState(context.Context) (state.State, string, error)
 	GenerateSecrets(
-		map[string]manifest.Secret, uuid.UUID, *x509.Certificate, *ecdsa.PrivateKey, *ecdsa.PrivateKey,
+		map[string]manifest.Secret, uuid.UUID, string, *x509.Certificate, *ecdsa.PrivateKey, *ecdsa.PrivateKey,
 	) (map[string]manifest.Secret, error)
 	GetQuote(reportData []byte) ([]byte, error)
 	GenerateQuote([]byte) error
@@ -387,13 +387,13 @@ func (a *ClientAPI) SetManifest(ctx context.Context, rawManifest []byte) (recove
 	}
 
 	// Generate shared secrets specified in manifest
-	secrets, err := a.core.GenerateSecrets(mnf.Secrets, uuid.Nil, marbleRootCert, intermediatePrivK, rootPrivK)
+	secrets, err := a.core.GenerateSecrets(mnf.Secrets, uuid.Nil, "", marbleRootCert, intermediatePrivK, rootPrivK)
 	if err != nil {
 		a.log.Error("Could not generate specified secrets for the given manifest.", zap.Error(err))
 		return nil, fmt.Errorf("generating secrets from manifest: %w", err)
 	}
 	// generate placeholders for private secrets specified in manifest
-	privSecrets, err := a.core.GenerateSecrets(mnf.Secrets, uuid.New(), marbleRootCert, intermediatePrivK, rootPrivK)
+	privSecrets, err := a.core.GenerateSecrets(mnf.Secrets, uuid.New(), "", marbleRootCert, intermediatePrivK, rootPrivK)
 	if err != nil {
 		a.log.Error("Could not generate specified secrets for the given manifest.", zap.Error(err))
 		return nil, fmt.Errorf("generating placeholder secrets from manifest: %w", err)
@@ -604,7 +604,7 @@ func (a *ClientAPI) UpdateManifest(ctx context.Context, rawUpdateManifest []byte
 	}
 
 	// Regenerate shared secrets specified in manifest
-	regeneratedSecrets, err := a.core.GenerateSecrets(secretsToRegenerate, uuid.Nil, marbleRootCert, intermediatePrivK, rootPrivK)
+	regeneratedSecrets, err := a.core.GenerateSecrets(secretsToRegenerate, uuid.Nil, "", marbleRootCert, intermediatePrivK, rootPrivK)
 	if err != nil {
 		a.log.Error("Could not generate specified secrets for the given manifest.", zap.Error(err))
 		return fmt.Errorf("regenerating shared secrets for updated manifest: %w", err)

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -924,7 +924,7 @@ func (c *fakeCore) GetState(_ context.Context) (state.State, string, error) {
 }
 
 func (c *fakeCore) GenerateSecrets(
-	newSecrets map[string]manifest.Secret, _ uuid.UUID, rootCert *x509.Certificate, privK *ecdsa.PrivateKey, _ *ecdsa.PrivateKey,
+	newSecrets map[string]manifest.Secret, _ uuid.UUID, _ string, rootCert *x509.Certificate, privK *ecdsa.PrivateKey, _ *ecdsa.PrivateKey,
 ) (map[string]manifest.Secret, error) {
 	if c.generateSecretsErr != nil || c.generatedSecrets != nil {
 		return c.generatedSecrets, c.generateSecretsErr

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -356,7 +356,7 @@ func (c *Core) GetState(ctx context.Context) (state.State, string, error) {
 
 // GenerateSecrets generates secrets for the given manifest and parent certificate.
 func (c *Core) GenerateSecrets(
-	secrets map[string]manifest.Secret, id uuid.UUID,
+	secrets map[string]manifest.Secret, id uuid.UUID, marbleName string,
 	parentCertificate *x509.Certificate, parentPrivKey *ecdsa.PrivateKey, rootPrivK *ecdsa.PrivateKey,
 ) (map[string]manifest.Secret, error) {
 	// Create a new map so we do not overwrite the entries in the manifest
@@ -395,7 +395,9 @@ func (c *Core) GenerateSecrets(
 				salt := id.String() + name
 				secretKeyDerive := rootPrivK.D.Bytes()
 				var err error
-				generatedValue, err = util.DeriveKey(secretKeyDerive, []byte(salt), secret.Size/8)
+
+				// Derive key using the uuid and secret name as salt, and the marble's name as info
+				generatedValue, err = util.DeriveKey(secretKeyDerive, []byte(salt), []byte(marbleName), secret.Size/8)
 				if err != nil {
 					return nil, err
 				}

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -202,7 +202,7 @@ func TestGenerateSecrets(t *testing.T) {
 	rootPrivK := testutil.GetPrivateKey(t, c.txHandle, constants.SKCoordinatorRootKey)
 
 	// This should return valid secrets
-	generatedSecrets, err := c.GenerateSecrets(secretsToGenerate, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	generatedSecrets, err := c.GenerateSecrets(secretsToGenerate, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	require.NoError(err)
 	// Check if rawTest1 has 128 Bits/16 Bytes and rawTest2 256 Bits/8 Bytes
 	assert.Len(generatedSecrets["rawTest1"].Public, 16)
@@ -222,7 +222,7 @@ func TestGenerateSecrets(t *testing.T) {
 
 	// Make sure a certificate gets a new serial number if its regenerated
 	firstSerial := generatedSecrets["cert-rsa-test"].Cert.SerialNumber
-	secondGeneration, err := c.GenerateSecrets(generatedSecrets, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	secondGeneration, err := c.GenerateSecrets(generatedSecrets, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	assert.NoError(err)
 	assert.NotEqualValues(*firstSerial, *secondGeneration["cert-rsa-test"].Cert.SerialNumber)
 
@@ -264,31 +264,31 @@ func TestGenerateSecrets(t *testing.T) {
 	assert.NoError(err)
 
 	// Check if we get an empty secret map as output for an empty map as input
-	generatedSecrets, err = c.GenerateSecrets(secretsEmptyMap, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	generatedSecrets, err = c.GenerateSecrets(secretsEmptyMap, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	require.NoError(err)
 	assert.IsType(map[string]manifest.Secret{}, generatedSecrets)
 	assert.Len(generatedSecrets, 0)
 
 	// Check if we get an empty secret map as output for nil
-	generatedSecrets, err = c.GenerateSecrets(nil, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	generatedSecrets, err = c.GenerateSecrets(nil, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	require.NoError(err)
 	assert.IsType(map[string]manifest.Secret{}, generatedSecrets)
 	assert.Len(generatedSecrets, 0)
 
 	// If no size is specified, the function should fail
-	_, err = c.GenerateSecrets(secretsNoSize, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	_, err = c.GenerateSecrets(secretsNoSize, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	assert.Error(err)
 
 	// Also, it should fail if we try to generate a secret with an unknown type
-	_, err = c.GenerateSecrets(secretsInvalidType, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	_, err = c.GenerateSecrets(secretsInvalidType, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	assert.Error(err)
 
 	// If Ed25519 key size is specified, we should fail
-	_, err = c.GenerateSecrets(secretsEd25519WrongKeySize, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	_, err = c.GenerateSecrets(secretsEd25519WrongKeySize, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	assert.Error(err)
 
 	// However, for ECDSA we fail as we can have multiple curves
-	_, err = c.GenerateSecrets(secretsECDSAWrongKeySize, uuid.Nil, rootCert, rootPrivK, rootPrivK)
+	_, err = c.GenerateSecrets(secretsECDSAWrongKeySize, uuid.Nil, "", rootCert, rootPrivK, rootPrivK)
 	assert.Error(err)
 }
 

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/store/stdstore"
 	"github.com/edgelesssys/marblerun/coordinator/store/wrapper/testutil"
 	"github.com/edgelesssys/marblerun/test"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
@@ -115,11 +116,12 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	}
 
 	// try to activate first backend marble prematurely before manifest is set
-	uuid := spawner.newMarble(t, "backendFirst", "Azure", false)
+	marbleUUID := uuid.New()
+	spawner.newMarble(t, "backendFirst", "Azure", marbleUUID, false)
 	promtest.CollectAndCount(metrics.activation)
 	promtest.CollectAndCount(metrics.activationSuccess)
-	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", uuid)))
-	assert.Equal(float64(0), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", uuid)))
+	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", marbleUUID.String())))
+	assert.Equal(float64(0), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", marbleUUID.String())))
 
 	// set manifest
 	clientAPI, err := clientapi.New(c.txHandle, c.recovery, c, zapLogger)
@@ -128,16 +130,18 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	require.NoError(err)
 
 	// activate first backend
-	uuid = spawner.newMarble(t, "backendFirst", "Azure", true)
+	marbleUUID = uuid.New()
+	spawner.newMarble(t, "backendFirst", "Azure", marbleUUID, true)
 	promtest.CollectAndCount(metrics.activation)
 	promtest.CollectAndCount(metrics.activationSuccess)
-	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", uuid)))
-	assert.Equal(float64(1), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", uuid)))
+	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", marbleUUID.String())))
+	assert.Equal(float64(1), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", marbleUUID.String())))
 
 	// try to activate another first backend
-	uuid = spawner.newMarble(t, "backendFirst", "Azure", false)
+	marbleUUID = uuid.New()
+	spawner.newMarble(t, "backendFirst", "Azure", marbleUUID, false)
 	promtest.CollectAndCount(metrics.activation)
 	promtest.CollectAndCount(metrics.activationSuccess)
-	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", uuid)))
-	assert.Equal(float64(0), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", uuid)))
+	assert.Equal(float64(1), promtest.ToFloat64(metrics.activation.WithLabelValues("backendFirst", marbleUUID.String())))
+	assert.Equal(float64(0), promtest.ToFloat64(metrics.activationSuccess.WithLabelValues("backendFirst", marbleUUID.String())))
 }

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -84,6 +84,9 @@ type Marble struct {
 	Parameters Parameters
 	// TLS holds a list of tags which are specified in the manifest
 	TLS []string
+	// DisableSecretBinding causes the Coordinator to not include the Marble's name for secret derivation.
+	// Effectively, this enforces the same behavior of the Coordinator previous to version 1.6.0.
+	DisableSecretBinding bool
 }
 
 // Equal returns true if two Marble definitions are equal.

--- a/util/util.go
+++ b/util/util.go
@@ -27,8 +27,8 @@ import (
 var DefaultCertificateIPAddresses = []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
 
 // DeriveKey derives a key from a secret.
-func DeriveKey(secret, salt []byte, length uint) ([]byte, error) {
-	hkdf := hkdf.New(sha256.New, secret, salt, nil)
+func DeriveKey(secret, salt, info []byte, length uint) ([]byte, error) {
+	hkdf := hkdf.New(sha256.New, secret, salt, info)
 	key := make([]byte, length)
 	if _, err := io.ReadFull(hkdf, key); err != nil {
 		return nil, err

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestDeriveKey(t *testing.T) {
 	assert := assert.New(t)
-	key, err := DeriveKey([]byte("secret"), []byte("salt"), 32)
+	key, err := DeriveKey([]byte("secret"), []byte("salt"), []byte("info"), 32)
 	assert.NoError(err)
 	assert.Len(key, 32)
 }


### PR DESCRIPTION
Currently, when a marble requests a private secret, that secret is derived from the coordinators root key using HKDF with the Marble's UUID and the name of the secret being used as salt for the derivation.
This means that any two marbles with the same UUID will receive the same secrets, even if they have different marble types.
Since this behavior is not always clear to users, and they should use shared secrets to facilitate this secret instead, this PR updates the secret generation code to include the name of the marble as Info parameter for the HKDF function so any two Marbles of different types will receive different secrets even if they have the same UUID.

### Proposed changes
- Include the Marble's Type in secret derivation along the secret name and Marble UUID
  -  the old behavior can be restored by setting the new `DisableSecretBinding` on a Marble 


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
