### PR TITLE
Allow specifying accepted avisories for `SWHardeningNeeded` TCB status

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   vale:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/api/api.go
+++ b/api/api.go
@@ -101,6 +101,7 @@ func VerifyCoordinator(ctx context.Context, endpoint string, opts VerifyOptions)
 		Debug:               opts.Debug,
 		Nonce:               opts.Nonce,
 		AcceptedTCBStatuses: opts.AcceptedTCBStatuses,
+		AcceptedAdvisories:  opts.AcceptedAdvisories,
 	}); err != nil {
 		return nil, nil, nil, fmt.Errorf("verifying Coordinator quote: %w", err)
 	}
@@ -467,6 +468,10 @@ type VerifyOptions struct {
 	// If not set, defaults to ["UpToDate", "SWHardeningNeeded"].
 	// If the Coordinator returns a TCB status not listed, an [attestation.TCBStatusError] is returned.
 	AcceptedTCBStatuses []string `json:"AcceptedTCBStatuses"`
+	// AcceptedAdvisories is a list of Intel Security Advisories that are acceptable.
+	// If the Coordinator returns TCB status "SWHardeningNeeded", the list of advisories for that report must be a subset of this list.
+	// If not set, all advisories are accepted.
+	AcceptedAdvisories []string `json:"AcceptedAdvisories"`
 
 	// Nonce is an optional, user-defined nonce to be included in the Coordinator's attestation statement.
 	// If set, the Coordinator will generate an SGX quote over sha256(Coordinator_root_cert, Nonce).

--- a/api/attestation/attestation.go
+++ b/api/attestation/attestation.go
@@ -25,16 +25,22 @@ import (
 type TCBStatusError struct {
 	// TCBStatus is the TCB status of the Coordinator enclave.
 	TCBStatus tcbstatus.Status
+	// Advisories is a list of Intel Security Advisories if the TCB status is SWHardeningNeeded.
+	Advisories []string
 }
 
 // NewTCBStatusError creates a new TCBStatusError.
-func NewTCBStatusError(tcbStatus tcbstatus.Status) error {
-	return &TCBStatusError{TCBStatus: tcbStatus}
+func NewTCBStatusError(tcbStatus tcbstatus.Status, advisories []string) error {
+	return &TCBStatusError{TCBStatus: tcbStatus, Advisories: advisories}
 }
 
 // Error returns the error message.
 func (e *TCBStatusError) Error() string {
-	return fmt.Sprintf("invalid TCB status: %s", e.TCBStatus)
+	var advisoryMsg string
+	if len(e.Advisories) > 0 {
+		advisoryMsg = fmt.Sprintf(": advisories not accepted by configuration: %s", e.Advisories)
+	}
+	return fmt.Sprintf("invalid TCB status: %s%s", e.TCBStatus, advisoryMsg)
 }
 
 // Config is the expected attestation metadata of a MarbleRun Coordinator enclave.
@@ -48,6 +54,7 @@ type Config struct {
 	Debug               bool
 	Nonce               []byte
 	AcceptedTCBStatuses []string
+	AcceptedAdvisories  []string
 }
 
 // VerifyCertificate verifies the Coordinator's TLS certificate against the Coordinator's SGX quote.
@@ -71,8 +78,13 @@ func verifyCertificate(
 
 	validity, err := tcb.CheckStatus(report.TCBStatus, quoteErr, config.AcceptedTCBStatuses)
 	if err != nil {
-		return NewTCBStatusError(report.TCBStatus)
+		return NewTCBStatusError(report.TCBStatus, report.TCBAdvisories)
 	}
+
+	if notAccepted := tcb.CheckAdvisories(report.TCBStatus, report.TCBAdvisories, config.AcceptedAdvisories); len(notAccepted) > 0 {
+		return NewTCBStatusError(report.TCBStatus, notAccepted)
+	}
+
 	switch validity {
 	case tcb.ValidityUnconditional:
 	case tcb.ValidityConditional:
@@ -83,7 +95,7 @@ func verifyCertificate(
 
 	if validity != tcb.ValidityUnconditional {
 		if report.TCBAdvisoriesErr != nil {
-			fmt.Fprintln(out, "Error: TCB Advisories:", err)
+			fmt.Fprintln(out, "Error: TCB Advisories:", report.TCBAdvisoriesErr)
 		} else {
 			fmt.Fprintln(out, "TCB Advisories:", report.TCBAdvisories)
 		}

--- a/api/attestation/attestation.go
+++ b/api/attestation/attestation.go
@@ -86,7 +86,11 @@ func verifyCertificate(
 		return NewTCBStatusError(report.TCBStatus)
 	}
 
-	if notAccepted := tcb.CheckAdvisories(report.TCBStatus, report.TCBAdvisories, config.AcceptedAdvisories); len(notAccepted) > 0 {
+	notAccepted, err := tcb.CheckAdvisories(report, config.AcceptedAdvisories)
+	if err != nil {
+		return err
+	}
+	if len(notAccepted) > 0 {
 		return NewTCBStatusErrorWithAdvisories(report.TCBStatus, notAccepted)
 	}
 

--- a/api/attestation/attestation.go
+++ b/api/attestation/attestation.go
@@ -30,7 +30,12 @@ type TCBStatusError struct {
 }
 
 // NewTCBStatusError creates a new TCBStatusError.
-func NewTCBStatusError(tcbStatus tcbstatus.Status, advisories []string) error {
+func NewTCBStatusError(tcbStatus tcbstatus.Status) error {
+	return &TCBStatusError{TCBStatus: tcbStatus}
+}
+
+// NewTCBStatusErrorWithAdvisories creates a new TCBStatusError with a list of Intel Security Advisories.
+func NewTCBStatusErrorWithAdvisories(tcbStatus tcbstatus.Status, advisories []string) error {
 	return &TCBStatusError{TCBStatus: tcbStatus, Advisories: advisories}
 }
 
@@ -78,11 +83,11 @@ func verifyCertificate(
 
 	validity, err := tcb.CheckStatus(report.TCBStatus, quoteErr, config.AcceptedTCBStatuses)
 	if err != nil {
-		return NewTCBStatusError(report.TCBStatus, report.TCBAdvisories)
+		return NewTCBStatusError(report.TCBStatus)
 	}
 
 	if notAccepted := tcb.CheckAdvisories(report.TCBStatus, report.TCBAdvisories, config.AcceptedAdvisories); len(notAccepted) > 0 {
-		return NewTCBStatusError(report.TCBStatus, notAccepted)
+		return NewTCBStatusErrorWithAdvisories(report.TCBStatus, notAccepted)
 	}
 
 	switch validity {

--- a/api/attestation/attestation_test.go
+++ b/api/attestation/attestation_test.go
@@ -244,6 +244,7 @@ func TestVerifyCertificate(t *testing.T) {
 		"tcb error with advisories rejected": {
 			config: func() Config {
 				config := defaultConfig
+				config.AcceptedTCBStatuses = []string{"SWHardeningNeeded"}
 				config.AcceptedAdvisories = []string{"INTEL-SA-0002"}
 				return config
 			}(),
@@ -277,6 +278,25 @@ func TestVerifyCertificate(t *testing.T) {
 					TCBAdvisories:   []string{"INTEL-SA-0001"},
 				}, attestation.ErrTCBLevelInvalid
 			},
+		},
+		"report contains tcb advisory parsing error": {
+			config: func() Config {
+				config := defaultConfig
+				config.AcceptedTCBStatuses = []string{"SWHardeningNeeded"}
+				config.AcceptedAdvisories = []string{"INTEL-SA-0001"}
+				return config
+			}(),
+			verify: func([]byte) (attestation.Report, error) {
+				return attestation.Report{
+					Data:             quoteData[:],
+					SecurityVersion:  2,
+					ProductID:        []byte{0x03, 0x00},
+					SignerID:         []byte{0xAB, 0xCD},
+					TCBStatus:        tcbstatus.SWHardeningNeeded,
+					TCBAdvisoriesErr: assert.AnError,
+				}, attestation.ErrTCBLevelInvalid
+			},
+			wantErr: true,
 		},
 	}
 

--- a/api/attestation/attestation_test.go
+++ b/api/attestation/attestation_test.go
@@ -226,6 +226,58 @@ func TestVerifyCertificate(t *testing.T) {
 				}, attestation.ErrTCBLevelInvalid
 			},
 		},
+		"tcb error with advisories": {
+			config: defaultConfig,
+			verify: func([]byte) (attestation.Report, error) {
+				return attestation.Report{
+					Data:            quoteData[:],
+					SecurityVersion: 2,
+					ProductID:       []byte{0x03, 0x00},
+					SignerID:        []byte{0xAB, 0xCD},
+					TCBStatus:       tcbstatus.SWHardeningNeeded,
+					TCBAdvisories:   []string{"INTEL-SA-0001"},
+				}, attestation.ErrTCBLevelInvalid
+			},
+			wantErr:    true,
+			wantTCBErr: true,
+		},
+		"tcb error with advisories rejected": {
+			config: func() Config {
+				config := defaultConfig
+				config.AcceptedAdvisories = []string{"INTEL-SA-0002"}
+				return config
+			}(),
+			verify: func([]byte) (attestation.Report, error) {
+				return attestation.Report{
+					Data:            quoteData[:],
+					SecurityVersion: 2,
+					ProductID:       []byte{0x03, 0x00},
+					SignerID:        []byte{0xAB, 0xCD},
+					TCBStatus:       tcbstatus.SWHardeningNeeded,
+					TCBAdvisories:   []string{"INTEL-SA-0001"},
+				}, attestation.ErrTCBLevelInvalid
+			},
+			wantErr:    true,
+			wantTCBErr: true,
+		},
+		"tcb error with advisories accepted": {
+			config: func() Config {
+				config := defaultConfig
+				config.AcceptedTCBStatuses = []string{"SWHardeningNeeded"}
+				config.AcceptedAdvisories = []string{"INTEL-SA-0001"}
+				return config
+			}(),
+			verify: func([]byte) (attestation.Report, error) {
+				return attestation.Report{
+					Data:            quoteData[:],
+					SecurityVersion: 2,
+					ProductID:       []byte{0x03, 0x00},
+					SignerID:        []byte{0xAB, 0xCD},
+					TCBStatus:       tcbstatus.SWHardeningNeeded,
+					TCBAdvisories:   []string{"INTEL-SA-0001"},
+				}, attestation.ErrTCBLevelInvalid
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -68,6 +68,7 @@ To install and configure MarbleRun, run:
 	rootCmd.PersistentFlags().String("era-config", "", "Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository")
 	rootCmd.PersistentFlags().BoolP("insecure", "i", false, "Set to skip quote verification, needed when running in simulation mode")
 	rootCmd.PersistentFlags().StringSlice("accepted-tcb-statuses", []string{"UpToDate", "SWHardeningNeeded"}, "Comma-separated list of user accepted TCB statuses")
+	rootCmd.PersistentFlags().StringSlice("accepted-advisories", nil, "Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted")
 	rootCmd.PersistentFlags().StringP("namespace", "n", helm.Namespace, "Kubernetes namespace of the MarbleRun installation")
 	rootCmd.PersistentFlags().String("nonce", "", "(Optional) nonce to use for quote verification. If set, the Coordinator will generate a quote over sha256(CoordinatorCert + nonce)")
 	rootCmd.PersistentFlags().String("save-sgx-quote", "", "If set, save the Coordinator's SGX quote to the specified file")

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -46,6 +46,10 @@ func parseRestFlags(cmd *cobra.Command) (api.VerifyOptions, string, error) {
 	if err != nil {
 		return api.VerifyOptions{}, "", err
 	}
+	acceptedAdvisories, err := cmd.Flags().GetStringSlice("accepted-advisories")
+	if err != nil {
+		return api.VerifyOptions{}, "", err
+	}
 	k8sNamespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return api.VerifyOptions{}, "", err
@@ -83,6 +87,7 @@ func parseRestFlags(cmd *cobra.Command) (api.VerifyOptions, string, error) {
 		}
 	}
 	verifyOptions.AcceptedTCBStatuses = acceptedTCBStatuses
+	verifyOptions.AcceptedAdvisories = acceptedAdvisories
 	verifyOptions.Nonce = []byte(nonce)
 
 	return verifyOptions, sgxQuotePath, nil

--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -556,19 +556,9 @@ func (a *ClientAPI) UpdateManifest(ctx context.Context, rawUpdateManifest []byte
 
 	// update manifest was valid, increase svn and regenerate secrets
 	for pkgName, pkg := range updateManifest.Packages {
-		if currentPackages[pkgName].SecurityVersion == nil {
-			currentPkg := currentPackages[pkgName]
-			currentPackages[pkgName] = quote.PackageProperties{
-				Debug:               currentPkg.Debug,
-				UniqueID:            currentPkg.UniqueID,
-				SecurityVersion:     pkg.SecurityVersion,
-				ProductID:           currentPkg.ProductID,
-				SignerID:            currentPkg.SignerID,
-				AcceptedTCBStatuses: currentPkg.AcceptedTCBStatuses,
-			}
-		} else {
-			*currentPackages[pkgName].SecurityVersion = *pkg.SecurityVersion
-		}
+		currentPkg := currentPackages[pkgName]
+		currentPkg.SecurityVersion = pkg.SecurityVersion
+		currentPackages[pkgName] = currentPkg
 	}
 
 	rootCert, err := txdata.GetCertificate(constants.SKCoordinatorRootCert)

--- a/coordinator/quote/ert.go
+++ b/coordinator/quote/ert.go
@@ -111,6 +111,9 @@ func (p PackageProperties) String() string {
 	if len(p.AcceptedTCBStatuses) > 0 {
 		values = append(values, fmt.Sprintf("AcceptedTCBStatuses: %v", p.AcceptedTCBStatuses))
 	}
+	if len(p.AcceptedAdvisories) > 0 {
+		values = append(values, fmt.Sprintf("AcceptedAdvisories: %v", p.AcceptedAdvisories))
+	}
 	return fmt.Sprintf("{%s}", strings.Join(values, ", "))
 }
 

--- a/coordinator/quote/ert.go
+++ b/coordinator/quote/ert.go
@@ -29,6 +29,10 @@ type PackageProperties struct {
 	SecurityVersion *uint
 	// AcceptedTCBStatuses is a list of TCB levels an enclave is allowed to have.
 	AcceptedTCBStatuses []string
+	// AcceptedAdvisories is a list of open Intel Security Advisories an enclave is allowed to run on,
+	// when it reports an SWHardeningNeeded TCB status.
+	// An empty list allows all advisories.
+	AcceptedAdvisories []string
 }
 
 // InfrastructureProperties contains the infrastructure-specific properties of a SGX DCAP quote.

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -47,6 +47,10 @@ func (v *ERTValidator) Validate(givenQuote []byte, cert []byte, pp quote.Package
 		v.log.Error("TCB Advisories", zap.Error(report.TCBAdvisoriesErr))
 	}
 
+	if notAccepted := tcb.CheckAdvisories(report.TCBStatus, report.TCBAdvisories, pp.AcceptedAdvisories); len(notAccepted) > 0 {
+		return fmt.Errorf("TCB status %s contains advisories not accepted by configuration: %s", report.TCBStatus, notAccepted)
+	}
+
 	switch validity {
 	case tcb.ValidityUnconditional:
 	case tcb.ValidityConditional:

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -47,7 +47,11 @@ func (v *ERTValidator) Validate(givenQuote []byte, cert []byte, pp quote.Package
 		v.log.Error("TCB Advisories", zap.Error(report.TCBAdvisoriesErr))
 	}
 
-	if notAccepted := tcb.CheckAdvisories(report.TCBStatus, report.TCBAdvisories, pp.AcceptedAdvisories); len(notAccepted) > 0 {
+	notAccepted, err := tcb.CheckAdvisories(report, pp.AcceptedAdvisories)
+	if err != nil {
+		return err
+	}
+	if len(notAccepted) > 0 {
 		return fmt.Errorf("TCB status %s contains advisories not accepted by configuration: %s", report.TCBStatus, notAccepted)
 	}
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -81,6 +81,7 @@ marblerun install --dcap-pccs-url https://pccs.example.com/sgx/certification/v4/
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -112,6 +113,7 @@ marblerun uninstall [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -142,6 +144,7 @@ marblerun precheck [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -173,6 +176,7 @@ marblerun check [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -208,6 +212,7 @@ manifest set manifest.json example.com:4433 [--era-config=config.json] [--insecu
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -249,6 +254,7 @@ marblerun manifest get $MARBLERUN -s --era-config=era.json
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -288,6 +294,7 @@ marblerun manifest log $MARBLERUN
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -325,6 +332,7 @@ marblerun manifest set manifest.json $MARBLERUN --recovery-data=recovery-secret.
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -355,6 +363,7 @@ marblerun manifest signature <manifest.json> [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -381,6 +390,7 @@ Manage manifest updates for the MarbleRun Coordinator.
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -422,6 +432,7 @@ marblerun manifest update apply update-manifest.json $MARBLERUN --cert=admin-cer
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -464,6 +475,7 @@ marblerun manifest update acknowledge update-manifest.json $MARBLERUN --cert=adm
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -502,6 +514,7 @@ marblerun manifest update cancel $MARBLERUN --cert=admin-cert.pem --key=admin-ke
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -540,6 +553,7 @@ marblerun manifest update get $MARBLERUN --era-config=era.json
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -576,6 +590,7 @@ marblerun manifest verify manifest.json $MARBLERUN
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -602,6 +617,7 @@ Retrieves the certificate of the MarbleRun Coordinator
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -633,6 +649,7 @@ marblerun certificate root <IP:PORT> [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -664,6 +681,7 @@ marblerun certificate intermediate <IP:PORT> [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -695,6 +713,7 @@ marblerun certificate chain <IP:PORT> [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -725,6 +744,7 @@ Set or retrieve a secret defined in the manifest.
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -773,6 +793,7 @@ marblerun secret set certificate.pem $MARBLERUN -c admin.crt -k admin.key --from
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
   -c, --cert string                     PEM encoded MarbleRun user certificate file (required)
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
@@ -816,6 +837,7 @@ marblerun secret get genericSecret symmetricKeyShared $MARBLERUN -c admin.crt -k
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
   -c, --cert string                     PEM encoded MarbleRun user certificate file (required)
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
@@ -864,6 +886,7 @@ marblerun status <IP:PORT> [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -900,6 +923,7 @@ marblerun recover recovery_key_decrypted $MARBLERUN
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -930,6 +954,7 @@ marblerun package-info [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
@@ -960,6 +985,7 @@ marblerun version [flags]
 ### Options inherited from parent commands
 
 ```
+      --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository

--- a/docs/docs/workflows/define-manifest.md
+++ b/docs/docs/workflows/define-manifest.md
@@ -15,6 +15,7 @@ The `Packages` section of the manifest lists all the secure enclave software pac
 * `SecurityVersion`: an integer that reflects the security-patch level of the enclave software. Can only be used in conjunction with `SignerID`.
 * `Debug`: set to `true` if the enclave is to be run in debug mode. This allows you to experiment with deploying your application with MarbleRun without having to worry about setting correct values for the above properties, but note that enclaves in debug mode aren't secure.
 * `AcceptedTCBStatuses`: a list of acceptable [TCB statuses](https://docs.trustauthority.intel.com/main/articles/concept-platform-tcb.html#attester-tcb-claims) a Marble is allowed to start with. You can use this option to allow Marbles to run on machines whose TCB is out-of-date. If not set, it defaults to `["UpToDate", "SWHardeningNeeded"]`.
+* `AcceptedAdivsories`: a list of acceptable [Intel Security Advisories](https://www.intel.com/content/www/us/en/security-center/default.html) when a Marble is allowed to run with an `SWHardeningNeeded` TCB status. If not set, all advisories are allowed. Has no effect if the Marble has a different TCB status from `SWHardeningNeeded`.
 
 The following gives an example of a simple `Packages` section with made-up values.
 
@@ -30,6 +31,9 @@ The following gives an example of a simple `Packages` section with made-up value
                 "SWHardeningNeeded",
                 "ConfigurationNeeded",
                 "ConfigurationAndSWHardeningNeeded"
+            ],
+            "AcceptedAdvisories": [
+                "INTEL-SA-00001"
             ]
         },
         "frontend": {

--- a/internal/tcb/tcb.go
+++ b/internal/tcb/tcb.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/edgelesssys/ego/attestation"
 	"github.com/edgelesssys/ego/attestation/tcbstatus"
@@ -51,4 +52,23 @@ func CheckStatus(status tcbstatus.Status, tcbErr error, accepted []string) (Vali
 		return ValidityInvalid, nil
 	}
 	return ValidityConditional, nil
+}
+
+// CheckAdvisories checks a list of Intel Security Advisories against a list of accepted advisories.
+// It returns a list of not accepted advisories if the status is SWHardeningNeeded.
+// If acceptedAdvisories is empty, all advisories are accepted and this function returns nil.
+func CheckAdvisories(status tcbstatus.Status, advisories, acceptedAdvisories []string) []string {
+	if status != tcbstatus.SWHardeningNeeded || len(acceptedAdvisories) == 0 {
+		return nil
+	}
+
+	var notAccepted []string
+	for _, advisory := range advisories {
+		if !slices.ContainsFunc(acceptedAdvisories, func(other string) bool {
+			return strings.EqualFold(advisory, other)
+		}) {
+			notAccepted = append(notAccepted, advisory)
+		}
+	}
+	return notAccepted
 }


### PR DESCRIPTION
https://github.com/edgelesssys/marblerun/pull/729 added support for reading the Security Advisories if attestation failed due to invalid TCB status.
This PR builds on that to allow users to specify just specific advisories when the reported TCB status is `SWHardeningNeeded`

### Proposed changes
- Add a new flag to the CLI `--accepted-advisories` which allows specifying a list of Intel Security Advisories to accept if the Coordinator's TCB status is `SWHardeningNeeded`. If not set, all advisories are accepted
- Add a new manifest field `Packages.AcceptedAdvisories` which allows specifying a list of Intel Security Advisories to accept if the package's TCB status is `SWHardeningNeeded`. If not set, all advisories are accepted
- Fix for the CLI printing a `nil` error if parsing the advisory list of a report failed
