### PR TITLE
coordinator: add debug logging

### DIFF
--- a/cmd/coordinator/enclavemain.go
+++ b/cmd/coordinator/enclavemain.go
@@ -32,7 +32,7 @@ func main() {
 	sealDirPrefix := filepath.Join(filepath.FromSlash("/edg"), "hostfs")
 	sealDir := util.Getenv(constants.SealDir, constants.SealDirDefault())
 	sealDir = filepath.Join(sealDirPrefix, sealDir)
-	sealer := seal.NewAESGCMSealer()
+	sealer := seal.NewAESGCMSealer(log)
 	recovery := recovery.NewSinglePartyRecovery()
 	run(log, validator, issuer, sealDir, sealer, recovery)
 }

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -29,7 +29,7 @@ func main() {
 	validator := quote.NewFailValidator()
 	issuer := quote.NewFailIssuer()
 	sealDir := util.Getenv(constants.SealDir, constants.SealDirDefault())
-	sealer := seal.NewNoEnclaveSealer()
+	sealer := seal.NewNoEnclaveSealer(log)
 	recovery := recovery.NewSinglePartyRecovery()
 	run(log, validator, issuer, sealDir, sealer, recovery)
 }

--- a/cmd/coordinator/run.go
+++ b/cmd/coordinator/run.go
@@ -66,7 +66,7 @@ func run(log *zap.Logger, validator quote.Validator, issuer quote.Issuer, sealDi
 		go server.RunPrometheusServer(promServerAddr, log, promRegistry, eventlog)
 	}
 
-	store := stdstore.New(sealer, afero.NewOsFs(), sealDir)
+	store := stdstore.New(sealer, afero.NewOsFs(), sealDir, log)
 
 	// creating core
 	log.Info("Creating the Core object")

--- a/coordinator/clientapi/clientapi_test.go
+++ b/coordinator/clientapi/clientapi_test.go
@@ -59,7 +59,7 @@ func TestGetCertQuote(t *testing.T) {
 	rootCert, intermediateCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
 
 	prepareDefaultStore := func() store.Store {
-		s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+		s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 		require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorRootCert, rootCert))
 		require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorIntermediateCert, intermediateCert))
 		return s
@@ -114,7 +114,7 @@ func TestGetCertQuote(t *testing.T) {
 		},
 		"root certificate not set": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorIntermediateCert, intermediateCert))
 				return s
 			}(),
@@ -126,7 +126,7 @@ func TestGetCertQuote(t *testing.T) {
 		},
 		"intermediate certificate not set": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, wrapper.New(s).PutCertificate(constants.SKCoordinatorRootCert, rootCert))
 				return s
 			}(),
@@ -186,7 +186,7 @@ func TestGetManifestSignature(t *testing.T) {
 	}{
 		"success": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, s.Put(request.Manifest, []byte("manifest")))
 				require.NoError(t, s.Put(request.ManifestSignature, []byte("signature")))
 				return s
@@ -194,7 +194,7 @@ func TestGetManifestSignature(t *testing.T) {
 		},
 		"GetRawManifest fails": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, s.Put(request.ManifestSignature, []byte("signature")))
 				return s
 			}(),
@@ -202,7 +202,7 @@ func TestGetManifestSignature(t *testing.T) {
 		},
 		"GetManifestSignature fails": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, s.Put(request.Manifest, []byte("manifest")))
 				return s
 			}(),
