### PR TITLE
cli: accept both PKCS#8 and PKCS#1 private keys for recovery

### DIFF
--- a/cli/internal/cmd/recover.go
+++ b/cli/internal/cmd/recover.go
@@ -129,7 +129,7 @@ func getRecoveryKeySigner(cmd *cobra.Command, fs afero.Afero) (pkcs11.SignerDecr
 		var pkcs1Err error
 		privK, pkcs1Err = x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
 		if pkcs1Err != nil {
-			return nil, nil, fmt.Errorf("failed to parse private key: tried PKCS #1 format: %w, tried PKCS #8 format: %w", pkcs1Err, err)
+			return nil, nil, fmt.Errorf("parsing private key: tried PKCS #1 format: %w, tried PKCS #8 format: %w", pkcs1Err, err)
 		}
 	}
 	signer, ok := privK.(pkcs11.SignerDecrypter)

--- a/cli/internal/cmd/recover_test.go
+++ b/cli/internal/cmd/recover_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRecoveryKeySigner(t *testing.T) {
+	testCases := map[string]struct {
+		keyFlag string
+		fs      afero.Fs
+		wantErr bool
+	}{
+		"PKCS #8 key": {
+			keyFlag: "private.pem",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+				privRaw, err := x509.MarshalPKCS8PrivateKey(privKey)
+				require.NoError(t, err)
+				privPEM := pem.EncodeToMemory(&pem.Block{
+					Type:  "PRIVATE KEY",
+					Bytes: privRaw,
+				})
+				require.NoError(t, afero.WriteFile(fs, "private.pem", privPEM, 0o644))
+				return fs
+			}(),
+		},
+		"PKCS #1 key": {
+			keyFlag: "private.pem",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+				privRaw := x509.MarshalPKCS1PrivateKey(privKey)
+				privPEM := pem.EncodeToMemory(&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: privRaw,
+				})
+				require.NoError(t, afero.WriteFile(fs, "private.pem", privPEM, 0o644))
+				return fs
+			}(),
+		},
+		"no key file": {
+			keyFlag: "private.pem",
+			fs:      afero.NewMemMapFs(),
+			wantErr: true,
+		},
+		"invalid key file": {
+			keyFlag: "private.pem",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				require.NoError(t, afero.WriteFile(fs, "private.pem", []byte("invalid"), 0o644))
+				return fs
+			}(),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			cmd := NewRecoverCmd()
+			require.NoError(t, cmd.Flags().Set("key", tc.keyFlag))
+
+			signer, cancel, err := getRecoveryKeySigner(cmd, afero.Afero{Fs: tc.fs})
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.NotNil(signer)
+			assert.NotNil(cancel)
+			assert.NoError(cancel())
+		})
+	}
+}

--- a/docs/versioned_docs/version-1.7/workflows/recover-coordinator.md
+++ b/docs/versioned_docs/version-1.7/workflows/recover-coordinator.md
@@ -34,7 +34,7 @@ MarbleRun requires the key to be in PKCS #8 format.
 Use the following command to convert the key:
 
 ```bash
-openssl pkcs8 -topk8 -inform PEM -outform PEM -in private_key.pem -out private_key_pkcs8.pem -nocrypt
+openssl pkcs8 -topk8 -in private_key.pem -out private_key_pkcs8.pem -nocrypt
 ```
 
 :::

--- a/docs/versioned_docs/version-1.7/workflows/recover-coordinator.md
+++ b/docs/versioned_docs/version-1.7/workflows/recover-coordinator.md
@@ -26,6 +26,19 @@ Assuming you named your recovery key `recoverKey1` in the manifest, and you save
 jq -r '.RecoverySecrets.recoverKey1' recovery_data | openssl base64 -d > recovery_key_encrypted
 ```
 
+:::caution
+
+If you generated the private recovery key using `openssl` version 1, the key will be in PKCS #1 format.
+MarbleRun requires the key to be in PKCS #8 format.
+
+Use the following command to convert the key:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in private_key.pem -out private_key_pkcs8.pem -nocrypt
+```
+
+:::
+
 Then decrypt and upload the extracted secret using the MarbleRun CLI:
 
 ```bash


### PR DESCRIPTION
### Proposed changes
- accept both PKCS#8 and PKCS#1 private keys for `marblerun recover`
- add a hint to the v1.7 docs about the CLI requiring PKCS#8 keys

