### PR TITLE
charts: allow configuration of Coordinator PVC size through helm values file

### DIFF
--- a/charts/templates/coordinator.yaml
+++ b/charts/templates/coordinator.yaml
@@ -121,7 +121,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Mi
+      storage: {{ .Values.coordinator.storageSize }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 # Values that are passed along to sub-charts
 global:
   # Additional annotations to add to all pods
@@ -21,7 +20,6 @@ global:
   #  Registry secrets are applied to the respective service accounts
   # pullSecret:
   # pullSecret: my-private-docker-registry-login-secret
-
 
 # webhook configuration
 marbleInjector:
@@ -53,7 +51,6 @@ marbleInjector:
   # See: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # Customize to limit injection to specific namespaces
   namespaceSelector: {}
-
 
 # coordinator configuration
 coordinator:
@@ -105,10 +102,14 @@ coordinator:
   # Set the storage class to use for creating the Coordinator's PVC
   # Leave empty to use the default storage class
   storageClass: ""
+
+  # Set the storage size for the Coordinator's PVC
+  # The Coordinator requires a minimum of 10Mi but some storageClasses don't allow such small sizes
+  storageSize: "10Mi"
+
   # Set to use an existing PVC for Coordinator storage
   # Leave empty to create a new one using the configured storage class
   pvcName: ""
-
 
 # Tolerations constraints for control-plane components
 # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/


### PR DESCRIPTION
### Proposed changes
- Some storage backends such as NetApp Trident technically only allow volumes bigger than 20Mi. We instead deploy a separate claim now that we use in the marblerun chart. As a little UX improvement I propose that we allow setting the pvc size via the values.yaml file

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
