### PR TITLE
Support injection of Coordinator root and intermediate certificates into Marble environment

### DIFF
--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -474,12 +474,12 @@ func TestParseSecrets(t *testing.T) {
 		"emptysecret":       {},
 	}
 
-	testReservedSecrets := reservedSecrets{
+	testReservedSecrets := manifest.ReservedSecrets{
 		RootCA:     manifest.Secret{Public: []byte{0, 0, 42}, Private: []byte{0, 0, 7}},
 		MarbleCert: manifest.Secret{Public: []byte{42, 0, 0}, Private: []byte{7, 0, 0}},
 	}
 
-	testWrappedSecrets := secretsWrapper{
+	testWrappedSecrets := manifest.SecretsWrapper{
 		MarbleRun: testReservedSecrets,
 		Secrets:   testSecrets,
 	}

--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -526,6 +526,12 @@ func (m Manifest) TemplateDryRun(secrets map[string]Secret) error {
 				Public:  []byte{0x41},
 				Private: []byte{0x41},
 			},
+			CoordinatorRoot: Secret{
+				Cert: Certificate{Raw: []byte{0x41}},
+			},
+			CoordinatorIntermediate: Secret{
+				Cert: Certificate{Raw: []byte{0x41}},
+			},
 		},
 	}
 	// make sure templates in file/env declarations can actually be executed
@@ -620,8 +626,10 @@ func (m Manifest) CheckUpdate(originalPackages map[string]quote.PackagePropertie
 
 // ReservedSecrets is a tuple of secrets reserved for a single Marble.
 type ReservedSecrets struct {
-	RootCA     Secret
-	MarbleCert Secret
+	RootCA                  Secret
+	MarbleCert              Secret
+	CoordinatorRoot         Secret
+	CoordinatorIntermediate Secret
 }
 
 // SecretsWrapper is used to define the "MarbleRun" prefix when mentioned in a manifest.

--- a/docs/docs/workflows/define-manifest.md
+++ b/docs/docs/workflows/define-manifest.md
@@ -177,6 +177,8 @@ The following named keys and certificates are always available.
 * `.MarbleRun.RootCA.Cert`: the root certificate of the cluster issued by the Coordinator; this can be used to verify the certificates of all Marbles in the cluster.
 * `.MarbleRun.MarbleCert.Cert`: the Marble's certificate; this is issued by the `.MarbleRun.RootCA.Cert` and is for Marble-to-Marble and Marble-to-client authentication.
 * `.MarbleRun.MarbleCert.Private`: the Marble's private key corresponding to `.MarbleRun.MarbleCert.Cert`
+* `.MarbleRun.CoordinatorRoot.Cert`: the root certificate of the Coordinator; this can be used to verify Marbles in the cluster across multiple manifest updates.
+* `.MarbleRun.CoordinatorIntermediate.Cert`: the intermediate certificate of the Coordinator; see [the public Key infrastructure and certificate authority section](../architecture/security.md#public-key-infrastructure-and-certificate-authority) for more information on how this certificate relates to `.MarbleRun.RootCA`.
 
 Finally, the optional field `MaxActivations` can be used to restrict the number of distinct instances that can be created of a Marble.
 


### PR DESCRIPTION
### Proposed changes
- Support injection of the Coordinator's root and intermediate certificates into a Marble's environment by adding a missing set up step to the manifest templating dry run function
- Add docs on how to inject the Coordinator's root certificate into a Marble's environment
- Clean up duplicated structs in `/coordinator/core/marblerapi.go`

### Additional info
- ~~The same thing can be done for https://github.com/edgelesssys/marblerun/pull/782 to support injecting the Coordinator's intermediate certificate. I can also wait until that PR is merged and then apply the required changes here, so we have them grouped in one PR~~ Added
