### PR TITLE
Change license from MPL-2.0 to BUSL-1.1

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -21,4 +21,4 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check for files without license header
-        run: "! grep -rL --include='*.go' -e'// Copyright (c) Edgeless Systems GmbH.' -e'DO NOT EDIT' | grep ''"
+        run: "! grep -rL --include='*.go' -e'Copyright (c) Edgeless Systems GmbH' -e'DO NOT EDIT' | grep ''"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,26 @@
-## First steps
+# First steps
+
 Thank you for getting involved! Before you start, please familiarize yourself with the [documentation](https://docs.edgeless.systems/marblerun).
 
 Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) when interacting with this project.
 
 If you want to support our development:
+
 * Add a GitHub Star to the project
 * Share our projects on social media
 * Join the [Confidential Computing Discord](https://discord.gg/rH8QTH56JN)
 
-MarbleRun is licensed under the [Mozilla Public License 2.0](LICENSE). When contributing, you also need to agree to our [Contributor License Agreement](https://cla-assistant.io/edgelesssys/marblerun).
+MarbleRun is licensed under the [Business Source License 1.1](LICENSE). When contributing, you also need to agree to our [Contributor License Agreement](https://cla-assistant.io/edgelesssys/marblerun).
 
 ## Development guidelines
 
-
 Adhere to the style and best practices described in [Effective Go](https://golang.org/doc/effective_go.html). Read [Common Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) for further information.
-
 
 ## Pull request process
 
 Submissions should remain focused in scope and avoid containing unrelated commits.
 For pull requests, we employ the following workflow:
+
 1. Fork the repository to your own GitHub account
 2. Create a branch locally with a descriptive name
 3. Commit changes to the branch
@@ -28,20 +29,22 @@ For pull requests, we employ the following workflow:
 6. Clean up your commit history
 7. Open a PR in our repository and summarize the changes in the description
 
-
 ## Reporting issues and bugs, asking questions
+
 This project uses the GitHub issue tracker. Please check the existing issues before submitting to avoid duplicates.
 
-Please report any security issue via a [private GitHub vulnerability report](https://github.com/edgelesssys/marblerun/security/advisories/new) or write to security@edgeless.systems.
+Please report any security issue via a [private GitHub vulnerability report](https://github.com/edgelesssys/marblerun/security/advisories/new) or write to <security@edgeless.systems>.
 
 Your bug report should cover the following points:
-*	A quick summary and/or background of the issue
-*	Steps to reproduce (be specific, e.g., provide sample code)
-*	What you expected would happen
-*	What actually happens
-*	Further notes:
-    * Thoughts on possible causes
-    * Tested workarounds or fixes
+
+* A quick summary and/or background of the issue
+* Steps to reproduce (be specific, e.g., provide sample code)
+* What you expected would happen
+* What actually happens
+* Further notes:
+  * Thoughts on possible causes
+  * Tested workarounds or fixes
 
 ## Major changes and feature requests
+
 You should discuss larger changes and feature requests with the maintainers. Please open an issue describing your plans.

--- a/LICENSE
+++ b/LICENSE
@@ -1,375 +1,91 @@
-Copyright (c) Edgeless Systems GmbH.
-
-Mozilla Public License Version 2.0
-==================================
-
-1. Definitions
---------------
+Business Source License 1.1
 
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
+Parameters
 
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
+Licensor:             Edgeless Systems GmbH
+Licensed Work:        MarbleRun version 1.6 or later
+                      The Licensed Work is (c) Edgeless Systems GmbH
+Additional Use Grant: None
 
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
+Change Date:          Two years from the date a MINOR version (SemVer) is published.
 
-1.5. "Incompatible With Secondary Licenses"
-    means
+Change License:       Mozilla Public License Version 2.0
 
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
+For information about alternative licensing arrangements for the Software,
+please visit: https://www.edgeless.systems/enterprise-support
 
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
+Notice
 
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
+License text copyright (c) 2023 MariaDB plc, All Rights Reserved.
+“Business Source License” is a trademark of MariaDB plc.
 
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
-    a separate file or files, that is not Covered Software.
+-----------------------------------------------------------------------------
 
-1.8. "License"
-    means this document.
+Business Source License 1.1
 
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
+Terms
 
-1.10. "Modifications"
-    means any of the following:
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
 
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-2. License Grants and Conditions
---------------------------------
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
 
-2.1. Grants
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark “Business Source License”,
+as long as you comply with the Covenants of Licensor below.
 
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
+Covenants of Licensor
 
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
+In consideration of the right to use this License’s text and the “Business
+Source License” name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where “compatible” means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
 
-2.2. Effective Date
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text “None”.
 
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
+3. To specify a Change Date.
 
-2.3. Limitations on Grant Scope
-
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Software under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
-
-(a) for any code that a Contributor has removed from Covered Software;
-    or
-
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of Covered Software, or (ii) the combination of its
-    Contributions with other software (except as part of its Contributor
-    Version); or
-
-(c) under Patent Claims infringed by Covered Software in the absence of
-    its Contributions.
-
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
-
-2.7. Conditions
-
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
-
-3. Responsibilities
--------------------
-
-3.1. Distribution of Source Form
-
-All distribution of Covered Software in Source Code Form, including any
-Modifications that You create or to which You contribute, must be under
-the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Software is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
-
-3.2. Distribution of Executable Form
-
-If You distribute Covered Software in Executable Form then:
-
-(a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients of
-    the Executable Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
-
-(b) You may distribute such Executable Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Executable Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and the
-Covered Software is not Incompatible With Secondary Licenses, this
-License permits You to additionally distribute such Covered Software
-under the terms of such Secondary License(s), so that the recipient of
-the Larger Work may, at their option, further distribute the Covered
-Software under the terms of either this License or such Secondary
-License(s).
-
-3.4. Notices
-
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Software, except that You may alter any license notices to
-the extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of Covered
-Software. However, You may do so only on Your own behalf, and not on
-behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
-
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Software due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Software under this License. Except to the extent prohibited by statute
-or regulation, such description must be sufficiently detailed for a
-recipient of ordinary skill to be able to understand it.
-
-5. Termination
---------------
-
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Software under Section
-2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
-
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  Covered Software is provided under this License on an "as is"       *
-*  basis, without warranty of any kind, either expressed, implied, or  *
-*  statutory, including, without limitation, warranties that the       *
-*  Covered Software is free of defects, merchantable, fit for a        *
-*  particular purpose or non-infringing. The entire risk as to the     *
-*  quality and performance of the Covered Software is with You.        *
-*  Should any Covered Software prove defective in any respect, You     *
-*  (not any Contributor) assume the cost of any necessary servicing,   *
-*  repair, or correction. This disclaimer of warranty constitutes an   *
-*  essential part of this License. No use of any Covered Software is   *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
-
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort      *
-*  (including negligence), contract, or otherwise, shall any           *
-*  Contributor, or anyone who distributes Covered Software as          *
-*  permitted above, be liable to You for any direct, indirect,         *
-*  special, incidental, or consequential damages of any character      *
-*  including, without limitation, damages for lost profits, loss of    *
-*  goodwill, work stoppage, computer failure or malfunction, or any    *
-*  and all other commercial damages or losses, even if such party      *
-*  shall have been informed of the possibility of such damages. This   *
-*  limitation of liability shall not apply to liability for death or   *
-*  personal injury resulting from such party's negligence to the       *
-*  extent applicable law prohibits such limitation. Some               *
-*  jurisdictions do not allow the exclusion or limitation of           *
-*  incidental or consequential damages, so this exclusion and          *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
-
-8. Litigation
--------------
-
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
-
-9. Miscellaneous
-----------------
-
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
-
-10. Versions of the License
----------------------------
-
-10.1. New Versions
-
-Mozilla Foundation is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
-
-10.2. Effect of New Versions
-
-You may distribute the Covered Software under the terms of the version
-of the License under which You originally received the Covered Software,
-or under the terms of any subsequent version published by the license
-steward.
-
-10.3. Modified Versions
-
-If you create software not governed by this License, and you want to
-create a new license for such software, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
-
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
-
-Exhibit A - Source Code Form License Notice
--------------------------------------------
-
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.
+4. Not to modify this License in any other way.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![logo](assets/marblerun-logo.svg)
 
 [![GitHub Actions Status][github-actions-badge]][github-actions]
-[![GitHub license][license-badge]](LICENSE)
 [![Go Report Card][go-report-card-badge]][go-report-card]
 [![PkgGoDev][go-pkg-badge]][go-pkg]
 [![Discord Chat][discord-badge]][discord]
@@ -38,7 +37,6 @@ MarbleRun supports services built with one of the following frameworks:
 * [Gramine][gramine]
 * [Occlum][occlum]
 * [Edgeless RT][edgelessrt]
-
 
 ## Quickstart and documentation
 
@@ -95,7 +93,6 @@ The popular [Linkerd][linkerd] service mesh uses the simple and scalable *emojiv
 [go-report-card]: https://goreportcard.com/report/github.com/edgelesssys/marblerun
 [go-report-card-badge]: https://goreportcard.com/badge/github.com/edgelesssys/marblerun
 [gramine]: https://github.com/gramineproject/gramine
-[license-badge]: https://img.shields.io/github/license/edgelesssys/marblerun
 [linkerd]: https://linkerd.io
 [marblerunsh]: https://marblerun.sh
 [occlum]: https://github.com/occlum/occlum

--- a/api/LICENSE
+++ b/api/LICENSE
@@ -1,0 +1,375 @@
+Copyright (c) Edgeless Systems GmbH.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/certcache/cert.go
+++ b/cli/internal/certcache/cert.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package certcache
 

--- a/cli/internal/certcache/cert_test.go
+++ b/cli/internal/certcache/cert_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package certcache
 

--- a/cli/internal/cmd/certificate.go
+++ b/cli/internal/cmd/certificate.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/certificateChain.go
+++ b/cli/internal/cmd/certificateChain.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/certificateIntermediate.go
+++ b/cli/internal/cmd/certificateIntermediate.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/certificateRoot.go
+++ b/cli/internal/cmd/certificateRoot.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/certificate_test.go
+++ b/cli/internal/cmd/certificate_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/check.go
+++ b/cli/internal/cmd/check.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/check_test.go
+++ b/cli/internal/cmd/check_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package cmd implements the MarbleRun's CLI commands.
 package cmd

--- a/cli/internal/cmd/csr.go
+++ b/cli/internal/cmd/csr.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/csr_legay.go
+++ b/cli/internal/cmd/csr_legay.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/csr_test.go
+++ b/cli/internal/cmd/csr_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/install.go
+++ b/cli/internal/cmd/install.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/install_test.go
+++ b/cli/internal/cmd/install_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifest.go
+++ b/cli/internal/cmd/manifest.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifestGet.go
+++ b/cli/internal/cmd/manifestGet.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifestLog.go
+++ b/cli/internal/cmd/manifestLog.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifestSet.go
+++ b/cli/internal/cmd/manifestSet.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifestSignature.go
+++ b/cli/internal/cmd/manifestSignature.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifestUpdate.go
+++ b/cli/internal/cmd/manifestUpdate.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifestVerify.go
+++ b/cli/internal/cmd/manifestVerify.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/manifest_test.go
+++ b/cli/internal/cmd/manifest_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/packageInfo.go
+++ b/cli/internal/cmd/packageInfo.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/packageInfo_test.go
+++ b/cli/internal/cmd/packageInfo_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/precheck.go
+++ b/cli/internal/cmd/precheck.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/precheck_test.go
+++ b/cli/internal/cmd/precheck_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/recover.go
+++ b/cli/internal/cmd/recover.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/secret.go
+++ b/cli/internal/cmd/secret.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/secretGet.go
+++ b/cli/internal/cmd/secretGet.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/secretSet.go
+++ b/cli/internal/cmd/secretSet.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/secret_test.go
+++ b/cli/internal/cmd/secret_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/uninstall.go
+++ b/cli/internal/cmd/uninstall.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/uninstall_test.go
+++ b/cli/internal/cmd/uninstall_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/cmd/version.go
+++ b/cli/internal/cmd/version.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package cmd
 

--- a/cli/internal/file/file.go
+++ b/cli/internal/file/file.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package file
 

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package helm
 

--- a/cli/internal/helm/client_test.go
+++ b/cli/internal/helm/client_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package helm
 

--- a/cli/internal/helm/helm.go
+++ b/cli/internal/helm/helm.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package helm provides functions to install and uninstall the MarbleRun Helm chart.
 package helm

--- a/cli/internal/kube/client.go
+++ b/cli/internal/kube/client.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package kube
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/coordinator/enclavemain.go
+++ b/cmd/coordinator/enclavemain.go
@@ -1,10 +1,10 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 //go:build enclave
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/coordinator/invokemain.go
+++ b/cmd/coordinator/invokemain.go
@@ -1,10 +1,10 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 //go:build enclave
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -1,10 +1,10 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 //go:build !enclave
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/marble-injector/main.go
+++ b/cmd/marble-injector/main.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/marble-test/main.go
+++ b/cmd/marble-test/main.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/marble-test/mesh.go
+++ b/cmd/marble-test/mesh.go
@@ -1,10 +1,10 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 //go:build enclave
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/marble-test/mock.go
+++ b/cmd/marble-test/mock.go
@@ -1,10 +1,10 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 //go:build !enclave
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/cmd/premain-libos/main.go
+++ b/cmd/premain-libos/main.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package main
 

--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // package clientapi implements methods for users to interact with the Coordinator.
 package clientapi

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package clientapi
 

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package clientapi
 

--- a/coordinator/constants/constants.go
+++ b/coordinator/constants/constants.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // constants defines constant values used in the Coordinator.
 package constants

--- a/coordinator/core/certificate_test.go
+++ b/coordinator/core/certificate_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package core
 

--- a/coordinator/core/core.go
+++ b/coordinator/core/core.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package core provides the core functionality for the Coordinator object including state transition, APIs for marbles and clients, handling of manifests and the sealing functionalities.
 package core

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package core
 

--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package core
 

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package core
 

--- a/coordinator/core/metrics.go
+++ b/coordinator/core/metrics.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package core
 

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package core
 

--- a/coordinator/crypto/crypto.go
+++ b/coordinator/crypto/crypto.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // crypto provides common cryptographic functions used by the Coordinator.
 package crypto

--- a/coordinator/events/eventlog.go
+++ b/coordinator/events/eventlog.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package events implements a log of coordinator events.
 package events

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package manifest
 

--- a/coordinator/manifest/manifest_test.go
+++ b/coordinator/manifest/manifest_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package manifest
 

--- a/coordinator/oid/oid.go
+++ b/coordinator/oid/oid.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package oid
 

--- a/coordinator/quote/ert.go
+++ b/coordinator/quote/ert.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package quote
 

--- a/coordinator/quote/ertvalidator/ertvalidator.go
+++ b/coordinator/quote/ertvalidator/ertvalidator.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package ertvalidator
 

--- a/coordinator/quote/failvalidator.go
+++ b/coordinator/quote/failvalidator.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package quote
 

--- a/coordinator/quote/interface.go
+++ b/coordinator/quote/interface.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package quote provides the quoting functionialty for remote attestation on both Coordinator and Marble site.
 package quote

--- a/coordinator/quote/mock.go
+++ b/coordinator/quote/mock.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package quote
 

--- a/coordinator/recovery/recovery.go
+++ b/coordinator/recovery/recovery.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package recovery
 

--- a/coordinator/recovery/single.go
+++ b/coordinator/recovery/single.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package recovery
 

--- a/coordinator/seal/mocksealer.go
+++ b/coordinator/seal/mocksealer.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package seal
 

--- a/coordinator/seal/mode.go
+++ b/coordinator/seal/mode.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package seal
 

--- a/coordinator/seal/noenclavesealer.go
+++ b/coordinator/seal/noenclavesealer.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package seal
 

--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package seal implements sealing operations for the Coordinator.
 package seal

--- a/coordinator/seal/seal_test.go
+++ b/coordinator/seal/seal_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package seal
 

--- a/coordinator/server/handler/handler.go
+++ b/coordinator/server/handler/handler.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package handler
 

--- a/coordinator/server/logging.go
+++ b/coordinator/server/logging.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package server
 

--- a/coordinator/server/metrics.go
+++ b/coordinator/server/metrics.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package server
 

--- a/coordinator/server/metrics_test.go
+++ b/coordinator/server/metrics_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package server
 

--- a/coordinator/server/server.go
+++ b/coordinator/server/server.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package server contains the ClientAPI HTTP-REST and MarbleAPI gRPC server.
 package server

--- a/coordinator/server/server_test.go
+++ b/coordinator/server/server_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package server
 

--- a/coordinator/server/v1/types.go
+++ b/coordinator/server/v1/types.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package v1
 

--- a/coordinator/server/v1/v1.go
+++ b/coordinator/server/v1/v1.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package v1
 

--- a/coordinator/server/v2/types.go
+++ b/coordinator/server/v2/types.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package v2
 

--- a/coordinator/server/v2/v2.go
+++ b/coordinator/server/v2/v2.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package v2
 

--- a/coordinator/state/state.go
+++ b/coordinator/state/state.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // State is the sequence of states a Coordinator may be in.
 package state

--- a/coordinator/store/request/request.go
+++ b/coordinator/store/request/request.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // request defines constants used to access the store.
 package request

--- a/coordinator/store/stdstore/stdstore.go
+++ b/coordinator/store/stdstore/stdstore.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package stdstore
 

--- a/coordinator/store/stdstore/stdstore_test.go
+++ b/coordinator/store/stdstore/stdstore_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package stdstore
 

--- a/coordinator/store/store.go
+++ b/coordinator/store/store.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package store
 

--- a/coordinator/store/wrapper/testutil/testutil.go
+++ b/coordinator/store/wrapper/testutil/testutil.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package testutil provides utility functions to access store values in unit tests.
 package testutil

--- a/coordinator/store/wrapper/wrapper.go
+++ b/coordinator/store/wrapper/wrapper.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package wrapper
 

--- a/coordinator/store/wrapper/wrapper_test.go
+++ b/coordinator/store/wrapper/wrapper_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package wrapper
 

--- a/coordinator/updatelog/updatelog.go
+++ b/coordinator/updatelog/updatelog.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package updatelog
 

--- a/coordinator/updatelog/updatelog_test.go
+++ b/coordinator/updatelog/updatelog_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package updatelog
 

--- a/coordinator/user/user.go
+++ b/coordinator/user/user.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package user
 

--- a/coordinator/user/user_test.go
+++ b/coordinator/user/user_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package user
 

--- a/hack/clidocgen/main.go
+++ b/hack/clidocgen/main.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Clidocgen generates a Markdown page describing all CLI commands.
 package main

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package injector
 

--- a/injector/injector_test.go
+++ b/injector/injector_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package injector
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package constants
 

--- a/internal/tcb/tcb.go
+++ b/internal/tcb/tcb.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package tcb
 

--- a/internal/tcb/tcb_test.go
+++ b/internal/tcb/tcb_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package tcb
 

--- a/marble/LICENSE
+++ b/marble/LICENSE
@@ -1,0 +1,375 @@
+Copyright (c) Edgeless Systems GmbH.
+
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 // Package framework provides a testing framework for MarbleRun integration testing.
 package framework

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,10 +1,10 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 //go:build integration
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package test
 

--- a/test/manifests.go
+++ b/test/manifests.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package test
 

--- a/util/k8sutil/k8sutil.go
+++ b/util/k8sutil/k8sutil.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package k8sutil
 

--- a/util/tls.go
+++ b/util/tls.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package util
 

--- a/util/tls_test.go
+++ b/util/tls_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package util
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package util
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,8 +1,8 @@
-// Copyright (c) Edgeless Systems GmbH.
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
 
 package util
 


### PR DESCRIPTION
Packages `api` and `marble` will remain MPL-2.0.