### PR TITLE
cli: align descriptions of `--cert` and `--key` flags

### DIFF
--- a/cli/internal/cmd/cmd.go
+++ b/cli/internal/cmd/cmd.go
@@ -34,8 +34,8 @@ func webhookDNSName(namespace string) string {
 }
 
 func addClientAuthFlags(cmd *cobra.Command, flags *pflag.FlagSet) {
-	flags.StringP("cert", "c", "", "PEM encoded admin certificate file")
-	flags.StringP("key", "k", "", "PEM encoded admin key file")
+	flags.StringP("cert", "c", "", "PEM encoded MarbleRun user certificate file")
+	flags.StringP("key", "k", "", "PEM encoded MarbleRun user key file")
 	cmd.MarkFlagsRequiredTogether("key", "cert")
 
 	flags.String("pkcs11-config", "", "Path to a PKCS#11 configuration file to load the client certificate with")

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -424,9 +424,9 @@ marblerun manifest update apply update-manifest.json $MARBLERUN --cert=admin-cer
 ### Options
 
 ```
-  -c, --cert string                PEM encoded admin certificate file
+  -c, --cert string                PEM encoded MarbleRun user certificate file
   -h, --help                       help for apply
-  -k, --key string                 PEM encoded admin key file
+  -k, --key string                 PEM encoded MarbleRun user key file
       --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
       --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
       --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with
@@ -472,9 +472,9 @@ marblerun manifest update acknowledge update-manifest.json $MARBLERUN --cert=adm
 ### Options
 
 ```
-  -c, --cert string                PEM encoded admin certificate file
+  -c, --cert string                PEM encoded MarbleRun user certificate file
   -h, --help                       help for acknowledge
-  -k, --key string                 PEM encoded admin key file
+  -k, --key string                 PEM encoded MarbleRun user key file
       --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
       --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
       --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with
@@ -516,9 +516,9 @@ marblerun manifest update cancel $MARBLERUN --cert=admin-cert.pem --key=admin-ke
 ### Options
 
 ```
-  -c, --cert string                PEM encoded admin certificate file
+  -c, --cert string                PEM encoded MarbleRun user certificate file
   -h, --help                       help for cancel
-  -k, --key string                 PEM encoded admin key file
+  -k, --key string                 PEM encoded MarbleRun user key file
       --pkcs11-cert-id string      ID of the certificate in the PKCS#11 token
       --pkcs11-cert-label string   Label of the certificate in the PKCS#11 token
       --pkcs11-config string       Path to a PKCS#11 configuration file to load the client certificate with


### PR DESCRIPTION
### Proposed changes
- https://github.com/edgelesssys/marblerun/pull/771 updated the `manifest update` and `secret` commands to use the same function to set up their flags. This ensures they use the same descriptions for their flags. This PR fixes the descriptions of the `--cert` and `--key` flags to refer to a "MarbleRun user" instead of an "admin"

### Additional info
- Supersedes https://github.com/edgelesssys/marblerun/pull/774

