### PR TITLE
deps: update GitHub actions runner base image to ubuntu 24.04

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/.github/workflows/docs-update-reference.yml
+++ b/.github/workflows/docs-update-reference.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pull-request:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/edgelesssys/edgelessrt-dev:ci
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/edgelesssys/edgelessrt-dev:ci
 

--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish-to-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: ghcr.io/edgelesssys/edgelessrt-dev:ci
 

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   vale:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,8 @@
         "pin",
         "pinDigest",
         "rollback"
-      ]
+      ],
+      "schedule": ["before 8am on monday"]
     },
     {
       "groupName": "Node dependencies",
@@ -49,7 +50,8 @@
         "js",
         "node"
       ],
-      "prPriority": -20
+      "prPriority": -20,
+      "schedule": ["before 8am on monday"]
     },
     {
       "groupName": "GitHub action dependencies",
@@ -65,7 +67,8 @@
         "lockFileMaintenance",
         "rollback",
         "bump"
-      ]
+      ],
+      "schedule": ["before 8am on monday"]
     }
   ]
 }


### PR DESCRIPTION
### Proposed changes
- Update GitHub actions runner base image to ubuntu 24.04
- Schedule grouped dependency updates for Monday morning


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- supersedes https://github.com/edgelesssys/marblerun/pull/734

<!-- (uncomment if applicable)
### Screenshots

-->
