### PR TITLE
docs: update PCS URL to v4

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -62,8 +62,7 @@ their default values.
 | `marbleInjector.namespaceSelector`           | object         | NamespaceSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector) for more information | `{}` |
 | `nodeSelector`                               | object         | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information | `{"beta.kubernetes.io/os": "linux"}` |
 | `tolerations`                                | object         | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information | `{key:"sgx.intel.com/epc",operator:"Exists",effect:"NoSchedule"}` |
-| `dcap.qpl`                                   | string         | SGX quote provider library (QPL) to use. Needs to be "intel" if the libsgx-dcap-default-qpl is to be used, otherwise az-dcap-client is used by default | `"azure"` |
-| `dcap.pccsUrl`                               | string         | URL of the PCCS. Only applicable if `dcap.qpl=intel` | `"https://localhost:8081/sgx/certification/v3/"` |
+| `dcap.pccsUrl`                               | string         | URL of the PCCS | `"https://global.acccache.azure.net/sgx/certification/v4/"` |
 | `dcap.useSecureCert`                         | string         | Whether or not the TLS certificate of the PCCS should be verified | `"TRUE"` |
 
 ## Add new version (maintainers)

--- a/docs/docs/deployment/platforms/alibaba.md
+++ b/docs/docs/deployment/platforms/alibaba.md
@@ -46,14 +46,14 @@ The description below uses a VM running Ubuntu 18.04.
     * If your instance is assigned a public IP address, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
 
         ```
-        PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v3/
+        PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v4/
         USE_SECURE_CERT=TRUE
         ```
 
     * If your instance is in a virtual private cloud and has only internal IP addresses, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
 
         ```
-        PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v3/
+        PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v4/
         USE_SECURE_CERT=TRUE
         ```
 

--- a/docs/docs/deployment/platforms/on-prem.md
+++ b/docs/docs/deployment/platforms/on-prem.md
@@ -67,14 +67,14 @@ You currently have two options regarding PCCS for your on-premises machines and 
     You can inspect the Intel Root CA CRL of your PCCS:
 
     ```bash
-    curl --insecure --request GET --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v3/rootcacrl > rootca.crl
+    curl --insecure --request GET --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v4/rootcacrl > rootca.crl
     openssl crl -inform DER -text -noout -in rootca.crl
     ```
 
     You can refresh all SGX collaterals for your PCCS:
 
     ```bash
-    curl --insecure --request GET -H "admin-token: <my password>" --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v3/refresh
+    curl --insecure --request GET -H "admin-token: <my password>" --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v4/refresh
     ```
 
     If refreshing CRL fails, you can manually delete the `pckcache.db` database (default location `/opt/intel/sgx-dcap-pccs/pckcache.db`) and restart your PCCS.

--- a/docs/versioned_docs/version-1.7/deployment/platforms/alibaba.md
+++ b/docs/versioned_docs/version-1.7/deployment/platforms/alibaba.md
@@ -46,14 +46,14 @@ The description below uses a VM running Ubuntu 18.04.
     * If your instance is assigned a public IP address, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
 
         ```
-        PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v3/
+        PCCS_URL=https://sgx-dcap-server.[Region-ID].aliyuncs.com/sgx/certification/v4/
         USE_SECURE_CERT=TRUE
         ```
 
     * If your instance is in a virtual private cloud and has only internal IP addresses, change the configuration to the following, where `[Region-ID]` is the ID of your instance's region:
 
         ```
-        PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v3/
+        PCCS_URL=https://sgx-dcap-server-vpc.[Region-ID].aliyuncs.com/sgx/certification/v4/
         USE_SECURE_CERT=TRUE
         ```
 

--- a/docs/versioned_docs/version-1.7/deployment/platforms/on-prem.md
+++ b/docs/versioned_docs/version-1.7/deployment/platforms/on-prem.md
@@ -67,14 +67,14 @@ You currently have two options regarding PCCS for your on-premises machines and 
     You can inspect the Intel Root CA CRL of your PCCS:
 
     ```bash
-    curl --insecure --request GET --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v3/rootcacrl > rootca.crl
+    curl --insecure --request GET --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v4/rootcacrl > rootca.crl
     openssl crl -inform DER -text -noout -in rootca.crl
     ```
 
     You can refresh all SGX collaterals for your PCCS:
 
     ```bash
-    curl --insecure --request GET -H "admin-token: <my password>" --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v3/refresh
+    curl --insecure --request GET -H "admin-token: <my password>" --url https://<YOUR_PCCS_DOMAIN>:<YOUR_PCCS_PORT>/sgx/certification/v4/refresh
     ```
 
     If refreshing CRL fails, you can manually delete the `pckcache.db` database (default location `/opt/intel/sgx-dcap-pccs/pckcache.db`) and restart your PCCS.


### PR DESCRIPTION
PCS API below v4 will be deprecated soon. Update remaining references to v4.