### PR TITLE
cli: fix certificate command errors when `--insecure` flag is set

### DIFF
--- a/cli/internal/cmd/certificate.go
+++ b/cli/internal/cmd/certificate.go
@@ -58,7 +58,9 @@ func runCertificate(saveCert func(writer io.Writer, fh *file.Handler, root, inte
 			return err
 		}
 
-		if !remoteRootCert.Equal(rootCert) {
+		// Skip this check if we're accepting insecure connections
+		// because we don't load the certificate in that case.
+		if !remoteRootCert.Equal(rootCert) && !verifyOpts.InsecureSkipVerify {
 			return errors.New("root certificate of Coordinator changed. Run 'marblerun manifest verify' to verify the instance and update the local cache")
 		}
 


### PR DESCRIPTION
### Proposed changes
The `marblerun certificate` commands check the remote coordinator's root certificate against the certificate cached on the local system. In case the `--insecure` flag is set, the cached certificate is not loaded, resulting in a comparison of the remote cert against `nil`. 
- Don't compare the certificates in case the `--insecure` flag is set. 
