### PR TITLE
Prepare release v1.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(marblerun VERSION 1.9.0)
+project(marblerun VERSION 1.9.1)
 find_package(OpenEnclave CONFIG REQUIRED)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/dockerfiles/Dockerfile.cli
+++ b/dockerfiles/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM ghcr.io/edgelesssys/marblerun/build-base-focal:v1.9.0 AS build
+FROM ghcr.io/edgelesssys/marblerun/build-base-focal:v1.9.1 AS build
 
 # don't run `apt-get update` because required packages are cached in build-base for reproducibility
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   wget
 
 ARG erttag=v0.5.2
-ARG mrtag=v1.9.0
+ARG mrtag=v1.9.1
 ARG goversion=1.26.1
 RUN wget -qO- https://go.dev/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -1,4 +1,4 @@
-FROM ghcr.io/edgelesssys/marblerun/build-base:v1.9.0 AS build
+FROM ghcr.io/edgelesssys/marblerun/build-base:v1.9.1 AS build
 
 # don't run `apt-get update` because required packages are cached in build-base for reproducibility
 RUN apt-get install -y --no-install-recommends \
@@ -12,7 +12,7 @@ RUN apt-get install -y --no-install-recommends \
   wget
 
 ARG erttag=v0.5.2
-ARG mrtag=v1.9.0
+ARG mrtag=v1.9.1
 ARG goversion=1.26.1
 RUN wget -qO- https://go.dev/dl/go${goversion}.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
@@ -43,8 +43,8 @@ COPY --from=build /mrbuild/marblerun /marblerun-ubuntu-22.04
 
 # the coordinator container image
 FROM ubuntu:jammy-20260410 AS release
-ARG PSW_VERSION=2.27.100.1-jammy1
-ARG DCAP_VERSION=1.24.100.2-jammy1
+ARG PSW_VERSION=2.28.100.1-jammy1
+ARG DCAP_VERSION=1.25.100.1-jammy1
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libcurl4 wget \
   && wget -qO /etc/apt/keyrings/intel-sgx-keyring.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
   && echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' > /etc/apt/sources.list.d/intel-sgx.list \

--- a/dockerfiles/Dockerfile.coordinator
+++ b/dockerfiles/Dockerfile.coordinator
@@ -54,7 +54,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
   libsgx-ae-qe3=$DCAP_VERSION \
   libsgx-dcap-ql=$DCAP_VERSION \
   libsgx-enclave-common=$PSW_VERSION \
-  libsgx-launch=$PSW_VERSION \
   libsgx-pce-logic=$DCAP_VERSION \
   libsgx-qe3-logic=$DCAP_VERSION \
   libsgx-urts=$PSW_VERSION \

--- a/dockerfiles/Dockerfile.marble-injector
+++ b/dockerfiles/Dockerfile.marble-injector
@@ -1,5 +1,5 @@
 FROM alpine/git:latest AS pull
-ARG mrtag=v1.9.0
+ARG mrtag=v1.9.1
 RUN git clone -b $mrtag --depth=1 https://github.com/edgelesssys/marblerun.git /marble-injector
 WORKDIR /marble-injector
 


### PR DESCRIPTION
### Proposed changes
- Bump version to v1.9.1
  - Doc changes (HSM sealing) will need to be backported
- Bump SGX PSW version to `2.28.100.1-jammy1`
  - With this the `ligbsgx-launch` package is discontinued (previously only needed for unsupported client SGX)
- Bump SGX DCAP version to `1.25.100.1-jammy1`

### Additional info
- [e2e test](https://github.com/edgelesssys/marblerun/actions/runs/24727326651)
