### PR TITLE
coordinator: remove obsolete GetRecoveryData

### DIFF
--- a/coordinator/clientapi/clientapi.go
+++ b/coordinator/clientapi/clientapi.go
@@ -638,13 +638,6 @@ func (a *ClientAPI) UpdateManifest(ctx context.Context, rawUpdateManifest []byte
 		return fmt.Errorf("regenerating shared secrets for updated manifest: %w", err)
 	}
 
-	// Retrieve current recovery data before we seal the state again
-	currentRecoveryData, err := a.recovery.GetRecoveryData()
-	if err != nil {
-		a.log.Error("Could not retrieve the current recovery data from the recovery module. Cannot reseal the state, the update manifest will not be applied.")
-		return fmt.Errorf("retrieving current recovery data: %w", err)
-	}
-
 	a.updateLog.Reset()
 	for pkgName, pkg := range updateManifest.Packages {
 		a.updateLog.Info("SecurityVersion increased", zap.String("user", updater.Name()), zap.String("package", pkgName), zap.Uint("new version", *pkg.SecurityVersion))
@@ -679,7 +672,6 @@ func (a *ClientAPI) UpdateManifest(ctx context.Context, rawUpdateManifest []byte
 	a.log.Info("An update manifest overriding package settings from the original manifest was set.")
 	a.log.Info("Please restart your Marbles to enforce the update.")
 
-	a.txHandle.SetRecoveryData(currentRecoveryData)
 	if err := commit(ctx); err != nil {
 		return fmt.Errorf("updating manifest failed: committing store transaction: %w", err)
 	}

--- a/coordinator/recovery/recovery.go
+++ b/coordinator/recovery/recovery.go
@@ -19,7 +19,6 @@ type Recovery interface {
 	GenerateEncryptionKey(recoveryKeys map[string]string) ([]byte, error)
 	GenerateRecoveryData(recoveryKeys map[string]string) (map[string][]byte, []byte, error)
 	RecoverKey(secret []byte) (int, []byte, error)
-	GetRecoveryData() ([]byte, error)
 	SetRecoveryData(data []byte) error
 }
 

--- a/coordinator/recovery/single.go
+++ b/coordinator/recovery/single.go
@@ -64,11 +64,6 @@ func (r *SinglePartyRecovery) RecoverKey(secret []byte) (int, []byte, error) {
 	return 0, secret, nil
 }
 
-// GetRecoveryData returns the current recovery hash map. Given that we do not need to store any additional data in the state for Single Party Recovery, it does nothing here.
-func (r *SinglePartyRecovery) GetRecoveryData() ([]byte, error) {
-	return nil, nil
-}
-
 // SetRecoveryData sets the recovery hash map retrieved from the sealer on (failed) decryption. Given that we do not need to store any additional data in the state for Single Party Recovery, it does nothing here.
 func (r *SinglePartyRecovery) SetRecoveryData(_ []byte) error {
 	return nil


### PR DESCRIPTION
In UpdateManifest, the recovery data is read from the recovery object and later set on the store. This is not required. It seems to be a leftover from when the func directly called sealState on the store, which expected the recovery data as an argument (https://github.com/edgelesssys/marblerun/commit/649b47676175686dc57fd34288ef451288d7fd77#diff-c9d54b7fdb3156de2d7b059657402c439b0065ae9bdd6d0b294edc4a6d6b2f40L293).

Furthermore, this behavior can be destructive in cases where recovery and store are not in sync. This shouldn't happen, but may be caused in edge cases, for example, if you start with multiparty recovery and later accidentally rerun with singleparty recovery. (But fixing this is just best effort. We don't support switching enterprise features after deployment.)

### Proposed changes
- Remove copying recovery data from Recovery to store in UpdateManifest
- Remove GetRecoveryData from Recovery to not encourage letting the data flow in this direction