### PR TITLE
cli: support for authenticating with private keys and certificates stored in PKCS #11 backend

### DIFF
--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgelesssys/marblerun/cli/internal/kube"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -30,6 +31,26 @@ const eraDefaultConfig = "era-config.json"
 
 func webhookDNSName(namespace string) string {
 	return "marble-injector." + namespace
+}
+
+func addClientAuthFlags(cmd *cobra.Command, flags *pflag.FlagSet) {
+	flags.StringP("cert", "c", "", "PEM encoded admin certificate file")
+	flags.StringP("key", "k", "", "PEM encoded admin key file")
+	cmd.MarkFlagsRequiredTogether("key", "cert")
+
+	flags.String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")
+	flags.String("pkcs11-key-id", "", "ID of the private key in the PKCS#11 token")
+	flags.String("pkcs11-key-label", "", "Label of the private key in the PKCS#11 token")
+	flags.String("pkcs11-cert-id", "", "ID of the certificate in the PKCS#11 token")
+	flags.String("pkcs11-cert-label", "", "Label of the certificate in the PKCS#11 token")
+	must(cobra.MarkFlagFilename(flags, "pkcs11-config", "json"))
+	cmd.MarkFlagsOneRequired("pkcs11-key-id", "pkcs11-key-label", "cert")
+	cmd.MarkFlagsOneRequired("pkcs11-cert-id", "pkcs11-cert-label", "cert")
+
+	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "cert")
+	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "key")
+	cmd.MarkFlagsOneRequired("pkcs11-config", "cert")
+	cmd.MarkFlagsOneRequired("pkcs11-config", "key")
 }
 
 // parseRestFlags parses the command line flags used to configure the REST client.

--- a/cli/internal/cmd/manifestUpdate.go
+++ b/cli/internal/cmd/manifestUpdate.go
@@ -45,24 +45,7 @@ An admin certificate specified in the original manifest is needed to verify the 
 		Args:    cobra.ExactArgs(2),
 		RunE:    runUpdateApply,
 	}
-
-	cmd.Flags().StringP("cert", "c", "", "PEM encoded admin certificate file")
-	cmd.Flags().StringP("key", "k", "", "PEM encoded admin key file")
-	cmd.MarkFlagsRequiredTogether("key", "cert")
-
-	cmd.Flags().String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")
-	cmd.Flags().String("pkcs11-key-id", "", "ID of the private key in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-key-label", "", "Label of the private key in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-cert-id", "", "ID of the certificate in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-cert-label", "", "Label of the certificate in the PKCS#11 token")
-	must(cmd.MarkFlagFilename("pkcs11-config", "json"))
-	cmd.MarkFlagsOneRequired("pkcs11-key-id", "pkcs11-key-label", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-cert-id", "pkcs11-cert-label", "cert")
-
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "cert")
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "key")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "key")
+	addClientAuthFlags(cmd, cmd.Flags())
 
 	return cmd
 }
@@ -80,24 +63,7 @@ All participants must use the same manifest to acknowledge the pending update.
 		Args:    cobra.ExactArgs(2),
 		RunE:    runUpdateAcknowledge,
 	}
-
-	cmd.Flags().StringP("cert", "c", "", "PEM encoded admin certificate file")
-	cmd.Flags().StringP("key", "k", "", "PEM encoded admin key file")
-	cmd.MarkFlagsRequiredTogether("key", "cert")
-
-	cmd.Flags().String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")
-	cmd.Flags().String("pkcs11-key-id", "", "ID of the private key in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-key-label", "", "Label of the private key in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-cert-id", "", "ID of the certificate in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-cert-label", "", "Label of the certificate in the PKCS#11 token")
-	must(cmd.MarkFlagFilename("pkcs11-config", "json"))
-	cmd.MarkFlagsOneRequired("pkcs11-key-id", "pkcs11-key-label", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-cert-id", "pkcs11-cert-label", "cert")
-
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "cert")
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "key")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "key")
+	addClientAuthFlags(cmd, cmd.Flags())
 
 	return cmd
 }
@@ -111,24 +77,7 @@ func newUpdateCancel() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE:    runUpdateCancel,
 	}
-
-	cmd.Flags().StringP("cert", "c", "", "PEM encoded admin certificate file")
-	cmd.Flags().StringP("key", "k", "", "PEM encoded admin key file")
-	cmd.MarkFlagsRequiredTogether("key", "cert")
-
-	cmd.Flags().String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")
-	cmd.Flags().String("pkcs11-key-id", "", "ID of the private key in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-key-label", "", "Label of the private key in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-cert-id", "", "ID of the certificate in the PKCS#11 token")
-	cmd.Flags().String("pkcs11-cert-label", "", "Label of the certificate in the PKCS#11 token")
-	must(cmd.MarkFlagFilename("pkcs11-config", "json"))
-	cmd.MarkFlagsOneRequired("pkcs11-key-id", "pkcs11-key-label", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-cert-id", "pkcs11-cert-label", "cert")
-
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "cert")
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "key")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "key")
+	addClientAuthFlags(cmd, cmd.Flags())
 
 	return cmd
 }

