### PR TITLE
cli: report accurate number of missing acknowledgements and users on update

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -311,21 +311,23 @@ func ManifestUpdateGet(ctx context.Context, endpoint string, trustedRoot *x509.C
 
 // ManifestUpdateAcknowledge acknowledges the pending manifest update of a MarbleRun deployment.
 // On success, it returns the number of remaining acknowledgements before the update is applied.
-func ManifestUpdateAcknowledge(ctx context.Context, endpoint string, trustedRoot *x509.Certificate, updateManifest []byte, clientKeyPair *tls.Certificate) (missingUsers []string, err error) {
+func ManifestUpdateAcknowledge(
+	ctx context.Context, endpoint string, trustedRoot *x509.Certificate, updateManifest []byte, clientKeyPair *tls.Certificate,
+) (missingUsers []string, missingAcknowledgements int, err error) {
 	client, err := rest.NewClient(endpoint, trustedRoot, clientKeyPair)
 	if err != nil {
-		return nil, fmt.Errorf("setting up client: %w", err)
+		return nil, -1, fmt.Errorf("setting up client: %w", err)
 	}
 
 	// Attempt to acknowledge the update using the v2 API first
-	missingUsers, err = manifestUpdateAcknowledgeV2(ctx, client, updateManifest)
+	missingUsers, missingAcknowledgements, err = manifestUpdateAcknowledgeV2(ctx, client, updateManifest)
 	if rest.IsNotAllowedErr(err) {
-		missingUsers, err = manifestUpdateAcknowledgeV1(ctx, client, updateManifest)
+		missingUsers, missingAcknowledgements, err = manifestUpdateAcknowledgeV1(ctx, client, updateManifest)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("sending manifest update acknowledgement: %w", err)
+		return nil, -1, fmt.Errorf("sending manifest update acknowledgement: %w", err)
 	}
-	return missingUsers, err
+	return missingUsers, missingAcknowledgements, err
 }
 
 // ManifestUpdateCancel cancels a pending manifest update of a MarbleRun deployment.

--- a/api/v1.go
+++ b/api/v1.go
@@ -83,26 +83,26 @@ func manifestUpdateApplyV1(ctx context.Context, client *rest.Client, manifest []
 }
 
 // manifestUpdateAcknowledgeV1 acknowledges an update manifest using the legacy v1 API.
-func manifestUpdateAcknowledgeV1(ctx context.Context, client *rest.Client, updateManifest []byte) (missingUsers []string, err error) {
+func manifestUpdateAcknowledgeV1(ctx context.Context, client *rest.Client, updateManifest []byte) (missingUsers []string, missingAcknowledgements int, err error) {
 	resp, err := client.Post(ctx, rest.UpdateStatusEndpoint, rest.ContentJSON, bytes.NewReader(updateManifest))
 	if err != nil {
-		return nil, err
+		return nil, -1, err
 	}
 
 	missing, _, _ := strings.Cut(string(resp), " ")
 	if missing == "All" {
-		return nil, nil
+		return nil, 0, nil
 	}
 	numMissing, err := strconv.Atoi(missing)
 	if err != nil {
-		return nil, fmt.Errorf("parsing number of missing users: %w", err)
+		return nil, -1, fmt.Errorf("parsing number of missing users: %w", err)
 	}
 
 	for i := 0; i < numMissing; i++ {
 		missingUsers = append(missingUsers, fmt.Sprintf("User%d", i))
 	}
 
-	return missingUsers, nil
+	return missingUsers, numMissing, nil
 }
 
 // secretGetV1 requests secrets from the Coordinator using the legacy v1 API.

--- a/cli/internal/cmd/manifestUpdate.go
+++ b/cli/internal/cmd/manifestUpdate.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/edgelesssys/marblerun/api"
 	"github.com/edgelesssys/marblerun/cli/internal/certcache"
@@ -152,20 +153,22 @@ func runUpdateAcknowledge(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	missing, err := api.ManifestUpdateAcknowledge(cmd.Context(), hostname, root, manifest, keyPair)
+	missingUsers, missingAcks, err := api.ManifestUpdateAcknowledge(cmd.Context(), hostname, root, manifest, keyPair)
 	if err != nil {
 		return fmt.Errorf("acknowledging update manifest: %w", err)
 	}
 
 	cmd.Println("Acknowledgement successful:")
-	switch len(missing) {
+	var msg string
+	switch missingAcks {
 	case 0:
-		cmd.Println("All users have acknowledged the update manifest. Update successfully applied")
+		msg = "All users have acknowledged the update manifest. Update successfully applied"
 	case 1:
-		cmd.Println("1 user still needs to acknowledge the update manifest")
+		msg = fmt.Sprintf("1 user still needs to acknowledge the update manifest.\nThe following users have not yet accepted: %s", strings.Join(missingUsers, ", "))
 	default:
-		cmd.Printf("%d users still need to acknowledge the update manifest", len(missing))
+		msg = fmt.Sprintf("%d users still need to acknowledge the update manifest.\nThe following users have not yet accepted: %s", missingAcks, strings.Join(missingUsers, ", "))
 	}
+	cmd.Println(msg)
 	return nil
 }
 

--- a/cli/internal/cmd/manifestUpdate.go
+++ b/cli/internal/cmd/manifestUpdate.go
@@ -122,10 +122,29 @@ func runUpdateApply(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := api.ManifestUpdateApply(cmd.Context(), hostname, root, manifest, keyPair); err != nil {
+	missingUsers, missingAcks, err := api.ManifestUpdateApply(cmd.Context(), hostname, root, manifest, keyPair)
+	if err != nil {
 		return fmt.Errorf("applying update: %w", err)
 	}
-	cmd.Println("Update manifest set successfully")
+
+	var msg string
+	switch missingAcks {
+	case 0:
+		msg = "Update manifest set successfully"
+	case 1:
+		msg = fmt.Sprintf(
+			"Update manifest submitted successfully.\nChanges are pending and have not been applied yet.\n"+
+				"1 user still needs to acknowledge the update manifest.\nThe following users may acknowledge the update: %s",
+			strings.Join(missingUsers, ", "),
+		)
+	default:
+		msg = fmt.Sprintf(
+			"Update manifest submitted successfully.\nChanges are pending and have not been applied yet.\n"+
+				"%d users still need to acknowledge the update manifest.\nThe following users may acknowledge the update: %s",
+			missingAcks, strings.Join(missingUsers, ", "),
+		)
+	}
+	cmd.Println(msg)
 	return nil
 }
 

--- a/coordinator/clientapi/legacy_test.go
+++ b/coordinator/clientapi/legacy_test.go
@@ -363,7 +363,7 @@ func TestUpdateManifest_Legacy(t *testing.T) {
 	assert.NoError(err)
 
 	// Update manifest
-	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
+	_, _, err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	// Get new certificates
@@ -438,14 +438,14 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 
 	// Try to update with unregistered user
 	someUser := user.NewUser("invalid", nil)
-	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), someUser)
+	_, _, err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), someUser)
 	assert.Error(err)
 
 	admin, err := data.GetUser("admin")
 	assert.NoError(err)
 
 	// Try to update manifest (frontend's SecurityVersion should rise from 3 to 5)
-	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
+	_, _, err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 	cUpdatedPackage, err := data.GetPackage("frontend")
 	assert.NoError(err)
@@ -459,7 +459,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["nonExisting"] = badUpdateManifest.Packages["frontend"]
 	badRawManifest, err := json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	delete(badUpdateManifest.Packages, "nonExisting")
@@ -470,7 +470,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	badModPackage.Debug = false
@@ -480,7 +480,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test if downgrading fails
@@ -490,7 +490,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test if downgrading fails
@@ -500,7 +500,7 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	badUpdateManifest.Packages["frontend"] = badModPackage
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test if removing a package from a currently existing update manifest fails
@@ -508,14 +508,14 @@ func TestUpdateManifestInvalid_Legacy(t *testing.T) {
 	delete(badUpdateManifest.Packages, "frontend")
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 
 	// Test what happens if no packages are defined at all
 	badUpdateManifest.Packages = nil
 	badRawManifest, err = json.Marshal(badUpdateManifest)
 	require.NoError(err)
-	err = c.UpdateManifest(ctx, badRawManifest, admin)
+	_, _, err = c.UpdateManifest(ctx, badRawManifest, admin)
 	assert.Error(err)
 }
 
@@ -568,7 +568,7 @@ func TestUpdateDebugMarble_Legacy(t *testing.T) {
 
 	// Try to update manifest
 	// frontend's security version, which was previously unset, should now be set to 5
-	err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
+	_, _, err = c.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	updatedPackage, err := data.GetPackage("frontend")

--- a/coordinator/core/marbleapi_test.go
+++ b/coordinator/core/marbleapi_test.go
@@ -608,7 +608,7 @@ func TestSecurityLevelUpdate(t *testing.T) {
 	spawner.newMarble(t, "frontend", "Azure", uuid.New(), true)
 
 	// update manifest
-	err = clientAPI.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
+	_, _, err = clientAPI.UpdateManifest(ctx, []byte(test.UpdateManifest), admin)
 	require.NoError(err)
 
 	// try to activate another first backend, should fail as required SecurityLevel is now higher after manifest update

--- a/coordinator/server/handler/handler.go
+++ b/coordinator/server/handler/handler.go
@@ -33,7 +33,7 @@ type ClientAPI interface {
 	SignQuote(ctx context.Context, quote []byte) (signature []byte, tcbStatus string, err error)
 	VerifyMarble(ctx context.Context, clientCerts []*x509.Certificate) (string, uuid.UUID, error)
 	VerifyUser(ctx context.Context, clientCerts []*x509.Certificate) (*user.User, error)
-	UpdateManifest(ctx context.Context, rawUpdateManifest []byte, updater *user.User) error
+	UpdateManifest(ctx context.Context, rawUpdateManifest []byte, updater *user.User) ([]string, int, error)
 	WriteSecrets(ctx context.Context, secrets map[string]manifest.UserSecret, updater *user.User) error
 	FeatureEnabled(ctx context.Context, feature string) bool
 }

--- a/coordinator/server/v1/v1.go
+++ b/coordinator/server/v1/v1.go
@@ -184,8 +184,7 @@ func (s *ClientAPIServer) UpdatePost(w http.ResponseWriter, r *http.Request) {
 		handler.WriteJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	err = s.api.UpdateManifest(r.Context(), updateManifest, verifiedUser)
-	if err != nil {
+	if _, _, err = s.api.UpdateManifest(r.Context(), updateManifest, verifiedUser); err != nil {
 		handler.WriteJSONError(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/coordinator/server/v2/types.go
+++ b/coordinator/server/v2/types.go
@@ -122,3 +122,11 @@ type UpdateApplyRequest struct {
 	// Manifest is the new manifest to apply.
 	Manifest []byte `json:"manifest"`
 }
+
+// UpdateApplyResponse is the response to an update apply request.
+type UpdateApplyResponse struct {
+	// MissingAcknowledgements is the number of acknowledgements required to apply the update.
+	MissingAcknowledgments int `json:"missingAcknowledgments"`
+	// MissingUsers is a list of users that have not acknowledged the update.
+	MissingUsers []string `json:"missingUsers"`
+}

--- a/coordinator/server/v2/v2.go
+++ b/coordinator/server/v2/v2.go
@@ -281,10 +281,14 @@ func (s *ClientAPIServer) UpdatePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.api.UpdateManifest(r.Context(), req.Manifest, verifiedUser); err != nil {
+	missingUsers, missingAcks, err := s.api.UpdateManifest(r.Context(), req.Manifest, verifiedUser)
+	if err != nil {
 		handler.WriteJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	handler.WriteJSON(w, nil)
+	handler.WriteJSON(w, UpdateApplyResponse{
+		MissingAcknowledgments: missingAcks,
+		MissingUsers:           missingUsers,
+	})
 }

--- a/docs/docs/reference/coordinator.md
+++ b/docs/docs/reference/coordinator.md
@@ -95,7 +95,7 @@ openssl x509 -in marblerunRootCA.crt -pubkey -noout > root.pubkey
 # verify signature
 openssl dgst -sha256 -verify root.pubkey -signature manifest.sig manifest.json
 # verification fails? try to remove newlines from manifest
-awk 'NF {sub(/\r/, ""); printf "%s",$0;}' original.manifest.json  > formated.manifest.json
+awk 'NF {sub(/\r/, ""); printf "%s",$0;}' original.manifest.json  > formatted.manifest.json
 ```
 
 #### Returns
@@ -897,6 +897,28 @@ Example request body:
 }
 ```
 
+#### Returns
+
+* `missingAcknowledgments` int
+
+    The number of users that need to acknowledge the update before it's applied.
+
+* `missingUsers` array of strings
+
+    An array of user IDs that haven't yet acknowledged the update.
+
+Example response:
+
+```json
+{
+    "status": "success",
+    "data": {
+        "missingAcknowledgments": 2,
+        "missingUsers": ["user1", "user2", "user3"]
+    }
+}
+```
+
 </TabItem>
 <TabItem value="v1" label="v1">
 
@@ -987,6 +1009,10 @@ Example request body:
 
     A human readable message indicating the success or progress of the update process.
 
+* `missingAcknowledgments` int
+
+    The number of users that need to acknowledge the update before it's applied.
+
 * `missingUsers` array of strings
 
     An array of user IDs that haven't yet acknowledged the update.
@@ -998,7 +1024,8 @@ Example response:
     "status": "success",
     "data": {
         "message": "2 users still needs to acknowledge the update manifest.",
-        "missingUsers": ["user1", "user2"]
+        "missingAcknowledgments": 2,
+        "missingUsers": ["user1", "user2", "user3"]
     }
 }
 ```

--- a/docs/docs/workflows/define-manifest.md
+++ b/docs/docs/workflows/define-manifest.md
@@ -544,7 +544,8 @@ The optional entry `Config` holds configuration settings for the Coordinator.
 See the section on [seal key types](../architecture/security.md#seal-key) for more information.
 
 `UpdateThreshold` specifies the number of acknowledgments required for a [multi-party manifest update](./update-manifest.md#full-update).
-If not set, all users with roles that have the `UpdateManifest` action need to acknowledge the update.
+If not set, or set to zero, all users with roles that have the `UpdateManifest` action need to acknowledge the update.
+The user submitting the update implicitly acknowledges it as well, meaning an `UpdateThreshold` of `1` requires no further acknowledgements from other users.
 
 `FeatureGates` allows you to opt-in to additional features that may be useful for certain use cases. The following features are available:
 

--- a/docs/versioned_docs/version-1.7/workflows/define-manifest.md
+++ b/docs/versioned_docs/version-1.7/workflows/define-manifest.md
@@ -544,7 +544,8 @@ The optional entry `Config` holds configuration settings for the Coordinator.
 See the section on [seal key types](../architecture/security.md#seal-key) for more information.
 
 `UpdateThreshold` specifies the number of acknowledgments required for a [multi-party manifest update](./update-manifest.md#full-update).
-If not set, all users with roles that have the `UpdateManifest` action need to acknowledge the update.
+If not set, or set to zero, all users with roles that have the `UpdateManifest` action need to acknowledge the update.
+The user submitting the update implicitly acknowledges it as well, meaning an `UpdateThreshold` of `1` requires no further acknowledgements from other users.
 
 `FeatureGates` allows you to opt-in to additional features that may be useful for certain use cases. The following features are available:
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -209,8 +209,8 @@ func (i IntegrationTest) SetManifest(manifest manifest.Manifest) (map[string][]b
 }
 
 // SetUpdateManifest sets performs a manifest update for the Coordinator.
-func (i IntegrationTest) SetUpdateManifest(manifest manifest.Manifest, certPEM []byte, key *rsa.PrivateKey) error {
-	// Setup requied client certificate for authentication
+func (i IntegrationTest) SetUpdateManifest(manifest manifest.Manifest, certPEM []byte, key *rsa.PrivateKey) (missingUsers []string, missingAcknowledgements int, err error) {
+	// Setup required client certificate for authentication
 	privk, err := x509.MarshalPKCS8PrivateKey(key)
 	i.require.NoError(err)
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -466,8 +466,9 @@ func TestManifestUpdate(t *testing.T) {
 
 	// Set the update manifest
 	t.Log("Setting the Update Manifest")
-	err = f.SetUpdateManifest(f.UpdatedManifest, AdminCert, RecoveryPrivateKey)
+	_, missingAcks, err := f.SetUpdateManifest(f.UpdatedManifest, AdminCert, RecoveryPrivateKey)
 	require.NoError(err, "failed to set Update Manifest")
+	assert.Equal(0, missingAcks, "failed to set Update Manifest")
 
 	// Try to start marbles again, should fail now due to increased minimum SecurityVersion
 	t.Log("Starting the same bunch of outdated Client-Marbles again (should fail now)...")


### PR DESCRIPTION
### Proposed changes
- Report the actual number of missing acknowledgements on `marblerun manifest update acknowledge`
- Print a list of all users who may still acknowledge the update
- Print the number of expected acknowledgements on `marblerun manifest update apply` in case of full manifest update

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- This PR introduces a breaking change in the Go API for `ManifestUpdateAcknowledge`. The function now returns a list of users who have not acknowledged the update as well as the number of users that still need to send an acknowledgement for the update to be applied
- This PR introduces a breaking change in the Go API for `ManifestUpdateApply`. The function now returns a list of a users who may acknowledge the update, as well as the number of missing acknowledgements for the update to be applied (in case of full manifest updates with more than 1 user)

