### PR TITLE
e2e: optimize SGX config and fix webhook test

### DIFF
--- a/.github/scripts/azure_sgx_conf.json
+++ b/.github/scripts/azure_sgx_conf.json
@@ -1,0 +1,18 @@
+{
+    "pccs_url": "https://global.acccache.azure.net/sgx/certification/v4/",
+    "use_secure_cert": true,
+    "retry_times": 6,
+    "local_pck_url": "http://169.254.169.254/metadata/THIM/sgx/certification/v4/",
+    "pck_cache_expire_hours": 48,
+    "verify_collateral_cache_expire_hours": 48,
+    "custom_request_options": {
+        "get_cert": {
+            "headers": {
+                "metadata": "true"
+            },
+            "params": {
+                "api-version": "2021-07-22-preview"
+            }
+        }
+    }
+}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -473,6 +473,8 @@ jobs:
             tags="${tags},hsmsealing"
           fi
 
+          yq -i eval ".dcap.qcnlConfig = (load(\".github/scripts/azure_sgx_conf.json\") | @json)" ./charts/values.yaml
+
           go test ./test/e2e/ -tags ${tags} --timeout 0 --parallel ${PARALLEL_RUNS} \
             --run "${TEST_FILTER}" \
             --cli /usr/bin/marblerun \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -221,7 +221,7 @@ jobs:
           CONTAINER: marble-injector
           UUID: ${{ steps.generate-uid.outputs.run-uid }}
         run: |
-          docker build --arg mrtag=${{ github.ref_name }} --tag ${CR}/${CONTAINER}:${UUID} -f dockerfiles/Dockerfile.marble-injector .
+          docker build --build-arg mrtag=${{ github.ref_name }} --tag ${CR}/${CONTAINER}:${UUID} -f dockerfiles/Dockerfile.marble-injector .
           docker push ${CR}/${CONTAINER}:${UUID}
 
           image_ref=$(docker inspect --format='{{index .RepoDigests 0}}' ${CR}/${CONTAINER}:${UUID})

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,7 +78,7 @@ on:
       HSM_RELEASE_CLIENT_SECRET:
         required: true
       HSM_RELEASE_OBJECT_ID:
-          required: true
+        required: true
 
 jobs:
   build-test-containers:
@@ -89,6 +89,7 @@ jobs:
       update-digest: ${{ steps.build-coordinator-update.outputs.digest }}
       previous-release-digest: ${{ steps.build-previous-release-coordinator.outputs.digest }}
       marble-digest: ${{ steps.build-marble.outputs.digest }}
+      marble-injector-digest: ${{ steps.build-marble-injector.outputs.digest }}
       era-config: ${{ steps.build-binaries.outputs.era-config }}
       previous-release-era-config: ${{ steps.build-previous-release-coordinator.outputs.era-config }}
       marble-config: ${{ steps.build-binaries.outputs.marble-config }}
@@ -206,6 +207,23 @@ jobs:
           docker push ${CR}/${CONTAINER}:${UUID}
 
           # Split image ref into registry/repo/tag and sha256 digest and set in output
+          image_ref=$(docker inspect --format='{{index .RepoDigests 0}}' ${CR}/${CONTAINER}:${UUID})
+          IFS='@' read -ra ADDR <<< "${image_ref}"
+          digest=${ADDR[1]}
+
+          echo "digest=${digest}" >> $GITHUB_OUTPUT
+
+      - name: Build and push marble-injector
+        id: build-marble-injector
+        env:
+          DOCKER_BUILDKIT: 1
+          CR: ghcr.io/edgelesssys/marblerun-e2e
+          CONTAINER: marble-injector
+          UUID: ${{ steps.generate-uid.outputs.run-uid }}
+        run: |
+          docker build --arg mrtag=${{ github.ref_name }} --tag ${CR}/${CONTAINER}:${UUID} -f dockerfiles/Dockerfile.marble-injector .
+          docker push ${CR}/${CONTAINER}:${UUID}
+
           image_ref=$(docker inspect --format='{{index .RepoDigests 0}}' ${CR}/${CONTAINER}:${UUID})
           IFS='@' read -ra ADDR <<< "${image_ref}"
           digest=${ADDR[1]}
@@ -422,11 +440,22 @@ jobs:
             --audience api://AzureADTokenExchange
 
       - name: Update MarbleRun chart