--- a/cli/internal/cmd/manifestUpdate.go
+++ b/cli/internal/cmd/manifestUpdate.go
@@ -8,7 +8,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 
@@ -98,7 +97,7 @@ func newUpdateGet() *cobra.Command {
 	return cmd
 }
 
-func runUpdateApply(cmd *cobra.Command, args []string) (err error) {
+func runUpdateApply(cmd *cobra.Command, args []string) error {
 	manifestFile := args[0]
 	hostname := args[1]
 	fs := afero.NewOsFs()
@@ -112,7 +111,9 @@ func runUpdateApply(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer func() {
-		err = errors.Join(err, cancel())
+		if err := cancel(); err != nil {
+			cmd.PrintErrf("Failed to close PKCS #11 session: %s\n", err)
+		}
 	}()
 
 	manifest, err := loadManifestFile(file.New(manifestFile, fs))
@@ -127,7 +128,7 @@ func runUpdateApply(cmd *cobra.Command, args []string) (err error) {
 	return nil
 }
 
-func runUpdateAcknowledge(cmd *cobra.Command, args []string) (err error) {
+func runUpdateAcknowledge(cmd *cobra.Command, args []string) error {
 	manifestFile := args[0]
 	hostname := args[1]
 	fs := afero.NewOsFs()
@@ -141,7 +142,9 @@ func runUpdateAcknowledge(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer func() {
-		err = errors.Join(err, cancel())
+		if err := cancel(); err != nil {
+			cmd.PrintErrf("Failed to close PKCS #11 session: %s\n", err)
+		}
 	}()
 
 	manifest, err := loadManifestFile(file.New(manifestFile, fs))
@@ -166,7 +169,7 @@ func runUpdateAcknowledge(cmd *cobra.Command, args []string) (err error) {
 	return nil
 }
 
-func runUpdateCancel(cmd *cobra.Command, args []string) (err error) {
+func runUpdateCancel(cmd *cobra.Command, args []string) error {
 	hostname := args[0]
 	fs := afero.NewOsFs()
 
@@ -179,7 +182,9 @@ func runUpdateCancel(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer func() {
-		err = errors.Join(err, cancel())
+		if err := cancel(); err != nil {
+			cmd.PrintErrf("Failed to close PKCS #11 session: %s\n", err)
+		}
 	}()
 
 	if err := api.ManifestUpdateCancel(cmd.Context(), hostname, root, keyPair); err != nil {

--- a/cli/internal/cmd/secret.go
+++ b/cli/internal/cmd/secret.go
@@ -20,10 +20,23 @@ Manage secrets for the MarbleRun Coordinator.
 Set or retrieve a secret defined in the manifest.`,
 	}
 
-	cmd.PersistentFlags().StringP("cert", "c", "", "PEM encoded MarbleRun user certificate file (required)")
-	cmd.PersistentFlags().StringP("key", "k", "", "PEM encoded MarbleRun user key file (required)")
-	must(cmd.MarkPersistentFlagRequired("key"))
-	must(cmd.MarkPersistentFlagRequired("cert"))
+	cmd.PersistentFlags().StringP("cert", "c", "", "PEM encoded MarbleRun user certificate file")
+	cmd.PersistentFlags().StringP("key", "k", "", "PEM encoded MarbleRun user key file")
+	cmd.MarkFlagsRequiredTogether("key", "cert")
+
+	cmd.PersistentFlags().String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")
+	cmd.PersistentFlags().String("pkcs11-key-id", "", "ID of the private key in the PKCS#11 token")
+	cmd.PersistentFlags().String("pkcs11-key-label", "", "Label of the private key in the PKCS#11 token")
+	cmd.PersistentFlags().String("pkcs11-cert-id", "", "ID of the certificate in the PKCS#11 token")
+	cmd.PersistentFlags().String("pkcs11-cert-label", "", "Label of the certificate in the PKCS#11 token")
+	must(cmd.MarkPersistentFlagFilename("pkcs11-config", "json"))
+	cmd.MarkFlagsOneRequired("pkcs11-key-id", "pkcs11-key-label", "cert")
+	cmd.MarkFlagsOneRequired("pkcs11-cert-id", "pkcs11-cert-label", "cert")
+
+	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "cert")
+	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "key")
+	cmd.MarkFlagsOneRequired("pkcs11-config", "cert")
+	cmd.MarkFlagsOneRequired("pkcs11-config", "key")
 
 	cmd.AddCommand(newSecretSet())
 	cmd.AddCommand(newSecretGet())

--- a/cli/internal/cmd/secret.go
+++ b/cli/internal/cmd/secret.go
@@ -19,24 +19,7 @@ func NewSecretCmd() *cobra.Command {
 Manage secrets for the MarbleRun Coordinator.
 Set or retrieve a secret defined in the manifest.`,
 	}
-
-	cmd.PersistentFlags().StringP("cert", "c", "", "PEM encoded MarbleRun user certificate file")
-	cmd.PersistentFlags().StringP("key", "k", "", "PEM encoded MarbleRun user key file")
-	cmd.MarkFlagsRequiredTogether("key", "cert")
-
-	cmd.PersistentFlags().String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")
-	cmd.PersistentFlags().String("pkcs11-key-id", "", "ID of the private key in the PKCS#11 token")
-	cmd.PersistentFlags().String("pkcs11-key-label", "", "Label of the private key in the PKCS#11 token")
-	cmd.PersistentFlags().String("pkcs11-cert-id", "", "ID of the certificate in the PKCS#11 token")
-	cmd.PersistentFlags().String("pkcs11-cert-label", "", "Label of the certificate in the PKCS#11 token")
-	must(cmd.MarkPersistentFlagFilename("pkcs11-config", "json"))
-	cmd.MarkFlagsOneRequired("pkcs11-key-id", "pkcs11-key-label", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-cert-id", "pkcs11-cert-label", "cert")
-
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "cert")
-	cmd.MarkFlagsMutuallyExclusive("pkcs11-config", "key")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "cert")
-	cmd.MarkFlagsOneRequired("pkcs11-config", "key")
+	addClientAuthFlags(cmd, cmd.PersistentFlags())
 
 	cmd.AddCommand(newSecretSet())
 	cmd.AddCommand(newSecretGet())

--- a/cli/internal/cmd/secretGet.go
+++ b/cli/internal/cmd/secretGet.go
@@ -9,7 +9,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
@@ -40,7 +39,7 @@ and need permissions in the manifest to read the requested secrets.
 	return cmd
 }
 
-func runSecretGet(cmd *cobra.Command, args []string) (err error) {
+func runSecretGet(cmd *cobra.Command, args []string) error {
 	hostname := args[len(args)-1]
 	secretIDs := args[0 : len(args)-1]
 	fs := afero.NewOsFs()
@@ -59,7 +58,9 @@ func runSecretGet(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer func() {
-		err = errors.Join(err, cancel())
+		if err := cancel(); err != nil {
+			cmd.PrintErrf("Failed to close PKCS #11 session: %s\n", err)
+		}
 	}()
 
 	getSecrets := func(ctx context.Context) (map[string]manifest.Secret, error) {

--- a/cli/internal/cmd/secretSet.go
+++ b/cli/internal/cmd/secretSet.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -48,7 +47,7 @@ marblerun secret set certificate.pem $MARBLERUN -c admin.crt -k admin.key --from
 	return cmd
 }
 
-func runSecretSet(cmd *cobra.Command, args []string) (err error) {
+func runSecretSet(cmd *cobra.Command, args []string) error {
 	secretFile := args[0]
 	hostname := args[1]
 	fs := afero.NewOsFs()
@@ -84,7 +83,9 @@ func runSecretSet(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 	defer func() {
-		err = errors.Join(err, cancel())
+		if err := cancel(); err != nil {
+			cmd.PrintErrf("Failed to close PKCS #11 session: %s\n", err)
+		}
 	}()
 
 	if err := api.SecretSet(cmd.Context(), hostname, root, keyPair, newSecrets); err != nil {

--- a/cli/internal/pkcs11/pkcs11.go
+++ b/cli/internal/pkcs11/pkcs11.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package pkcs11
+
+import (
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"github.com/ThalesGroup/crypto11"
+)
+
+// LoadX509KeyPair loads a [tls.Certificate] using the provided PKCS#11 configuration file.
+// The returned cancel function must be called to release the PKCS#11 resources only after the certificate is no longer needed.
+func LoadX509KeyPair(pkcs11ConfigPath string, keyID, keyLabel, certID, certLabel string) (crt tls.Certificate, cancel func() error, err error) {
+	pkcs11, err := crypto11.ConfigureFromFile(pkcs11ConfigPath)
+	if err != nil {
+		return crt, nil, err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, pkcs11.Close())
+		}
+	}()
+
+	var keyIDBytes, keyLabelBytes, certIDBytes, certLabelBytes []byte
+	if keyID != "" {
+		keyIDBytes = []byte(keyID)
+	}
+	if keyLabel != "" {
+		keyLabelBytes = []byte(keyLabel)
+	}
+	if certID != "" {
+		certIDBytes = []byte(certID)
+	}
+	if certLabel != "" {
+		certLabelBytes = []byte(certLabel)
+	}
+
+	privateKey, err := loadPrivateKey(pkcs11, keyIDBytes, keyLabelBytes)
+	if err != nil {
+		return crt, nil, err
+	}
+	cert, err := loadCertificate(pkcs11, certIDBytes, certLabelBytes)
+	if err != nil {
+		return crt, nil, err
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{cert.Raw},
+		PrivateKey:  privateKey,
+		Leaf:        cert,
+	}, pkcs11.Close, nil
+}
+
+func loadPrivateKey(pkcs11 *crypto11.Context, id, label []byte) (crypto.Signer, error) {
+	priv, err := pkcs11.FindKeyPair(id, label)
+	if err != nil {
+		return nil, err
+	}
+	if priv == nil {
+		return nil, fmt.Errorf("no key pair found for id \"%s\" and label \"%s\"", id, label)
+	}
+	return priv, nil
+}
+
+func loadCertificate(pkcs11 *crypto11.Context, id, label []byte) (*x509.Certificate, error) {
+	cert, err := pkcs11.FindCertificate(id, label, nil)
+	if err != nil {
+		return nil, err
+	}
+	if cert == nil {
+		return nil, fmt.Errorf("no certificate found for id \"%s\" and label \"%s\"", id, label)
+	}
+	return cert, nil
+}

--- a/cli/internal/pkcs11/pkcs11_integration_test.go
+++ b/cli/internal/pkcs11/pkcs11_integration_test.go
@@ -1,0 +1,172 @@
+//go:build integration && pkcs11
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package pkcs11
+
+import (
+	"crypto"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/ThalesGroup/crypto11"
+	"github.com/edgelesssys/marblerun/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var configPath = flag.String("pkcs11-config", "", "path to PKCS#11 configuration file")
+
+func TestLoadX509KeyPair(t *testing.T) {
+	// Ensure we can load the PKCS#11 configuration file
+	pkcs11, err := crypto11.ConfigureFromFile(*configPath)
+	require.NoError(t, err)
+	require.NoError(t, pkcs11.Close())
+
+	testCases := map[string]struct {
+		init    func(t *testing.T) (keyID, keyLabel, certID, certLabel string)
+		wantErr bool
+	}{
+		"identified by ID and label": {
+			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
+				t.Helper()
+				require := require.New(t)
+				prefix := t.TempDir()
+				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
+				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
+				require.NoError(err)
+				defer pkcs11.Close()
+				privK, err := pkcs11.GenerateECDSAKeyPairWithLabel([]byte(keyID), []byte(keyLabel), elliptic.P256())
+				require.NoError(err)
+				cert, err := createSelfSignedCertificate(privK)
+				require.NoError(err)
+				require.NoError(pkcs11.ImportCertificateWithLabel([]byte(certID), []byte(certLabel), cert))
+				return keyID, keyLabel, certID, certLabel
+			},
+		},
+		"identified by ID only": {
+			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
+				t.Helper()
+				require := require.New(t)
+				prefix := t.TempDir()
+				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
+				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
+				require.NoError(err)
+				defer pkcs11.Close()
+				privK, err := pkcs11.GenerateECDSAKeyPair([]byte(keyID), elliptic.P256())
+				require.NoError(err)
+				cert, err := createSelfSignedCertificate(privK)
+				require.NoError(err)
+				require.NoError(pkcs11.ImportCertificate([]byte(certID), cert))
+				return keyID, "", certID, ""
+			},
+		},
+		"identified by label only": {
+			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
+				t.Helper()
+				require := require.New(t)
+				prefix := t.TempDir()
+				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
+				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
+				require.NoError(err)
+				defer pkcs11.Close()
+				privK, err := pkcs11.GenerateECDSAKeyPairWithLabel([]byte(keyID), []byte(keyLabel), elliptic.P256())
+				require.NoError(err)
+				cert, err := createSelfSignedCertificate(privK)
+				require.NoError(err)
+				require.NoError(pkcs11.ImportCertificateWithLabel([]byte(certID), []byte(certLabel), cert))
+				return "", keyLabel, "", certLabel
+			},
+		},
+		"key not found": {
+			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
+				t.Helper()
+				require := require.New(t)
+				prefix := t.TempDir()
+				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
+				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
+				require.NoError(err)
+				defer pkcs11.Close()
+				privK, err := pkcs11.GenerateECDSAKeyPairWithLabel([]byte(keyID), []byte(keyLabel), elliptic.P256())
+				require.NoError(err)
+				cert, err := createSelfSignedCertificate(privK)
+				require.NoError(err)
+				require.NoError(pkcs11.ImportCertificateWithLabel([]byte(certID), []byte(certLabel), cert))
+				return "not-found", "not-found", certID, certLabel
+			},
+			wantErr: true,
+		},
+		"cert not found": {
+			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
+				t.Helper()
+				require := require.New(t)
+				prefix := t.TempDir()
+				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
+				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
+				require.NoError(err)
+				defer pkcs11.Close()
+				_, err = pkcs11.GenerateECDSAKeyPairWithLabel([]byte(keyID), []byte(keyLabel), elliptic.P256())
+				require.NoError(err)
+				return keyID, keyLabel, certID, certLabel
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			keyID, keyLabel, certID, certLabel := tc.init(t)
+			crt, cancel, err := LoadX509KeyPair(*configPath, keyID, keyLabel, certID, certLabel)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			require.NoError(err)
+			defer cancel()
+
+			assert.NotNil(crt.PrivateKey)
+			assert.NotNil(crt.Certificate)
+			assert.NotNil(crt.Leaf)
+
+			require.Len(crt.Certificate, 1)
+			leafCrt, err := x509.ParseCertificate(crt.Certificate[0])
+			require.NoError(err)
+			assert.True(crt.Leaf.Equal(leafCrt))
+
+			privK, ok := crt.PrivateKey.(crypto.Signer)
+			require.True(ok)
+			pubK, ok := privK.Public().(interface{ Equal(crypto.PublicKey) bool })
+			require.True(ok)
+			assert.True(pubK.Equal(crt.Leaf.PublicKey))
+		})
+	}
+}
+
+func createSelfSignedCertificate(priv crypto.Signer) (*x509.Certificate, error) {
+	serialNumber, err := util.GenerateCertificateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		NotBefore:    now.Add(-2 * time.Hour),
+		NotAfter:     now.Add(2 * time.Hour),
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, priv.Public(), priv)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(cert)
+}

--- a/cli/internal/pkcs11/pkcs11_integration_test.go
+++ b/cli/internal/pkcs11/pkcs11_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ThalesGroup/crypto11"
 	"github.com/edgelesssys/marblerun/util"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func TestLoadX509KeyPair(t *testing.T) {
 			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
 				t.Helper()
 				require := require.New(t)
-				prefix := t.TempDir()
+				prefix := uuid.New().String()
 				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
 				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
 				require.NoError(err)
@@ -56,7 +57,7 @@ func TestLoadX509KeyPair(t *testing.T) {
 			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
 				t.Helper()
 				require := require.New(t)
-				prefix := t.TempDir()
+				prefix := uuid.New().String()
 				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
 				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
 				require.NoError(err)
@@ -73,7 +74,7 @@ func TestLoadX509KeyPair(t *testing.T) {
 			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
 				t.Helper()
 				require := require.New(t)
-				prefix := t.TempDir()
+				prefix := uuid.New().String()
 				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
 				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
 				require.NoError(err)
@@ -90,7 +91,7 @@ func TestLoadX509KeyPair(t *testing.T) {
 			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
 				t.Helper()
 				require := require.New(t)
-				prefix := t.TempDir()
+				prefix := uuid.New().String()
 				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
 				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
 				require.NoError(err)
@@ -108,7 +109,7 @@ func TestLoadX509KeyPair(t *testing.T) {
 			init: func(t *testing.T) (keyID, keyLabel, certID, certLabel string) {
 				t.Helper()
 				require := require.New(t)
-				prefix := t.TempDir()
+				prefix := uuid.New().String()
 				keyID, keyLabel, certID, certLabel = prefix+"keyID", prefix+"keyLabel", prefix+"certID", prefix+"certLabel"
 				pkcs11, err := crypto11.ConfigureFromFile(*configPath)
 				require.NoError(err)
@@ -133,7 +134,9 @@ func TestLoadX509KeyPair(t *testing.T) {
 				return
 			}
 			require.NoError(err)
-			defer cancel()
+			defer func() {
+				_ = cancel()
+			}()
 
 			assert.NotNil(crt.PrivateKey)
 			assert.NotNil(crt.Certificate)

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -424,9 +424,14 @@ marblerun manifest update apply update-manifest.json $MARBLERUN --cert=admin-cer
 ### Options
 
 ```
-  -c, --cert string   PEM encoded admin certificate file (required)
-  -h, --help          help for apply
-  -k, --key string    PEM encoded admin key file (required)
+  -c, --cert string                PEM encoded admin certificate file
+  -h, --help                       help for apply
+  -k, --key string                 PEM encoded admin key file
+      --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
+      --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
+      --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with
+      --pkcs11-key-id string       ID of the private key in the PKCS#11 token
+      --pkcs11-key-label string    Label of the private key in the PKCS#11 token
 ```
 
 ### Options inherited from parent commands
@@ -467,9 +472,14 @@ marblerun manifest update acknowledge update-manifest.json $MARBLERUN --cert=adm
 ### Options
 
 ```
-  -c, --cert string   PEM encoded admin certificate file (required)
-  -h, --help          help for acknowledge
-  -k, --key string    PEM encoded admin key file (required)
+  -c, --cert string                PEM encoded admin certificate file
+  -h, --help                       help for acknowledge
+  -k, --key string                 PEM encoded admin key file
+      --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
+      --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
+      --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with
+      --pkcs11-key-id string       ID of the private key in the PKCS#11 token
+      --pkcs11-key-label string    Label of the private key in the PKCS#11 token
 ```
 
 ### Options inherited from parent commands
@@ -506,9 +516,14 @@ marblerun manifest update cancel $MARBLERUN --cert=admin-cert.pem --key=admin-ke
 ### Options
 
 ```
-  -c, --cert string   PEM encoded admin certificate file (required)
-  -h, --help          help for cancel
-  -k, --key string    PEM encoded admin key file (required)
+  -c, --cert string                PEM encoded admin certificate file
+  -h, --help                       help for cancel
+  -k, --key string                 PEM encoded admin key file
+      --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
+      --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
+      --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with
+      --pkcs11-key-id string       ID of the private key in the PKCS#11 token
+      --pkcs11-key-label string    Label of the private key in the PKCS#11 token
 ```
 
 ### Options inherited from parent commands
@@ -736,9 +751,14 @@ Set or retrieve a secret defined in the manifest.
 ### Options
 
 ```
-  -c, --cert string   PEM encoded MarbleRun user certificate file (required)
-  -h, --help          help for secret
-  -k, --key string    PEM encoded MarbleRun user key file (required)
+  -c, --cert string                PEM encoded MarbleRun user certificate file
+  -h, --help                       help for secret
+  -k, --key string                 PEM encoded MarbleRun user key file
+      --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
+      --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
+      --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with
+      --pkcs11-key-id string       ID of the private key in the PKCS#11 token
+      --pkcs11-key-label string    Label of the private key in the PKCS#11 token
 ```
 
 ### Options inherited from parent commands
@@ -795,13 +815,18 @@ marblerun secret set certificate.pem $MARBLERUN -c admin.crt -k admin.key --from
 ```
       --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
-  -c, --cert string                     PEM encoded MarbleRun user certificate file (required)
+  -c, --cert string                     PEM encoded MarbleRun user certificate file
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
   -i, --insecure                        Set to skip quote verification, needed when running in simulation mode
-  -k, --key string                      PEM encoded MarbleRun user key file (required)
+  -k, --key string                      PEM encoded MarbleRun user key file
   -n, --namespace string                Kubernetes namespace of the MarbleRun installation (default "marblerun")
       --nonce string                    (Optional) nonce to use for quote verification. If set, the Coordinator will generate a quote over sha256(CoordinatorCert + nonce)
+      --pkcs11-cert-id string           ID of the certificate in the PKCS#11 token
+      --pkcs11-cert-label string        Label of the certificate in the PKCS#11 token
+      --pkcs11-config string            Path to a PKCS#11 configuration file to load the client certificate with
+      --pkcs11-key-id string            ID of the private key in the PKCS#11 token
+      --pkcs11-key-label string         Label of the private key in the PKCS#11 token
       --save-sgx-quote string           If set, save the Coordinator's SGX quote to the specified file
 ```
 
@@ -839,13 +864,18 @@ marblerun secret get genericSecret symmetricKeyShared $MARBLERUN -c admin.crt -k
 ```
       --accepted-advisories strings     Comma-separated list of user accepted Intel Security Advisories for SWHardeningNeeded TCB status. If empty, all advisories are accepted
       --accepted-tcb-statuses strings   Comma-separated list of user accepted TCB statuses (default [UpToDate,SWHardeningNeeded])
-  -c, --cert string                     PEM encoded MarbleRun user certificate file (required)
+  -c, --cert string                     PEM encoded MarbleRun user certificate file
       --coordinator-cert string         Path to MarbleRun Coordinator's root certificate to use for TLS connections (default "$HOME/.config/marblerun/coordinator-cert.pem")
       --era-config string               Path to a remote-attestation config file in JSON format. If none is provided, the command attempts to use './coordinator-era.json'. If that does not exist, the command will attempt to load a matching config file from the MarbleRun GitHub repository
   -i, --insecure                        Set to skip quote verification, needed when running in simulation mode
-  -k, --key string                      PEM encoded MarbleRun user key file (required)
+  -k, --key string                      PEM encoded MarbleRun user key file
   -n, --namespace string                Kubernetes namespace of the MarbleRun installation (default "marblerun")
       --nonce string                    (Optional) nonce to use for quote verification. If set, the Coordinator will generate a quote over sha256(CoordinatorCert + nonce)
+      --pkcs11-cert-id string           ID of the certificate in the PKCS#11 token
+      --pkcs11-cert-label string        Label of the certificate in the PKCS#11 token
+      --pkcs11-config string            Path to a PKCS#11 configuration file to load the client certificate with
+      --pkcs11-key-id string            ID of the private key in the PKCS#11 token
+      --pkcs11-key-label string         Label of the private key in the PKCS#11 token
       --save-sgx-quote string           If set, save the Coordinator's SGX quote to the specified file
 ```
 

--- a/docs/docs/workflows/user-authentication.md
+++ b/docs/docs/workflows/user-authentication.md
@@ -43,7 +43,7 @@ The following shows an example for authenticating with a key and certificate sto
 }
 ```
 
-Assuming the key and certificate have the label `marblerun-key` and `marblerun-cert` respectively, invoked the CLI as follows:
+Assuming the key and certificate have the label `marblerun-key` and `marblerun-cert` respectively, invoke the CLI as follows:
 
 ```bash
 marblerun --pkcs11-config /path/to/pkcs11-config.json --pkcs11-key-label marblerun-key --pkcs11-cert-label marblerun-cert [COMMAND]

--- a/docs/docs/workflows/user-authentication.md
+++ b/docs/docs/workflows/user-authentication.md
@@ -1,32 +1,32 @@
 # User authentication
 
-Some privileged workflows require a user to authenticate themselves to the MarbleRun Coordinator.
+Privileged workflows require a user to authenticate themselves to the MarbleRun Coordinator.
 This is done by first [adding a user to the manifest](./define-manifest.md#users) and then using the certificate and matching private key as TLS client credentials when connecting to the Coordinator.
 
-## File based authentication
+## File-based authentication
 
-With file based authentication, you need to have access to a private key and certificate as PEM formatted files.
+With file-based authentication, you need to have access to a private key and certificate as PEM-formatted files.
 For example, you can generate your credentials using the following `openssl` command:
 
-```sh
+```bash
 openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout admin_private.pem -out admin_certificate.pem
 ```
 
 You can then use these files to authenticate with the MarbleRun Coordinator:
 
-```sh
+```bash
 marblerun --cert admin_certificate.pem --key admin_private.pem [COMMAND]
 ```
 
-## PKCS#11 based authentication
+## PKCS #11-based authentication
 
-MarbleRun's CLI supports authentication with private keys stored in a PKCS#11 compatible device.
-To load client credentials using PKCS#11, a [PKCS#11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config) must be provided, which specifies how to access the PKCS#11 token.
-Additionally, the ID and/or label of the private key and certificate must be provided to the CLI.
+The MarbleRun CLI supports authentication with private keys stored in a PKCS #11-compatible device.
+To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config), which specifies how to access the PKCS #11 token.
+Additionally, you must provide the ID and/or label of the private key and certificate to the CLI.
 
-The PKCS#11 config file is a JSON file that should specify the following fields:
+The PKCS #11 config file is a JSON file that should specify the following fields:
 
-- `Path` (string) - The full path to the PKCS#11 shared library.
+- `Path` (string) - The full path to the PKCS #11 shared library.
 - `Pin` (string) - The PIN (password) to access the token.
 - One of:
   - `TokenSerial` (string) - Serial number of the token to use.
@@ -35,16 +35,16 @@ The PKCS#11 config file is a JSON file that should specify the following fields:
 
 The following shows an example for authenticating with a key and certificate stored in a token with the label `marblerun-token`:
 
-```json5
+```json
 {
-    "Path": "/usr/lib/softhsm/libsofthsm2.so", # Replace with path to your PKCS#11 shared library
+    "Path": "/usr/lib/softhsm/libsofthsm2.so", # Replace with path to your PKCS #11 shared library
     "TokenLabel": "marblerun-token",
     "Pin": "1234" # Replace with your token's actual password
 }
 ```
 
-Assuming the key and certificate have the label `marblerun-key` and `marblerun-cert` respectively, the CLI can be invoked as follows:
+Assuming the key and certificate have the label `marblerun-key` and `marblerun-cert` respectively, invoked the CLI as follows:
 
-```sh
+```bash
 marblerun --pkcs11-config /path/to/pkcs11-config.json --pkcs11-key-label marblerun-key --pkcs11-cert-label marblerun-cert [COMMAND]
 ```

--- a/docs/docs/workflows/user-authentication.md
+++ b/docs/docs/workflows/user-authentication.md
@@ -1,0 +1,50 @@
+# User authentication
+
+Some privileged workflows require a user to authenticate themselves to the MarbleRun Coordinator.
+This is done by first [adding a user to the manifest](./define-manifest.md#users) and then using the certificate and matching private key as TLS client credentials when connecting to the Coordinator.
+
+## File based authentication
+
+With file based authentication, you need to have access to a private key and certificate as PEM formatted files.
+For example, you can generate your credentials using the following `openssl` command:
+
+```sh
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout admin_private.pem -out admin_certificate.pem
+```
+
+You can then use these files to authenticate with the MarbleRun Coordinator:
+
+```sh
+marblerun --cert admin_certificate.pem --key admin_private.pem [COMMAND]
+```
+
+## PKCS#11 based authentication
+
+MarbleRun's CLI supports authentication with private keys stored in a PKCS#11 compatible device.
+To load client credentials using PKCS#11, a [PKCS#11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config) must be provided, which specifies how to access the PKCS#11 token.
+Additionally, the ID and/or label of the private key and certificate must be provided to the CLI.
+
+The PKCS#11 config file is a JSON file that should specify the following fields:
+
+- `Path` (string) - The full path to the PKCS#11 shared library.
+- `Pin` (string) - The PIN (password) to access the token.
+- One of:
+  - `TokenSerial` (string) - Serial number of the token to use.
+  - `TokenLabel` (string) - Label of the token to use.
+  - `SlotNumber` (int) - Number of the slot containing the token to use.
+
+The following shows an example for authenticating with a key and certificate stored in a token with the label `marblerun-token`:
+
+```json5
+{
+    "Path": "/usr/lib/softhsm/libsofthsm2.so", # Replace with path to your PKCS#11 shared library
+    "TokenLabel": "marblerun-token",
+    "Pin": "1234" # Replace with your token's actual password
+}
+```
+
+Assuming the key and certificate have the label `marblerun-key` and `marblerun-cert` respectively, the CLI can be invoked as follows:
+
+```sh
+marblerun --pkcs11-config /path/to/pkcs11-config.json --pkcs11-key-label marblerun-key --pkcs11-cert-label marblerun-cert [COMMAND]
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -162,6 +162,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          label: 'User authentication',
+          id: 'workflows/user-authentication',
+        },
+        {
+          type: 'doc',
           label: 'Update a manifest',
           id: 'workflows/update-manifest',
         },

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/edgelesssys/marblerun
 go 1.23.3
 
 require (
+	github.com/ThalesGroup/crypto11 v1.2.6
 	github.com/cert-manager/cert-manager v1.16.2
 	github.com/edgelesssys/ego v1.6.0
 	github.com/gofrs/flock v0.12.1
@@ -109,6 +110,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
@@ -133,6 +135,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
+	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/Microsoft/hcsshim v0.11.7 h1:vl/nj3Bar/CvJSYo7gIQPyRWc9f3c6IeSNavBTSZ
 github.com/Microsoft/hcsshim v0.11.7/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/ThalesGroup/crypto11 v1.2.6 h1:KixeJpVw3Y9gLSsz393XHh/Pez7q+KBXit4TQebmOz4=
+github.com/ThalesGroup/crypto11 v1.2.6/go.mod h1:Grol7G+6zQdI94hGq+j702L1QFHSlJA5lBLl8uWAhG0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
@@ -270,6 +272,8 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
 github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -378,6 +382,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
+github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=


### PR DESCRIPTION
### Proposed changes
Allow users to authenticate themselves with private keys and certificates stored in a PKCS#11 compatible backend.
This removes the need for storing private keys on disk, and instead manage them in a HSM, YubiKey, or any other PKCS#11 compatible device.
Support is implemented through the [crypto11 library by Thales](https://github.com/ThalesGroup/crypto11).

To initialize the PKCS#11 library, a configuration file with the Token Label/Serial/Slot, Pin of the token, and path to the PKCS#11 library has to be provided.
- Alternatively, we could forgo the need for a config file and instead let users provide flags for token label, pin and library path

Additionally, users have to specify the ID and/or label of the key and certificate stored in the token to use for authentication.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- AB#4683

<!-- (uncomment if applicable)
### Screenshots

-->
