### PR TITLE
deps: update crypto11 import

### DIFF
--- a/cli/internal/pkcs11/pkcs11.go
+++ b/cli/internal/pkcs11/pkcs11.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ThalesGroup/crypto11"
+	"github.com/eclipse-keypont/crypto11"
 )
 
 // SignerDecrypter is a combined interface for [crypto.Signer] and [crypto.Decrypter].

--- a/cli/internal/pkcs11/pkcs11_integration_test.go
+++ b/cli/internal/pkcs11/pkcs11_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ThalesGroup/crypto11"
+	"github.com/eclipse-keypont/crypto11"
 	"github.com/edgelesssys/marblerun/util"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/docs/docs/workflows/user-authentication.md
+++ b/docs/docs/workflows/user-authentication.md
@@ -21,7 +21,7 @@ marblerun --cert admin_certificate.pem --key admin_private.pem [COMMAND]
 ## PKCS #11-based authentication
 
 The MarbleRun CLI supports authentication with private keys stored in a PKCS #11-compatible device.
-To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config), which specifies how to access the PKCS #11 token.
+To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/eclipse-keypont/crypto11@v1.6.5#Config), which specifies how to access the PKCS #11 token.
 Additionally, you must provide the ID and/or label of the private key and certificate to the CLI.
 
 The PKCS #11 config file is a JSON file that should specify the following fields:

--- a/docs/versioned_docs/version-1.7/workflows/user-authentication.md
+++ b/docs/versioned_docs/version-1.7/workflows/user-authentication.md
@@ -21,7 +21,7 @@ marblerun --cert admin_certificate.pem --key admin_private.pem [COMMAND]
 ## PKCS #11-based authentication
 
 The MarbleRun CLI supports authentication with private keys stored in a PKCS #11-compatible device.
-To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config), which specifies how to access the PKCS #11 token.
+To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/eclipse-keypont/crypto11@v1.6.5#Config), which specifies how to access the PKCS #11 token.
 Additionally, you must provide the ID and/or label of the private key and certificate to the CLI.
 
 The PKCS #11 config file is a JSON file that should specify the following fields:

--- a/docs/versioned_docs/version-1.8/workflows/user-authentication.md
+++ b/docs/versioned_docs/version-1.8/workflows/user-authentication.md
@@ -21,7 +21,7 @@ marblerun --cert admin_certificate.pem --key admin_private.pem [COMMAND]
 ## PKCS #11-based authentication
 
 The MarbleRun CLI supports authentication with private keys stored in a PKCS #11-compatible device.
-To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config), which specifies how to access the PKCS #11 token.
+To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/eclipse-keypont/crypto11@v1.6.5#Config), which specifies how to access the PKCS #11 token.
 Additionally, you must provide the ID and/or label of the private key and certificate to the CLI.
 
 The PKCS #11 config file is a JSON file that should specify the following fields:

--- a/docs/versioned_docs/version-1.9/workflows/user-authentication.md
+++ b/docs/versioned_docs/version-1.9/workflows/user-authentication.md
@@ -21,7 +21,7 @@ marblerun --cert admin_certificate.pem --key admin_private.pem [COMMAND]
 ## PKCS #11-based authentication
 
 The MarbleRun CLI supports authentication with private keys stored in a PKCS #11-compatible device.
-To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/ThalesGroup/crypto11@v1.2.6#Config), which specifies how to access the PKCS #11 token.
+To load client credentials using PKCS #11, you must provide a [PKCS #11 config file](https://pkg.go.dev/github.com/eclipse-keypont/crypto11@v1.6.5#Config), which specifies how to access the PKCS #11 token.
 Additionally, you must provide the ID and/or label of the private key and certificate to the CLI.
 
 The PKCS #11 config file is a JSON file that should specify the following fields:

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0
-	github.com/ThalesGroup/crypto11 v1.6.2
 	github.com/cert-manager/cert-manager v1.20.3
+	github.com/eclipse-keypont/crypto11 v1.6.5
 	github.com/edgelesssys/ego v1.9.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/ThalesGroup/crypto11 v1.6.2 h1:X+JsrOlKanaIlHgwV/3MJ/cFivbEaQ8kpXRPoiC2T+c=
-github.com/ThalesGroup/crypto11 v1.6.2/go.mod h1:fQ61t02lJdXD2HrG7upt/VRlDECsipwtqpPcZJEjBKg=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -101,6 +99,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1 h1:idfl8M8rPW93NehFw5H1qqH8yG158t5POr+LX9avbJY=
 github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1/go.mod h1:C8DzXehI4zAbrdlbtOByKX6pfivJTBiV9Jjqv56Yd9Q=
+github.com/eclipse-keypont/crypto11 v1.6.5 h1:m5m6c1ttIYNsG4ZeuHcV1sBXk8KBday/HPYHFO17zGs=
+github.com/eclipse-keypont/crypto11 v1.6.5/go.mod h1:NIBgfiTuqvCyaktz22yE33PB4Aa0dU0M2Uf6QUTfDFk=
 github.com/edgelesssys/ego v1.9.0 h1:BJyJaBWc74Zxt+M/O1sGhOee9TtM+0YBCtRSEM6E+fA=
 github.com/edgelesssys/ego v1.9.0/go.mod h1:fg0M/xfLWnrkoD2OZpY9xmltGlAPFsIiUmyHTuCS7zo=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=


### PR DESCRIPTION
### Proposed changes
ThalesGroup donated the `crypto11` to the Eclipse Foundation and is now located at `github.com/eclipse-keypont/crypto11`
- Update the relevant imports and links
