### PR TITLE
coordinator: limit request body size to 10MB

### DIFF
--- a/coordinator/server/handler/handler.go
+++ b/coordinator/server/handler/handler.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/edgelesssys/marblerun/coordinator/manifest"
@@ -20,6 +21,8 @@ import (
 	"github.com/edgelesssys/marblerun/coordinator/user"
 	"github.com/google/uuid"
 )
+
+const maxBodySize = 10 * 1024 * 1024 // 10 MB
 
 // ClientAPI is the interface implementing the backend logic of the REST API.
 type ClientAPI interface {
@@ -47,9 +50,9 @@ type ClientAPI interface {
 
 // GeneralResponse is a wrapper for all our REST API responses to follow the JSend style: https://github.com/omniti-labs/jsend
 type GeneralResponse struct {
-	Status  string      `json:"status"`
-	Data    interface{} `json:"data"`
-	Message string      `json:"message,omitempty"` // only used when status = "error"
+	Status  string `json:"status"`
+	Data    any    `json:"data"`
+	Message string `json:"message,omitempty"` // only used when status = "error"
 }
 
 // GetPost is a helper function to assign different handlers depending on the HTTP method.
@@ -93,7 +96,7 @@ func VerifyUser(verifyFunc func(context.Context, []*x509.Certificate) (*user.Use
 }
 
 // WriteJSON writes a JSend response to the given http.ResponseWriter.
-func WriteJSON(w http.ResponseWriter, v interface{}) {
+func WriteJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	dataToReturn := GeneralResponse{Status: "success", Data: v}
 	if err := json.NewEncoder(w).Encode(dataToReturn); err != nil {
@@ -112,7 +115,7 @@ func WriteJSONError(w http.ResponseWriter, errorString string, httpErrorCode int
 }
 
 // WriteJSONFailure writes a JSend failure response to the given http.ResponseWriter.
-func WriteJSONFailure(w http.ResponseWriter, v interface{}, message string, httpErrorCode int) {
+func WriteJSONFailure(w http.ResponseWriter, v any, message string, httpErrorCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	dataToReturn := GeneralResponse{Status: "fail", Data: v, Message: message}
 	w.WriteHeader(httpErrorCode)
@@ -124,4 +127,21 @@ func WriteJSONFailure(w http.ResponseWriter, v interface{}, message string, http
 // MethodNotAllowedHandler returns a 405 Method Not Allowed error.
 func MethodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
 	WriteJSONError(w, "", http.StatusMethodNotAllowed)
+}
+
+// ReadJSON reads a JSON request body into the given struct.
+// Body size is limited to 20 MB.
+func ReadJSON(w http.ResponseWriter, r *http.Request, v any) error {
+	body := http.MaxBytesReader(w, r.Body, maxBodySize)
+	defer body.Close()
+	return json.NewDecoder(body).Decode(v)
+}
+
+// ReadBody reads the request body into a byte slice.
+// Body size is limited to 20 MB.
+func ReadBody(w http.ResponseWriter, r *http.Request) ([]byte, error) {
+	body := http.MaxBytesReader(w, r.Body, maxBodySize)
+	defer body.Close()
+	rawBody, err := io.ReadAll(body)
+	return rawBody, err
 }

--- a/coordinator/server/handler/handler.go
+++ b/coordinator/server/handler/handler.go
@@ -130,7 +130,7 @@ func MethodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 // ReadJSON reads a JSON request body into the given struct.
-// Body size is limited to 20 MB.
+// Body size is limited to 10 MB.
 func ReadJSON(w http.ResponseWriter, r *http.Request, v any) error {
 	body := http.MaxBytesReader(w, r.Body, maxBodySize)
 	defer body.Close()
@@ -138,10 +138,9 @@ func ReadJSON(w http.ResponseWriter, r *http.Request, v any) error {
 }
 
 // ReadBody reads the request body into a byte slice.
-// Body size is limited to 20 MB.
+// Body size is limited to 10 MB.
 func ReadBody(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 	body := http.MaxBytesReader(w, r.Body, maxBodySize)
 	defer body.Close()
-	rawBody, err := io.ReadAll(body)
-	return rawBody, err
+	return io.ReadAll(body)
 }

--- a/coordinator/server/v1/v1.go
+++ b/coordinator/server/v1/v1.go
@@ -9,10 +9,8 @@ package v1
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -109,7 +107,7 @@ func (s *ClientAPIServer) ManifestGet(w http.ResponseWriter, r *http.Request) {
 //
 //	curl --cacert marblerun.crt --data-binary @manifest.json "https://$MARBLERUN/manifest"
 func (s *ClientAPIServer) ManifestPost(w http.ResponseWriter, r *http.Request) {
-	manifest, err := io.ReadAll(r.Body)
+	manifest, err := handler.ReadBody(w, r)
 	if err != nil {
 		handler.WriteJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -184,7 +182,7 @@ func (s *ClientAPIServer) UpdatePost(w http.ResponseWriter, r *http.Request) {
 		handler.WriteJSONError(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
-	updateManifest, err := io.ReadAll(r.Body)
+	updateManifest, err := handler.ReadBody(w, r)
 	if err != nil {
 		handler.WriteJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -259,13 +257,8 @@ func (s *ClientAPIServer) SecretsPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rawSecrets, err := io.ReadAll(r.Body)
-	if err != nil {
-		handler.WriteJSONError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	var secrets map[string]manifest.UserSecret
-	if err := json.Unmarshal(rawSecrets, &secrets); err != nil {
+	if err := handler.ReadJSON(w, r, &secrets); err != nil {
 		handler.WriteJSONError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -288,7 +281,7 @@ func (s *ClientAPIServer) UpdateManifestPost(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	rawUpdateManifest, err := io.ReadAll(r.Body)
+	rawUpdateManifest, err := handler.ReadBody(w, r)
 	if err != nil {
 		s.log.Error("Failed to read request body", zap.Error(err))
 		handler.WriteJSONError(w, err.Error(), http.StatusBadRequest)

--- a/coordinator/server/v2/v2.go
+++ b/coordinator/server/v2/v2.go
@@ -10,10 +10,8 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -57,7 +55,7 @@ func (s *ClientAPIServer) ManifestGet(w http.ResponseWriter, r *http.Request) {
 // If the manifest contains recovery data, the Coordinator will return the encrypted secrets to be used for recovery.
 func (s *ClientAPIServer) ManifestPost(w http.ResponseWriter, r *http.Request) {
 	var req ManifestSetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		handler.WriteJSONFailure(w, nil, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -87,7 +85,7 @@ func (s *ClientAPIServer) MonotonicCounterPost(w http.ResponseWriter, r *http.Re
 	}
 
 	var req MonotonicCounterRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		handler.WriteJSONFailure(w, nil, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -127,7 +125,7 @@ func (s *ClientAPIServer) QuoteGet(w http.ResponseWriter, r *http.Request) {
 // This API endpoint is only available when the coordinator is in recovery mode.
 func (s *ClientAPIServer) RecoverPost(w http.ResponseWriter, r *http.Request) {
 	var req RecoveryRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 20480)).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		handler.WriteJSONFailure(w, nil, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -227,7 +225,7 @@ func (s *ClientAPIServer) SecretsPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req SecretsSetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		handler.WriteJSONFailure(w, nil, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -263,7 +261,7 @@ func (s *ClientAPIServer) SignQuotePost(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req QuoteSignRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		handler.WriteJSONFailure(
 			w, map[string]string{"sgxQuote": "failed to parse JSON data"},
 			fmt.Sprintf("bad request: %s", err), http.StatusBadRequest,
@@ -311,7 +309,7 @@ func (s *ClientAPIServer) UpdatePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateApplyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		handler.WriteJSONFailure(w, nil, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -368,7 +366,7 @@ func (s *ClientAPIServer) UpdateManifestPost(w http.ResponseWriter, r *http.Requ
 	}
 
 	var req UpdateManifestPostRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := handler.ReadJSON(w, r, &req); err != nil {
 		s.log.Error("Failed to read request body", zap.Error(err))
 		handler.WriteJSONFailure(w, nil, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
### Proposed changes
- Limit request size on the Coordinator's user API to 10MB
