### PR TITLE
dockerfiles: fix AppImage build

### DIFF
--- a/dockerfiles/Dockerfile.cli
+++ b/dockerfiles/Dockerfile.cli
@@ -33,13 +33,7 @@ RUN cd marblerun && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /m
 
 # create AppImage
 RUN chmod +x linuxdeploy-x86_64.AppImage && touch marblerun.svg \
-  # workaround for reproducibility based on https://github.com/AppImage/AppImageKit/issues/929#issuecomment-926001098
   && /linuxdeploy-x86_64.AppImage --appimage-extract \
-  && cd squashfs-root/plugins/linuxdeploy-plugin-appimage/appimagetool-prefix/usr/lib/appimagekit \
-  && mv mksquashfs mksquashfs_orig \
-  && echo '$0_orig $(echo $* | sed -e "s/-mkfs-time 0//")' > mksquashfs \
-  && chmod +x mksquashfs \
-  && cd / \
   # create AppDir
   && squashfs-root/AppRun \
   --appdir=marblerun.AppDir \


### PR DESCRIPTION
[AppImageKit](https://github.com/AppImage/AppImageKit) has been deprecated in favor of [appimagetool](https://github.com/AppImage/appimagetool), which is now shipped with linuxdeploy by default.
This doesn't change anything for our build, but lets us remove a workaround that was required for reproducible squashfs builds.

### Proposed changes
-  Remove a workaround for squashfs not needed for newer versions of linuxdeploy
