### PR TITLE
cli: allow specifying custom qcnl config when installing MarbleRun

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -62,8 +62,9 @@ their default values.
 | `marbleInjector.namespaceSelector`           | object         | NamespaceSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector) for more information | `{}` |
 | `nodeSelector`                               | object         | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information | `{"beta.kubernetes.io/os": "linux"}` |
 | `tolerations`                                | object         | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information | `{key:"sgx.intel.com/epc",operator:"Exists",effect:"NoSchedule"}` |
-| `dcap.pccsUrl`                               | string         | URL of the PCCS | `"https://global.acccache.azure.net/sgx/certification/v4/"` |
-| `dcap.useSecureCert`                         | string         | Whether or not the TLS certificate of the PCCS should be verified | `"TRUE"` |
+| `dcap.qcnlConfig`                            | string         | Inline defined QCNL configuration. If set, this configuration is used instead of the default one or the one provided via `dcap.qcnlConfigFile` | `""` |
+| `dcap.pccsUrl`                               | string         | URL of the PCCS. Only used if `dcap.qcnlConfig` is not set  | `"https://global.acccache.azure.net/sgx/certification/v4/"` |
+| `dcap.useSecureCert`                         | string         | Whether or not the TLS certificate of the PCCS should be verified. Only used if `dcap.qcnlConfig` is not set  | `"TRUE"` |
 
 ## Add new version (maintainers)
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -62,9 +62,9 @@ their default values.
 | `marbleInjector.namespaceSelector`           | object         | NamespaceSelector to trigger marble-injector mutation, See the [K8S documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector) for more information | `{}` |
 | `nodeSelector`                               | object         | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information | `{"beta.kubernetes.io/os": "linux"}` |
 | `tolerations`                                | object         | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information | `{key:"sgx.intel.com/epc",operator:"Exists",effect:"NoSchedule"}` |
-| `dcap.qcnlConfig`                            | string         | Inline defined QCNL configuration. If set, this configuration is used instead of the default one or the one provided via `dcap.qcnlConfigFile` | `""` |
+| `dcap.qcnlConfig`                            | string         | Inline defined QCNL configuration. If set, this configuration is used instead of the one created from `dcap.pccsUrl` and `dcap.useSecureCert` | `""` |
 | `dcap.pccsUrl`                               | string         | URL of the PCCS. Only used if `dcap.qcnlConfig` is not set  | `"https://global.acccache.azure.net/sgx/certification/v4/"` |
-| `dcap.useSecureCert`                         | string         | Whether or not the TLS certificate of the PCCS should be verified. Only used if `dcap.qcnlConfig` is not set  | `"TRUE"` |
+| `dcap.useSecureCert`                         | string         | Whether or not the TLS certificate of the PCCS should be verified. Only used if `dcap.qcnlConfig` is not set  | `true` |
 
 ## Add new version (maintainers)
 

--- a/charts/templates/sgx_qcnl.yaml
+++ b/charts/templates/sgx_qcnl.yaml
@@ -20,7 +20,11 @@ data:
   sgx_default_qcnl.conf: |
     {
       "pccs_url": "{{ .Values.dcap.pccsUrl }}",
-      "use_secure_cert": "{{ .Values.dcap.useSecureCert }}"
+      {{- if kindIs "bool" .Values.dcap.useSecureCert }}
+      "use_secure_cert": {{ .Values.dcap.useSecureCert }}
+      {{- else }}
+      "use_secure_cert": {{ eq (lower (toString .Values.dcap.useSecureCert)) "true" }}
+      {{- end }}
     }
   {{- end}}
 {{ end }}

--- a/charts/templates/sgx_qcnl.yaml
+++ b/charts/templates/sgx_qcnl.yaml
@@ -13,7 +13,14 @@ metadata:
     {{ .Values.global.coordinatorComponentLabel }}: dcap-config
     {{ .Values.global.coordinatorNamespaceLabel }}: {{ .Release.Namespace }}
 data:
+  {{- if .Values.dcap.qcnlConfig }}
+  sgx_default_qcnl.conf: |-
+{{ .Values.dcap.qcnlConfig | indent 4 }}
+  {{- else }}
   sgx_default_qcnl.conf: |
-    PCCS_URL={{ .Values.dcap.pccsUrl }}
-    USE_SECURE_CERT={{ .Values.dcap.useSecureCert }}
+    {
+      "pccs_url": "{{ .Values.dcap.pccsUrl }}",
+      "use_secure_cert": "{{ .Values.dcap.useSecureCert }}"
+    }
+  {{- end}}
 {{ end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -125,5 +125,8 @@ nodeSelector:
 
 # DCAP configuration settings
 dcap:
+  # Set to use an inline defined QCNL configuration
+  qcnlConfig: ""
+  # If qcnlConfig is not set, the default values below are used to create a config file
   pccsUrl: "https://global.acccache.azure.net/sgx/certification/v4/"
   useSecureCert: "TRUE"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -129,4 +129,4 @@ dcap:
   qcnlConfig: ""
   # If qcnlConfig is not set, the default values below are used to create a config file
   pccsUrl: "https://global.acccache.azure.net/sgx/certification/v4/"
-  useSecureCert: "TRUE"
+  useSecureCert: true

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -64,8 +64,9 @@ marblerun install --dcap-pccs-url https://pccs.example.com/sgx/certification/v4/
 
 ```
       --client-server-port int           Set the client server port. Needs to be configured to the same port as in your client tool stack (default 4433)
-      --dcap-pccs-url string             Provisioning Certificate Caching Service (PCCS) server address. Defaults to Azure PCCS. (default "https://global.acccache.azure.net/sgx/certification/v4/")
-      --dcap-secure-cert string          To accept insecure HTTPS certificate from the PCCS, set this option to FALSE (default "TRUE")
+      --dcap-pccs-url string             Provisioning Certificate Caching Service (PCCS) server address. Defaults to Azure PCCS. Mutually exclusive with "--dcap-qcnl-config-file" (default "https://global.acccache.azure.net/sgx/certification/v4/")
+      --dcap-qcnl-config-file string     Path to a custom QCNL configuration file. Mutually exclusive with "--dcap-pccs-url" and "--dcap-secure-cert".
+      --dcap-secure-cert string          To accept insecure HTTPS certificate from the PCCS, set this option to FALSE. Mutually exclusive with "--dcap-qcnl-config-file" (default "TRUE")
       --disable-auto-injection           Install MarbleRun without auto-injection webhook
       --domain strings                   Sets additional DNS names and IPs for the Coordinator TLS certificate
       --enterprise-access-token string   Access token for Enterprise Coordinator. Leave empty for default installation

--- a/util/tls.go
+++ b/util/tls.go
@@ -38,7 +38,7 @@ func MustGenerateTestMarbleCredentials() (cert *x509.Certificate, csrRaw []byte,
 		panic(err)
 	}
 	csrRaw = csr.Raw
-	return
+	return cert, csrRaw, privk
 }
 
 // GenerateCert generates a new self-signed certificate associated key-pair.


### PR DESCRIPTION
### Proposed changes
- Add a new flag to to `marblerun install`: `--dcap-qcnl-config-file`
  - Allows specifying the path to a qcnl config, which will be added to the Helm chart instead of using the default values in `--dcap-pccs-url` and `--dcap-secure-cert`
- The Helm chart similarly received a new settable value: `dcap.qcnlConfig`
  - Allows defining a qcnl config inline as a string
  - Alternatively the value may be set by reading a file using Helm's `--set-file` flag:
      ```
      helm install -n marblerun ./charts --set-file dcap.qcnlConfig=/path/to/sgx_qcnl.conf
      ```
- Update the default qcnl generated by the CLI and the Helm chart to use the newer JSON formatted config
