### PR TITLE
security: update P256 elliptic keys to P384

### DIFF
--- a/coordinator/core/marbleapi.go
+++ b/coordinator/core/marbleapi.go
@@ -386,7 +386,7 @@ func parseSecrets(data string, tplFunc template.FuncMap, secretsWrapped manifest
 
 func (c *Core) generateMarbleAuthSecrets(txdata storeGetter, req *rpc.ActivationReq, marbleUUID uuid.UUID) (manifest.ReservedSecrets, error) {
 	// generate key-pair for marble
-	privk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privk, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return manifest.ReservedSecrets{}, err
 	}

--- a/coordinator/crypto/crypto.go
+++ b/coordinator/crypto/crypto.go
@@ -29,7 +29,7 @@ func GenerateCert(
 	// Generate private key
 	var err error
 	if privk == nil {
-		privk, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		privk, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		if err != nil {
 			return nil, nil, fmt.Errorf("generating private key: %w", err)
 		}

--- a/docs/docs/architecture/security.md
+++ b/docs/docs/architecture/security.md
@@ -37,10 +37,10 @@ See the [attested TLS](#attested-tls-atls) section for details behind that conce
 All MarbleRun clients and Marbles can then use the attested *Root CA Certificate* for authenticating TLS connections.
 This is further illustrated conceptually in the [attestation](../features/attestation.md) section. The following focuses on the cryptographic primitives.
 The Coordinator generates a root X.509 certificate and corresponding asymmetric key pair during initialization.
-The [Elliptic Curve Digital Signature Algorithm (ECDSA)](https://www.secg.org/sec1-v2.pdf#page=49) is used with curve [P256](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf#page=111).
+The [Elliptic Curve Digital Signature Algorithm (ECDSA)](https://www.secg.org/sec1-v2.pdf#page=49) is used with curve [P384](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf#page=113).
 The *Root CA Certificate* has no expiry date and lives as long as the MarbleRun deployment.
 
-Alongside the *Root CA Certificate*, the Coordinator generates an X.509 *Intermediate Certificate* and corresponding asymmetric key pair, again using ECDSA with P256.
+Alongside the *Root CA Certificate*, the Coordinator generates an X.509 *Intermediate Certificate* and corresponding asymmetric key pair, again using ECDSA with P384.
 The *Intermediate Certificate* is signed by the Coordinator's *Root CA Certificate* and rotated with every manifest update.
 When you push an update to the manifest (for example, bump up the *SecurityVersion* of a Marble), the *Intermediate Certificate* will change.
 Marble instances of the new version won't authenticate with instances of the old version and vice versa.
@@ -58,7 +58,7 @@ However, while the *Intermediate Certificate* is signed by the *Root Certificate
 The goal here is to implement a  [cross-signed certificate chain](https://www.ssltrust.com.au/blog/understanding-certificate-cross-signing).
 In that way, the Marbles see the *Marble Root Certificate* as a self-signed root certificate. Hence, they're dealing with a terminating certificate chain without knowing about the Coordinator's *Root CA Certificate*.
 The "outside world" sees an intermediate certificate signed by the Coordinator's *Root CA Certificate*.
-The Coordinator generates a unique leaf *Marble Certificate* and corresponding key pair using ECDSA with P256 for every Marble.
+The Coordinator generates a unique leaf *Marble Certificate* and corresponding key pair using ECDSA with P384 for every Marble.
 The *Marble Root Certificate* signs the *Marble Certificate*.
 The *Marble Certificate* is provisioned to the Marble's enclave via the secure channel established during the [attestation procedure](../features/attestation.md).
 Depending on the Marble's runtime, the certificate can be used [manually](../workflows/add-service.md#make-your-service-use-the-provided-tls-credentials) or [automatically](../features/transparent-TLS.md) to establish mutually authenticated TLS connections.

--- a/docs/docs/features/attestation.md
+++ b/docs/docs/features/attestation.md
@@ -22,7 +22,7 @@ The [manifest](../workflows/define-manifest.md) describes which Marbles (service
 The Coordinator enforces the manifest and only admits the desired Marbles to the cluster.
 Each Marble registers itself with a quote via gRPC to the Coordinator. This quote is tied to the TLS session of the gRPC call. It contains the Marble's measurements. The Coordinator compares them to the manifest to ensure the Marble's identity and integrity.
 
-More specifically, the Marble generates an [ECDSA](https://www.secg.org/sec1-v2.pdf#page=49) private key using curve [P256](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf#page=111), and a self-signed TLS certificate.
+More specifically, the Marble generates an [ECDSA](https://www.secg.org/sec1-v2.pdf#page=49) private key using curve [P384](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf#page=113), and a self-signed TLS certificate.
 It then hashes the certificate using SHA-256 and creates an SGX quote over the hash.
 The Marble uses this certificate to establish a TLS connection with the Coordinator and send the quote.
 The Coordinator verifies the Marble's measurements contained in the quote against the manifest and makes sure the Marble's TLS certificate matches the quote.

--- a/enclave/coordinator.conf
+++ b/enclave/coordinator.conf
@@ -4,4 +4,4 @@ NumHeapPages=131072
 NumStackPages=1024
 NumTCS=32
 ProductID=3
-SecurityVersion=2
+SecurityVersion=3

--- a/util/tls.go
+++ b/util/tls.go
@@ -43,7 +43,7 @@ func MustGenerateTestMarbleCredentials() (cert *x509.Certificate, csrRaw []byte,
 
 // GenerateCert generates a new self-signed certificate associated key-pair.
 func GenerateCert(subjAltNames []string, ipAddrs []net.IP, isCA bool) (*x509.Certificate, *ecdsa.PrivateKey, error) {
-	privk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privk, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Proposed changes
- Update elliptic keys from P256 to P384. This affects
  - Coordinator Root certificate
  - Coordinator Intermediate certificate
  - Marble TLS certificate