+        env:
+          IMAGE_VERSION: ${{ needs.build-test-containers.outputs.run-uid }}
+          COORDINATOR_DIGEST: ${{ needs.build-test-containers.outputs.coordinator-digest }}
+          MARBLE_INJECTOR_DIGEST: ${{ needs.build-test-containers.outputs.marble-injector-digest }}
         run: |
           yq -i eval "(.coordinator.repository=\"$CR\") |
-            (.coordinator.version=\"${{ needs.build-test-containers.outputs.run-uid }}\") |
-            (.coordinator.hash=\"${{ needs.build-test-containers.outputs.coordinator-digest }}\")" \
+            (.coordinator.version=\"$IMAGE_VERSION\") |
+            (.coordinator.hash=\"$COORDINATOR_DIGEST\")" \
             ./charts/values.yaml
+
+          yq -i eval "(.marbleInjector.repository=\"$CR\") |
+            (.marbleInjector.version=\"$IMAGE_VERSION\") |
+            (.marbleInjector.hash=\"$MARBLE_INJECTOR_DIGEST\")" \
+            ./charts/values.yaml
+
+          yq -i eval ".dcap.qcnlConfig = (load(\".github/scripts/azure_sgx_conf.json\") | @json)" ./charts/values.yaml
 
       - name: Get latest release tag
         id: get-tag
@@ -441,11 +470,16 @@ jobs:
           path: previous
 
       - name: Update latest release MarbleRun chart
+        env:
+          IMAGE_VERSION: ${{ needs.build-test-containers.outputs.run-uid }}
+          COORDINATOR_DIGEST: ${{ needs.build-test-containers.outputs.previous-release-digest }}
         run: |
           yq -i eval "(.coordinator.repository=\"$CR\") |
-            (.coordinator.version=\"${{ needs.build-test-containers.outputs.run-uid }}-release\") |
-            (.coordinator.hash=\"${{ needs.build-test-containers.outputs.previous-release-digest }}\")" \
+            (.coordinator.version=\"${IMAGE_VERSION}-release\") |
+            (.coordinator.hash=\"${COORDINATOR_DIGEST}\")" \
             ./previous/charts/values.yaml
+
+          yq -i eval ".dcap.qcnlConfig = (load(\".github/scripts/azure_sgx_conf.json\") | @json)" ./previous/charts/values.yaml
 
       - name: Run e2e test
         env:
@@ -472,8 +506,6 @@ jobs:
           if [ "${HSM_SEALING}" = "enabled" ] || [ "${HSM_SEALING}" = "fake" ]; then
             tags="${tags},hsmsealing"
           fi
-
-          yq -i eval ".dcap.qcnlConfig = (load(\".github/scripts/azure_sgx_conf.json\") | @json)" ./charts/values.yaml
 
           go test ./test/e2e/ -tags ${tags} --timeout 0 --parallel ${PARALLEL_RUNS} \
             --run "${TEST_FILTER}" \

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -94,7 +94,7 @@ coordinator:
       periodSeconds: 60
       timeoutSeconds: 30
     startup:
-      initialDelaySeconds: 60
+      initialDelaySeconds: 15
       failureThreshold: 3
       periodSeconds: 2
       timeoutSeconds: 30

--- a/dockerfiles/Dockerfile.marble-injector
+++ b/dockerfiles/Dockerfile.marble-injector
@@ -3,7 +3,7 @@ ARG mrtag=v1.9.0
 RUN git clone -b $mrtag --depth=1 https://github.com/edgelesssys/marblerun.git /marble-injector
 WORKDIR /marble-injector
 
-FROM ghcr.io/edgelesssys/edgelessrt-dev AS build
+FROM ghcr.io/edgelesssys/edgelessrt-dev:v0.5.2 AS build
 COPY --from=pull /marble-injector /marble-injector
 WORKDIR /marble-injector/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..


### PR DESCRIPTION
### Proposed changes
- Add a dedicated SGX config for Azure to fix slow attestation
  - This fixes the weekly e2e test running into the 6h GitHub timeout
- Build and use marble-injector container during the e2e test instead of using the one from the latest release
  - Fixes an issue where the chart on the master branch was using options not supported by the binary of the latest release

### Additional info
- [e2e test](https://github.com/edgelesssys/marblerun/actions/runs/24668673214)

<!-- (uncomment if applicable)
### Screenshots

-->
