### PR TITLE
coordinator: threshold manifest update support

### DIFF
--- a/coordinator/manifest/manifest.go
+++ b/coordinator/manifest/manifest.go
@@ -499,16 +499,17 @@ func (m Manifest) Check(zaplogger *zap.Logger) error {
 		}
 	}
 
-	var manifestUpdaters int
+	var manifestUpdaters uint
 	for _, mrUser := range m.Users {
 		for _, roleName := range mrUser.Roles {
-			if m.Roles[roleName].ResourceType == "Manifest" && strings.ToLower(m.Roles[roleName].Actions[0]) == user.PermissionUpdateManifest {
+			if m.Roles[roleName].ResourceType == "Manifest" && len(m.Roles[roleName].Actions) > 0 &&
+				strings.ToLower(m.Roles[roleName].Actions[0]) == user.PermissionUpdateManifest {
 				manifestUpdaters++
 				break // Avoid counting the same user multiple times if they are assigned more than one role with update permission
 			}
 		}
 	}
-	if manifestUpdaters < int(m.Config.UpdateThreshold) {
+	if manifestUpdaters < m.Config.UpdateThreshold {
 		return fmt.Errorf("not enough users with manifest update permissions (%d) to meet the threshold of %d", manifestUpdaters, m.Config.UpdateThreshold)
 	}
 

--- a/docs/docs/workflows/define-manifest.md
+++ b/docs/docs/workflows/define-manifest.md
@@ -522,6 +522,7 @@ The optional entry `Config` holds configuration settings for the Coordinator.
     "Config":
     {
         "SealMode": "ProductKey",
+        "UpdateThreshold": 5,
         "FeatureGates": []
     }
     //...
@@ -535,6 +536,9 @@ The optional entry `Config` holds configuration settings for the Coordinator.
 * `Disabled`: In single instance mode, the Coordinator won't persist state. This can be useful for ephemeral deployments. For distributed Coordinator mode, this setting is the same as `UniqueKey`.
 
 See the section on [seal key types](../architecture/security.md#seal-key) for more information.
+
+`UpdateThreshold` specifies the number of acknowledgments required for a [multi-party manifest update](./update-manifest.md#full-update).
+If not set, all users with roles that have the `UpdateManifest` action need to acknowledge the update.
 
 `FeatureGates` allows you to opt-in to additional features that may be useful for certain use cases. The following features are available:
 

--- a/docs/docs/workflows/update-manifest.md
+++ b/docs/docs/workflows/update-manifest.md
@@ -54,7 +54,8 @@ Don't define other values except the `SecurityVersion` value for a package, as M
 Some deployment scenarios require more flexibility regarding changes to the manifest. To this end, MarbleRun also allows uploading a full manifest. User-defined secrets and secrets of type `symmetric-key` are retained if their definition doesn't change.
 
 To deploy a new manifest, your user must have a [role assigned that contains the `UpdateManifest` action](define-manifest.md#roles).
-If multiple users have such a role assigned, each of them must [acknowledge](#acknowledging-a-multi-party-update) the new manifest.
+If more than one user have such a role assigned, the manifest field `.Config.UpdateThreshold` specifies how many of them must [acknowledge](#acknowledging-a-multi-party-update) the new manifest.
+If not set, all must acknowledge the new manifest.
 
 ## Deploying an update
 
@@ -68,7 +69,7 @@ On success, no message will be returned and your MarbleRun logs should highlight
 
 ## Acknowledging a multi-party update
 
-All users that have the `UpdateManifest` permission are required to acknowledge a full manifest update.
+Users that have the `UpdateManifest` permission are required to acknowledge a full manifest update.
 To this end, they need to upload the same manifest.
 This proves that they have knowledge of and agree on this manifest.
 


### PR DESCRIPTION
### Proposed changes
- Add a new manifest option `.Config.UpdateThreshold` to control the number of acknowledgements required to perform a full manifest update
  - This allows to define n users with update permission, but only require m users to acknowledge an update before its applied. Where m <= n
  - Can not be higher than the amount of users allowed to update the full manifest
  - If not set (0), all users have to acknowledge the update
