### PR TITLE
coordinator: seal with 32 byte key

### DIFF
--- a/coordinator/recovery/recovery.go
+++ b/coordinator/recovery/recovery.go
@@ -43,7 +43,7 @@ func ParseRSAPublicKeyFromPEM(pemContent string) (*rsa.PublicKey, error) {
 }
 
 func generateRandomKey() ([]byte, error) {
-	generatedValue := make([]byte, 16)
+	generatedValue := make([]byte, 32)
 	_, err := rand.Read(generatedValue)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/ThalesGroup/crypto11 v1.4.1
 	github.com/cert-manager/cert-manager v1.18.2
-	github.com/edgelesssys/ego v1.8.0
+	github.com/edgelesssys/ego v1.8.1-0.20250916065612-5d02806cea8b
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/edgelesssys/ego v1.8.0 h1:g/02JeTC/vajbAfFqxckwSC+siKno/R4H/Em2YsHheU=
 github.com/edgelesssys/ego v1.8.0/go.mod h1:fg0M/xfLWnrkoD2OZpY9xmltGlAPFsIiUmyHTuCS7zo=
+github.com/edgelesssys/ego v1.8.1-0.20250916065612-5d02806cea8b h1:n9AkJo7gGlmVyXK3egu9oFzBActF2wTYR77Yf5Y+V/U=
+github.com/edgelesssys/ego v1.8.1-0.20250916065612-5d02806cea8b/go.mod h1:fg0M/xfLWnrkoD2OZpY9xmltGlAPFsIiUmyHTuCS7zo=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=

--- a/samples/estore/go.mod
+++ b/samples/estore/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
-	github.com/edgelesssys/ego v1.8.0 // indirect
+	github.com/edgelesssys/ego v1.8.1-0.20250916065612-5d02806cea8b // indirect
 	github.com/getsentry/sentry-go v0.29.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/samples/estore/go.sum
+++ b/samples/estore/go.sum
@@ -15,8 +15,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgelesssys/ego v1.8.0 h1:g/02JeTC/vajbAfFqxckwSC+siKno/R4H/Em2YsHheU=
-github.com/edgelesssys/ego v1.8.0/go.mod h1:fg0M/xfLWnrkoD2OZpY9xmltGlAPFsIiUmyHTuCS7zo=
+github.com/edgelesssys/ego v1.8.1-0.20250916065612-5d02806cea8b h1:n9AkJo7gGlmVyXK3egu9oFzBActF2wTYR77Yf5Y+V/U=
+github.com/edgelesssys/ego v1.8.1-0.20250916065612-5d02806cea8b/go.mod h1:fg0M/xfLWnrkoD2OZpY9xmltGlAPFsIiUmyHTuCS7zo=
 github.com/edgelesssys/estore v1.2.0 h1:QIpEme6/ZG/aq1C51kUDKVC5VARAr2bg34aa75WLVF0=
 github.com/edgelesssys/estore v1.2.0/go.mod h1:X6YRliq5kd5j6fvhR9F3SQJthIXzw5xgZSVU+lHx8TM=
 github.com/getsentry/sentry-go v0.29.1 h1:DyZuChN8Hz3ARxGVV8ePaNXh1dQ7d76AiB117xcREwA=


### PR DESCRIPTION
### Proposed changes
- Seal encryption key using `SealWithProductKey256`
  - Unsealing happens using `Unseal256` or `Unseal` if unsealing with the 32 byte key fails as a fallback
- Seal data using a 32 byte key
  - A 32 byte sealing key is only generated for new MarbleRun deployments. Deployments upgrading from a previous MarbleRun version will continue using a 16 byte key for data sealing

### Additional info
- AB#6112