### PR TITLE
ci: update vale import path

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           files: docs/docs
           fail_on_error: true
-          version: 3.9.3
+          version: 3.15.2

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Vale
-        uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # reviewdog
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # reviewdog
         with:
           files: docs/docs
           fail_on_error: true

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "docs/**"
+  workflow_dispatch:
 
 jobs:
   vale:

--- a/docs/docs/building-marbles/gramine.md
+++ b/docs/docs/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/styles/config/vocabularies/edgeless/accept.txt
+++ b/docs/styles/config/vocabularies/edgeless/accept.txt
@@ -36,6 +36,7 @@ precheck
 premain
 Redis
 runtime
+runtimes
 SGX
 subcommand
 Tensorflow

--- a/docs/versioned_docs/version-1.1/building-services/gramine.md
+++ b/docs/versioned_docs/version-1.1/building-services/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.2/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.2/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.3/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.3/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.4/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.4/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.5/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.5/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.6/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.6/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.7/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.7/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.8/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.8/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 

--- a/docs/versioned_docs/version-1.9/building-marbles/gramine.md
+++ b/docs/versioned_docs/version-1.9/building-marbles/gramine.md
@@ -130,7 +130,7 @@ You can see how this is done in the [nginx example](https://github.com/edgelesss
 
 ## Troubleshooting
 
-### aesm_service returned error: 30
+### AESM service returns error code 30
 
 If you receive the following error message on launch:
 


### PR DESCRIPTION
### Proposed changes
- the vale action was moved from `errate-ai/vale-action` to `vale-cli/vale-action`
- Update vale to `v3.15.2`
- Fix some wording in the docs that was flagged by the newest vale version

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
