### PR TITLE
Update samples to Gramine v1.8

### DIFF
--- a/samples/gramine-hello/Makefile
+++ b/samples/gramine-hello/Makefile
@@ -12,7 +12,7 @@ clean:
 hello: hello.c
 	$(CC) -Os -o$@ $<
 
-hello.manifest: hello.manifest.template
+hello.manifest: hello.manifest.template premain-libos
 	gramine-manifest $< > $@
 
 premain-libos:

--- a/samples/gramine-nginx/Makefile
+++ b/samples/gramine-nginx/Makefile
@@ -45,7 +45,7 @@ $(NGINX_SRC).tar.gz:
 	wget -O $@ $(NGINX_URL)/$(NGINX_SRC).tar.gz
 	echo "$(NGINX_SHA256) $@" | sha256sum -c --status
 
-nginx.manifest: nginx.manifest.template
+nginx.manifest: nginx.manifest.template premain-libos
 	gramine-manifest \
 		-Dlog_level=$(GRAMINE_LOG_LEVEL) \
 		-Darch_libdir=$(ARCH_LIBDIR) \
@@ -66,8 +66,7 @@ nginx.manifest.sgx nginx.sig: sgx_sign
 sgx_sign: nginx.manifest $(INSTALL_DIR)/sbin/nginx \
 		$(INSTALL_DIR)/conf/nginx-gramine.conf \
 		$(TEST_DATA) \
-		$(INSTALL_DIR)/conf/server.crt \
-		premain-libos
+		$(INSTALL_DIR)/conf/server.crt
 	gramine-sgx-sign \
 		--manifest $< \
 		--key $(SGX_SIGNER_KEY) \


### PR DESCRIPTION
### Proposed changes
- `gramine-manifest` now checks for existence of files. Make the make targets depend on the required file.
- ~Update redis sample base image to v1.8~ new Gramine docker image hasn't been released yet

### Additional info
- ~TODO test redis sample~