@@ -255,7 +255,7 @@ func TestGetSecrets(t *testing.T) {
 	}{
 		"success": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
 					Type:    manifest.SecretTypePlain,
 					Private: []byte("secret"),
@@ -275,7 +275,7 @@ func TestGetSecrets(t *testing.T) {
 		},
 		"wrong state": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
 					Type:    manifest.SecretTypePlain,
 					Private: []byte("secret"),
@@ -296,7 +296,7 @@ func TestGetSecrets(t *testing.T) {
 		},
 		"user is missing permissions": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
 					Type:    manifest.SecretTypePlain,
 					Private: []byte("secret"),
@@ -317,7 +317,7 @@ func TestGetSecrets(t *testing.T) {
 		},
 		"secret does not exist": {
 			store: func() store.Store {
-				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+				s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 				require.NoError(t, wrapper.New(s).PutSecret("secret1", manifest.Secret{
 					Type:    manifest.SecretTypePlain,
 					Private: []byte("secret"),
@@ -410,7 +410,7 @@ func TestRecover(t *testing.T) {
 	someErr := errors.New("failed")
 	_, rootCert := test.MustSetupTestCerts(test.RecoveryPrivateKey)
 	defaultStore := func() store.Store {
-		s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+		s := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 		wr := wrapper.New(s)
 		require.NoError(t, wr.PutCertificate(constants.SKCoordinatorRootCert, rootCert))
 		require.NoError(t, wr.PutRawManifest([]byte(`{}`)))
@@ -500,7 +500,7 @@ func TestRecover(t *testing.T) {
 		},
 		"GetCertificate fails": {
 			store: &fakeStore{
-				store: stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), ""),
+				store: stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t)),
 			},
 			recovery: &stubRecovery{},
 			core: &fakeCore{

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -616,8 +616,8 @@ func setupAPI(t *testing.T) (*ClientAPI, wrapper.Wrapper) {
 	t.Helper()
 	require := require.New(t)
 
-	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
 	log := zaptest.NewLogger(t)
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", log)
 
 	wrapper := wrapper.New(store)
 

--- a/coordinator/constants/constants.go
+++ b/coordinator/constants/constants.go
@@ -59,6 +59,11 @@ const (
 	// DevModeDefault is the default logging mode.
 	DevModeDefault = "0"
 
+	// DebugLogging enables debug logs.
+	DebugLogging = "EDG_DEBUG_LOGGING"
+	// DebugLoggingDefault is the default value to use when the [DebugLogging] env variable is not set.
+	DebugLoggingDefault = "0"
+
 	// StartupManifest is a path to a manifest to start with instead of waiting for a manifest from the api.
 	StartupManifest = "EDG_STARTUP_MANIFEST"
 )

--- a/coordinator/core/certificate_test.go
+++ b/coordinator/core/certificate_test.go
@@ -47,7 +47,7 @@ func TestCertificateVerify(t *testing.T) {
 	// create core
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
-	stor := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	stor := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zapLogger)
 	recovery := recovery.NewSinglePartyRecovery()
 	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stor, recovery, zapLogger, nil, nil)
 	require.NoError(err)

--- a/coordinator/core/core_test.go
+++ b/coordinator/core/core_test.go
@@ -71,7 +71,7 @@ func TestSeal(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
 
-	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 
 	// Set manifest. This will seal the state.
@@ -89,7 +89,7 @@ func TestSeal(t *testing.T) {
 	cSecrets := testutil.GetSecretMap(t, c.txHandle)
 
 	// Check sealing with a new core initialized with the sealed state.
-	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	clientAPI, err = clientapi.New(c2.txHandle, c2.recovery, c2, zapLogger)
 	require.NoError(err)
@@ -125,7 +125,7 @@ func TestRecover(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
 
-	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	clientAPI, err := clientapi.New(c.txHandle, c.recovery, c, zapLogger)
 	require.NoError(err)
@@ -145,7 +145,7 @@ func TestRecover(t *testing.T) {
 
 	// Initialize new core and let unseal fail
 	sealer.UnsealError = &seal.EncryptionKeyError{}
-	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	sealer.UnsealError = nil
 	require.NoError(err)
 	clientAPI, err = clientapi.New(c2.txHandle, c2.recovery, c2, zapLogger)
@@ -304,14 +304,14 @@ func TestUnsetRestart(t *testing.T) {
 	recovery := recovery.NewSinglePartyRecovery()
 
 	// create a new core, this seals the state with only certificate and keys
-	c1, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	c1, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	c1State := testutil.GetState(t, c1.txHandle)
 	assert.Equal(state.AcceptingManifest, c1State)
 	cCert := testutil.GetCertificate(t, c1.txHandle, constants.SKCoordinatorRootCert)
 
 	// create a second core, this should overwrite the previously sealed certificate and keys since no manifest was set
-	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	c2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	c2State := testutil.GetState(t, c2.txHandle)
 	assert.Equal(state.AcceptingManifest, c2State)

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -59,7 +59,7 @@ func TestActivate(t *testing.T) {
 	sealer := &seal.MockSealer{}
 	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -153,7 +153,7 @@ func TestMarbleSecretDerivation(t *testing.T) {
 	sealer := &seal.MockSealer{}
 	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -584,7 +584,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	sealer := &seal.MockSealer{}
 	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -615,7 +615,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	spawner.newMarble(t, "frontend", "Azure", uuid.New(), false)
 
 	// Use a new core and test if updated manifest persisted after restart
-	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	coreServer2, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	coreServer2State := testutil.GetState(t, coreServer2.txHandle)
 	coreServer2UpdatedPkg := testutil.GetPackage(t, coreServer2.txHandle, "frontend")
@@ -691,7 +691,7 @@ func TestActivateWithMissingParameters(t *testing.T) {
 	sealer := &seal.MockSealer{}
 	fs := afero.NewMemMapFs()
 	recovery := recovery.NewSinglePartyRecovery()
-	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, nil, nil)
+	coreServer, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, nil, nil)
 	require.NoError(err)
 	require.NotNil(coreServer)
 
@@ -718,10 +718,11 @@ func TestActivateWithTTLSforMarbleWithoutEnvVars(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
+	log := zaptest.NewLogger(t)
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
-	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
-	coreServer, err := NewCore(nil, validator, issuer, store, recovery.NewSinglePartyRecovery(), zaptest.NewLogger(t), nil, nil)
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", log)
+	coreServer, err := NewCore(nil, validator, issuer, store, recovery.NewSinglePartyRecovery(), log, nil, nil)
 	require.NoError(err)
 
 	clientAPI, err := clientapi.New(coreServer.txHandle, coreServer.recovery, coreServer, coreServer.log)

--- a/coordinator/core/metrics_test.go
+++ b/coordinator/core/metrics_test.go
@@ -47,7 +47,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	//
 	reg := prometheus.NewRegistry()
 	fac := promauto.With(reg)
-	c, _ := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, &fac, nil)
+	c, _ := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, &fac, nil)
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
 	assert.Equal(float64(state.AcceptingManifest), promtest.ToFloat64(c.metrics.coordinatorState))
 
@@ -64,7 +64,7 @@ func TestStoreWrapperMetrics(t *testing.T) {
 	reg = prometheus.NewRegistry()
 	fac = promauto.With(reg)
 	sealer.UnsealError = &seal.EncryptionKeyError{}
-	c, err = NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, ""), recovery, zapLogger, &fac, nil)
+	c, err = NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, fs, "", zapLogger), recovery, zapLogger, &fac, nil)
 	sealer.UnsealError = nil
 	require.NoError(err)
 	assert.Equal(1, promtest.CollectAndCount(c.metrics.coordinatorState))
@@ -98,7 +98,7 @@ func TestMarbleAPIMetrics(t *testing.T) {
 	recovery := recovery.NewSinglePartyRecovery()
 	promRegistry := prometheus.NewRegistry()
 	promFactory := promauto.With(promRegistry)
-	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, afero.NewMemMapFs(), ""), recovery, zapLogger, &promFactory, nil)
+	c, err := NewCore([]string{"localhost"}, validator, issuer, stdstore.New(sealer, afero.NewMemMapFs(), "", zapLogger), recovery, zapLogger, &promFactory, nil)
 	require.NoError(err)
 	require.NotNil(c)
 

--- a/coordinator/seal/noenclavesealer.go
+++ b/coordinator/seal/noenclavesealer.go
@@ -10,22 +10,26 @@ import (
 	"fmt"
 
 	"github.com/edgelesssys/ego/ecrypto"
+	"go.uber.org/zap"
 )
 
 // NoEnclaveSealer is a sealer for a -noenclave instance and performs encryption with a fixed key.
 type NoEnclaveSealer struct {
 	encryptionKey []byte
+	log           *zap.Logger
 }
 
 // NewNoEnclaveSealer creates and initializes a new NoEnclaveSealer object.
-func NewNoEnclaveSealer() *NoEnclaveSealer {
-	return &NoEnclaveSealer{}
+func NewNoEnclaveSealer(log *zap.Logger) *NoEnclaveSealer {
+	return &NoEnclaveSealer{
+		log: log,
+	}
 }
 
 // Unseal decrypts sealedData and returns the decrypted data,
 // as well as the prefixed unencrypted metadata of the cipher text.
 func (s *NoEnclaveSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
-	unencryptedData, cipherText, err := prepareCipherText(sealedData)
+	unencryptedData, cipherText, err := prepareCipherText(sealedData, s.log)
 	if err != nil {
 		return unencryptedData, nil, err
 	}
@@ -45,7 +49,7 @@ func (s *NoEnclaveSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
 
 // Seal encrypts the given data using the sealer's key.
 func (s *NoEnclaveSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte, error) {
-	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey)
+	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey, s.log)
 }
 
 // SealEncryptionKey implements the Sealer interface.

--- a/coordinator/seal/seal.go
+++ b/coordinator/seal/seal.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/edgelesssys/ego/ecrypto"
+	"go.uber.org/zap"
 )
 
 // EncryptionKeyError occurs if the encryption key cannot be unsealed.
@@ -49,17 +50,20 @@ type Sealer interface {
 // AESGCMSealer implements the Sealer interface using AES-GCM for confidentiality and authentication.
 type AESGCMSealer struct {
 	encryptionKey []byte
+	log           *zap.Logger
 }
 
 // NewAESGCMSealer creates and initializes a new AESGCMSealer object.
-func NewAESGCMSealer() *AESGCMSealer {
-	return &AESGCMSealer{}
+func NewAESGCMSealer(log *zap.Logger) *AESGCMSealer {
+	return &AESGCMSealer{
+		log: log,
+	}
 }
 
 // Unseal decrypts sealedData and returns the decrypted data,
 // as well as the prefixed unencrypted metadata of the cipher text.
 func (s *AESGCMSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
-	unencryptedData, cipherText, err := prepareCipherText(sealedData)
+	unencryptedData, cipherText, err := prepareCipherText(sealedData, s.log)
 	if err != nil {
 		return unencryptedData, nil, err
 	}
@@ -79,15 +83,17 @@ func (s *AESGCMSealer) Unseal(sealedData []byte) ([]byte, []byte, error) {
 
 // Seal encrypts and stores information to the fs.
 func (s *AESGCMSealer) Seal(unencryptedData []byte, toBeEncrypted []byte) ([]byte, error) {
-	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey)
+	return sealData(unencryptedData, toBeEncrypted, s.encryptionKey, s.log)
 }
 
 // SealEncryptionKey seals an encryption key with the selected enclave key.
 func (s *AESGCMSealer) SealEncryptionKey(encryptionKey []byte, mode Mode) ([]byte, error) {
 	switch mode {
 	case ModeProductKey:
+		s.log.Debug("Sealing encryption key with product key")
 		return ecrypto.SealWithProductKey(encryptionKey, nil)
 	case ModeUniqueKey:
+		s.log.Debug("Sealing encryption key with unique key")
 		return ecrypto.SealWithUniqueKey(encryptionKey, nil)
 	}
 	return nil, errors.New("sealing is disabled")
@@ -123,13 +129,15 @@ func GenerateEncryptionKey() ([]byte, error) {
 
 // prepareCipherText validates format of the given sealed data.
 // It returns the unencrypted metadata and the cipher text.
-func prepareCipherText(sealedData []byte) (unencryptedData []byte, cipherText []byte, err error) {
+func prepareCipherText(sealedData []byte, log *zap.Logger) (unencryptedData []byte, cipherText []byte, err error) {
+	log.Debug("Preparing cipher text for unsealing", zap.Int("sealedDataLength", len(sealedData)))
 	if len(sealedData) <= 4 {
 		return nil, nil, errors.New("sealed state is missing data")
 	}
 
 	// Retrieve recovery secret hash map
 	encodedUnencryptedDataLength := binary.LittleEndian.Uint32(sealedData[:4])
+	log.Debug("Checking encoded unencrypted data", zap.Uint32("length", encodedUnencryptedDataLength))
 
 	// Check if we do not go out of bounds
 	if 4+encodedUnencryptedDataLength > uint32(len(sealedData)) {
@@ -140,6 +148,7 @@ func prepareCipherText(sealedData []byte) (unencryptedData []byte, cipherText []
 		unencryptedData = sealedData[4 : 4+encodedUnencryptedDataLength]
 	}
 	cipherText = sealedData[4+encodedUnencryptedDataLength:]
+	log.Debug("Cipher text is ready for unsealing", zap.Binary("unencryptedData", unencryptedData))
 
 	return unencryptedData, cipherText, nil
 }
@@ -148,7 +157,8 @@ func prepareCipherText(sealedData []byte) (unencryptedData []byte, cipherText []
 // It returns the encrypted data prefixed with the unencrypted data and it's length.
 //
 // Format: uint32(littleEndian(len(unencryptedData))) || unencryptedData || encrypt(toBeEncrypted).
-func sealData(unencryptedData, toBeEncrypted, encryptionKey []byte) ([]byte, error) {
+func sealData(unencryptedData, toBeEncrypted, encryptionKey []byte, log *zap.Logger) ([]byte, error) {
+	log.Debug("Preparing to seal data", zap.Binary("unencryptedData", unencryptedData))
 	if encryptionKey == nil {
 		return nil, fmt.Errorf("encrypting data: %w", ErrMissingEncryptionKey)
 	}
@@ -166,5 +176,6 @@ func sealData(unencryptedData, toBeEncrypted, encryptionKey []byte) ([]byte, err
 	// Append unencrypted data with encrypted data
 	encryptedData = append(unencryptedData, encryptedData...)
 
+	log.Debug("Data sealing completed")
 	return encryptedData, nil
 }

--- a/coordinator/seal/seal_test.go
+++ b/coordinator/seal/seal_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestPrepareCipherText(t *testing.T) {
@@ -66,7 +67,7 @@ func TestPrepareCipherText(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			_, _, err := prepareCipherText(tc.sealedData)
+			_, _, err := prepareCipherText(tc.sealedData, zaptest.NewLogger(t))
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
@@ -118,7 +119,7 @@ func TestSealUnseal(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			sealer := NewAESGCMSealer()
+			sealer := NewAESGCMSealer(zaptest.NewLogger(t))
 
 			sealer.encryptionKey = tc.encryptionKey
 			sealedData, err := sealer.Seal(tc.metadata, tc.data)

--- a/coordinator/server/metrics_test.go
+++ b/coordinator/server/metrics_test.go
@@ -92,7 +92,7 @@ func newTestClientAPI(t *testing.T) *clientapi.ClientAPI {
 
 	validator := quote.NewMockValidator()
 	issuer := quote.NewMockIssuer()
-	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", log)
 	recovery := recovery.NewSinglePartyRecovery()
 	core, err := core.NewCore([]string{"localhost"}, validator, issuer, store, recovery, log, nil, nil)
 	require.NoError(err)

--- a/coordinator/store/stdstore/stdstore_test.go
+++ b/coordinator/store/stdstore/stdstore_test.go
@@ -15,13 +15,14 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestStdStore(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	str := New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	str := New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 	_, err := str.LoadState()
 	assert.NoError(err)
 
@@ -56,7 +57,7 @@ func TestStdIterator(t *testing.T) {
 	assert := assert.New(t)
 
 	sealer := &seal.MockSealer{}
-	store := New(sealer, afero.NewMemMapFs(), "")
+	store := New(sealer, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 	store.data = map[string][]byte{
 		"test:1":    {0x00, 0x11},
 		"test:2":    {0x00, 0x11},
@@ -123,7 +124,7 @@ func TestStdStoreSealing(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			sealer := &seal.MockSealer{}
 
-			store := New(sealer, fs, "")
+			store := New(sealer, fs, "", zaptest.NewLogger(t))
 			_, err := store.LoadState()
 			require.NoError(err)
 
@@ -133,7 +134,7 @@ func TestStdStoreSealing(t *testing.T) {
 			require.NoError(store.Put("test:input", testData1))
 
 			// Check sealing with a new store initialized with the sealed state
-			store2 := New(sealer, fs, "")
+			store2 := New(sealer, fs, "", zaptest.NewLogger(t))
 			_, err = store2.LoadState()
 			require.NoError(err)
 			val, err := store2.Get("test:input")
@@ -152,7 +153,7 @@ func TestStdStoreRollback(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	store := New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	store := New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 	_, err := store.LoadState()
 	assert.NoError(err)
 
@@ -199,7 +200,7 @@ func TestStdStoreRollback(t *testing.T) {
 func TestStdStoreDelete(t *testing.T) {
 	assert := assert.New(t)
 
-	str := New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	str := New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 
 	inputName := "test:input"
 	inputData := []byte("test data")

--- a/coordinator/store/wrapper/wrapper_test.go
+++ b/coordinator/store/wrapper/wrapper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestMain(m *testing.M) {
@@ -34,7 +35,7 @@ func TestStoreWrapper(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	store := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 	rawManifest := []byte(test.ManifestJSON)
 	curState := state.AcceptingManifest
 	testSecret := manifest.Secret{
@@ -87,7 +88,7 @@ func TestStoreWrapperRollback(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 
-	stor := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "")
+	stor := stdstore.New(&seal.MockSealer{}, afero.NewMemMapFs(), "", zaptest.NewLogger(t))
 	data := New(stor)
 
 	startingState := state.AcceptingManifest

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -23,10 +23,16 @@ func New() (*zap.Logger, error) {
 		cfg = zap.NewProductionConfig()
 		cfg.DisableStacktrace = true // Disable stacktraces in production
 	}
+
+	if util.Getenv(constants.DebugLogging, constants.DebugLoggingDefault) == "1" {
+		cfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	}
+
 	log, err := cfg.Build()
 	if err != nil {
 		return nil, err
 	}
+	log.Debug("Debug logging enabled")
 	return log, nil
 }
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -144,6 +144,7 @@ func (i IntegrationTest) StartCoordinator(ctx context.Context, cfg CoordinatorCo
 		MakeEnv(constants.ClientAddr, i.ClientServerAddr),
 		MakeEnv(constants.DNSNames, cfg.dnsNames),
 		MakeEnv(constants.SealDir, cfg.sealDir),
+		MakeEnv(constants.DebugLogging, "1"),
 		i.SimulationFlag,
 	}
 	cmd.Env = append(cmd.Env, cfg.extraEnv...)


### PR DESCRIPTION
### Proposed changes
- Add debug logging for Coordinator internals
  - Can be enabled by setting the `EDG_DEBUG_LOGGING` environment variable to `1` 


